### PR TITLE
Documentation: Update ISSUE TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,45 @@
+name: 🐛 Bug Report
+description: Submit a bug report to help us improve
+labels: bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing your issue, ask yourself:
+        - Do I have basic ideas about where it goes wrong? (E.g. front or back-end)
+        - Could it be because of my own mistakes?
+        - Does an issue about the bug already exist?
+
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: Write down the steps to reproduce the bug. You should start with a fresh installation, or your git repository linked above. If it's in production, point out the page with the context.
+      placeholder: |
+        1. Step 1...
+        2. Step 2...
+        3. Step 3...
+    validations:
+      required: false
+
+  - type: input
+    attributes:
+      label: Rucio WebUI Version
+      description: The used Rucio WebUI Version.
+      placeholder: "e.g. 1.28.4, master"
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: Include other relevant details, e.g. about your environment or setup.
+      placeholder: |
+        - Browser with version
+        - Operating System
+        - ...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Question - Ask us
+    url: https://rucio.cern.ch/contact.html
+    about: This issue tracker is not for technical support. Please use one of our dedicated channels, and ask the community for help.
+  - name: 📖 Documentation
+    url: https://rucio.cern.ch/documentation/
+    about: The Rucio Documentation might give you some information related to the problem.
+  - name: 🖋️  Issue related to the Documentation
+    url: https://github.com/rucio/documentation
+    about: If the issue is in or related to the documentation, please open it in the dedicated `rucio/documentation` repository.
+  - name: 🚢 Issue related to the Containers
+    url: https://github.com/rucio/containers
+    about: If the issue is in or related to the containers, please open it in the dedicated `rucio/containers` repository.
+  - name: 📈 Issue related to the Helm Charts
+    url: https://github.com/rucio/helm-charts
+    about: If the issue is in or related to the helm-charts, please open it in the dedicated `rucio/helm-charts` repository.

--- a/.github/ISSUE_TEMPLATE/devops.yaml
+++ b/.github/ISSUE_TEMPLATE/devops.yaml
@@ -1,0 +1,34 @@
+name: 🚀 Dev Ops
+description: Submit a Dev Ops change request
+labels: ["DevOps"]
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: What is the problem or desired behavior for the CI/CD / Developer tools?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Please outline the motivation for the proposal and why it should be implemented.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Change
+      description: Please outline the change for the proposal in detail.
+    validations:
+      required: true
+
+  - type: checkboxes
+    attributes:
+      label: Additional Information
+      description: Please select all conditions that apply.
+      options:
+        - label: It is related to the Storybook?
+        - label: It is related to the GitHub Actions?
+        - label: It is related to the developer tools?
+

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,31 @@
+name: 💅 Feature Request
+description: Submit a feature request
+labels: enhancement
+body:
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and concise description of what the feature is.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Please outline the motivation for the proposal and why it should be implemented. Has this been requested by a lot of users?
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Change
+      description: Please outline the change for the proposal in detail.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Additional Information
+      description: Please select all conditions that apply.
+      options:
+        - label: The Rucio API needs to be changed.


### PR DESCRIPTION
The new GitHub Issue Forms allow us to create more user-friendly issue
templates. These templates can provide more information to the issuer, as well
as the developer (e.g. specifically asking for the Rucio WebUI version used for
bugs, marking breaking changes in features, ...).