### PR TITLE
Switch Accounts in Session

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -4,7 +4,7 @@ import { LoginViewModel } from "@/lib/infrastructure/data/view-model/login";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Login as LoginStory } from "@/component-library/components/Pages/Login/Login";
-import { Role, VO } from "@/lib/core/entity/auth-models";
+import { AuthType, Role, VO } from "@/lib/core/entity/auth-models";
 
 
 export default function Login() {
@@ -124,7 +124,7 @@ export default function Login() {
             auth.status = 'success'
             auth.message = "Login successful. The session has not been set yet."
             auth.rucioAccount = rucioAccount
-            auth.rucioAuthType = 'x509'
+            auth.rucioAuthType = AuthType.x509
             auth.rucioAuthToken = rucioAuthToken
             auth.rucioAuthTokenExpires = rucioAuthTokenExpires
             return Promise.resolve(auth)

--- a/src/component-library/components/Pages/Login/Login.stories.tsx
+++ b/src/component-library/components/Pages/Login/Login.stories.tsx
@@ -1,4 +1,4 @@
-import { OIDCProvider, Role, VO } from '@/lib/core/entity/auth-models'
+import { AuthType, OIDCProvider, Role, VO } from '@/lib/core/entity/auth-models'
 import { StoryFn, Meta } from '@storybook/react'
 
 import { Login } from './Login'
@@ -65,7 +65,7 @@ LoginPage.args = {
         rucioIdentity: '',
         rucioAccount: '',
         rucioAuthToken: '',
-        rucioAuthType: 'userpass',
+        rucioAuthType: AuthType.USERPASS,
         rucioAuthTokenExpires: '',
         role: Role.USER,
     }

--- a/src/lib/common/ioc/ioc-symbols-input-port.ts
+++ b/src/lib/common/ioc/ioc-symbols-input-port.ts
@@ -7,6 +7,7 @@ const INPUT_PORT = {
     SET_X509_LOGIN_SESSION: Symbol.for("SetX509LoginSessionInputPort"),
     SITE_HEADER: Symbol.for("SiteHeaderInputPort"),
     STREAM: Symbol.for("StreamInputPort"),
+    SWITCH_ACCOUNT: Symbol.for("SwitchAccountInputPort"),
     TEST: Symbol.for("TestInputPort"),
     USERPASS_LOGIN: Symbol.for("UserPassLoginInputPort"),
 }

--- a/src/lib/core/data/switch-account-usecase-models.ts
+++ b/src/lib/core/data/switch-account-usecase-models.ts
@@ -1,0 +1,28 @@
+/**
+ * Switch Account Use Case Models
+ * @property {string} rucioIdentity - Rucio Identity
+ * @property {string} rucioAccount - Rucio Account
+ * @property {string} rucioAuthType - Rucio Auth Type i.e. userpass, x509, oidc
+ * @property {string} redirectTo - Redirect URL
+ */
+export interface SwitchAccountRequest {
+    rucioIdentity: string,
+    rucioAccount: string,
+    rucioAuthType: 'userpass' | 'x509' | 'oidc',
+    redirectTo?: string
+}
+
+
+export interface SwitchAccountResponse extends SwitchAccountRequest {}
+
+/**
+ * Error Model for {@link SwitchAccountOutputPort}
+ * @property {string} type - Type of error:
+ * 'invalid_auth_type': If the auth type is invalid i.e. not one of userpass, x509, oidc
+ * 'bad request': If the request is invalid i.e. missing required fields
+ * 'cannot_switch_account': If the account switching process failed
+ */
+export interface SwitchAccountError {
+    message: string
+    type: 'invalid_auth_type' | 'bad request' | 'cannot_switch_account'
+}

--- a/src/lib/core/data/switch-account-usecase-models.ts
+++ b/src/lib/core/data/switch-account-usecase-models.ts
@@ -13,7 +13,9 @@ export interface SwitchAccountRequest {
 }
 
 
-export interface SwitchAccountResponse extends SwitchAccountRequest {}
+export interface SwitchAccountResponse{
+    redirectTo: string
+}
 
 /**
  * Error Model for {@link SwitchAccountOutputPort}

--- a/src/lib/core/data/switch-account-usecase-models.ts
+++ b/src/lib/core/data/switch-account-usecase-models.ts
@@ -1,3 +1,5 @@
+import { AuthType } from "../entity/auth-models"
+
 /**
  * Switch Account Use Case Models
  * @property {string} rucioIdentity - Rucio Identity
@@ -8,7 +10,7 @@
 export interface SwitchAccountRequest {
     rucioIdentity: string,
     rucioAccount: string,
-    rucioAuthType: 'userpass' | 'x509' | 'oidc',
+    rucioAuthType: AuthType,
     redirectTo?: string
 }
 

--- a/src/lib/core/entity/auth-models.ts
+++ b/src/lib/core/entity/auth-models.ts
@@ -45,7 +45,7 @@ export type User = {
 export interface SessionUser extends User {
     rucioAuthToken: string
     rucioAuthTokenExpires: string
-    rucioAuthType: AuthType
+    rucioAuthType: AuthType | null
     rucioOIDCProvider: string | null
     isLoggedIn: boolean
 }

--- a/src/lib/core/entity/auth-models.ts
+++ b/src/lib/core/entity/auth-models.ts
@@ -1,4 +1,15 @@
 /**
+ * Represents the auth type in Rucio. If the auth type is x509, the user is authenticated via x509 certificates.
+ * If the auth type is userpass, the user is authenticated via username and password.
+ * If the auth type is oidc, the user is authenticated via OpenID Connect.
+ */
+export enum AuthType {
+    x509 = "x509",
+    USERPASS = "userpass",
+    OIDC = "oidc",
+}
+
+/**
  * Represents the role of a user in Rucio. If the user has an account attribute 'admin' set to True, the user is an admin.
  * Otherwise, the user is a regular user.
  * @property ADMIN - Admin user
@@ -34,7 +45,7 @@ export type User = {
 export interface SessionUser extends User {
     rucioAuthToken: string
     rucioAuthTokenExpires: string
-    rucioAuthType: 'x509' | 'userpass' | 'oidc' | null
+    rucioAuthType: AuthType
     rucioOIDCProvider: string | null
     isLoggedIn: boolean
 }

--- a/src/lib/core/port/primary/switch-account-input-port.ts
+++ b/src/lib/core/port/primary/switch-account-input-port.ts
@@ -1,5 +1,14 @@
+import { IronSession } from "iron-session";
 import { SwitchAccountRequest } from "../../data/switch-account-usecase-models";
 
+/**
+ * Provides an interface for the {@link SwitchAccountUseCase}.
+ */
 export default interface SwitchAccountInputPort {
-    switchAccount(request: SwitchAccountRequest): Promise<void>
+    /**
+     * This function breaks the clean architecture, but it is necessary to do so in this case.
+     * @param request {@link SwitchAccountRequest}
+     * @param session The IronSession object
+     */
+    switchAccount(request: SwitchAccountRequest, session: IronSession): Promise<void>
 }

--- a/src/lib/core/port/primary/switch-account-input-port.ts
+++ b/src/lib/core/port/primary/switch-account-input-port.ts
@@ -1,0 +1,5 @@
+import { SwitchAccountRequest } from "../../data/switch-account-usecase-models";
+
+export default interface SwitchAccountInputPort {
+    switchAccount(request: SwitchAccountRequest): Promise<void>
+}

--- a/src/lib/core/port/primary/switch-account-output-port.ts
+++ b/src/lib/core/port/primary/switch-account-output-port.ts
@@ -1,0 +1,7 @@
+import { SwitchAccountError, SwitchAccountResponse } from "../../data/switch-account-usecase-models";
+
+export default interface SwitchAccountOutputPort<T>{
+    response: T;
+    presentSuccess(responseModel: SwitchAccountResponse): Promise<void>;
+    presentError(error: SwitchAccountError): Promise<void>;
+}

--- a/src/lib/core/use-case/switch-account-usecase.ts
+++ b/src/lib/core/use-case/switch-account-usecase.ts
@@ -1,0 +1,69 @@
+import { getSessionUserIndex } from "@/lib/infrastructure/auth/session-utils";
+import { IronSession } from "iron-session";
+import { SwitchAccountRequest, SwitchAccountResponse } from "../data/switch-account-usecase-models";
+import { Role, SessionUser } from "../entity/auth-models";
+import SwitchAccountInputPort from "../port/primary/switch-account-input-port";
+import SwitchAccountOutputPort from "../port/primary/switch-account-output-port";
+
+export default class SwitchAccountUseCase implements SwitchAccountInputPort {
+    constructor(
+        private presenter: SwitchAccountOutputPort<any>,
+    ){
+        this.presenter = presenter;
+    }
+    
+    async switchAccount(request: SwitchAccountRequest, session: IronSession): Promise<void> {
+        const {rucioIdentity, rucioAccount, rucioAuthType, redirectTo } = request;
+        const redirectUrl = redirectTo ? redirectTo : '/dashboard';
+
+        if(!rucioAuthType) {
+            await this.presenter.presentError({
+                type: 'invalid_auth_type',
+                message: 'Invalid auth type. Must be one of: userpass, x509, oidc'
+            })
+            return;
+        }
+
+        if(!rucioIdentity || !rucioAccount) {
+            await this.presenter.presentError({
+                type: 'bad request',
+                message: 'rucioIdentity and rucioAccount are required'
+            })
+            return;
+        }
+
+        const user: SessionUser = {
+            rucioIdentity: rucioIdentity,
+            rucioAccount: rucioAccount,
+            rucioAuthType: rucioAuthType,
+            role: Role.USER, // does not mean anything here
+            rucioAuthToken: '', // does not mean anything here
+            rucioAuthTokenExpires: '', // does not mean anything here
+            rucioOIDCProvider: null, // does not mean anything here
+            rucioVO: '', // does not mean anything here
+            isLoggedIn: true, // does not mean anything here
+        }
+        const userIndex = getSessionUserIndex(session, user)
+        if(userIndex === -1) {
+            await this.presenter.presentError({
+                type: 'cannot_switch_account',
+                message: 'user not found in session'
+            })
+            return;
+        }
+
+        if(!session.allUsers) {
+            await this.presenter.presentError({
+                type: 'cannot_switch_account',
+                message: 'Could not switch user, as session is in invalid state. This is possibly a bug. Please report to the developers!'
+            })
+            return;
+        }
+        
+        session.user = session.allUsers[userIndex]
+        await session.save()
+        await this.presenter.presentSuccess({
+            redirectTo: redirectUrl
+        } as SwitchAccountResponse)
+    }
+}

--- a/src/lib/core/use-case/switch-account-usecase.ts
+++ b/src/lib/core/use-case/switch-account-usecase.ts
@@ -1,10 +1,12 @@
 import { getSessionUserIndex } from "@/lib/infrastructure/auth/session-utils";
+import { injectable } from "inversify";
 import { IronSession } from "iron-session";
 import { SwitchAccountRequest, SwitchAccountResponse } from "../data/switch-account-usecase-models";
 import { Role, SessionUser } from "../entity/auth-models";
 import SwitchAccountInputPort from "../port/primary/switch-account-input-port";
-import SwitchAccountOutputPort from "../port/primary/switch-account-output-port";
+import type SwitchAccountOutputPort from "../port/primary/switch-account-output-port";
 
+@injectable()
 export default class SwitchAccountUseCase implements SwitchAccountInputPort {
     constructor(
         private presenter: SwitchAccountOutputPort<any>,

--- a/src/lib/infrastructure/config/ioc/container-config.ts
+++ b/src/lib/infrastructure/config/ioc/container-config.ts
@@ -35,6 +35,11 @@ import SiteHeaderInputPort from "@/lib/core/port/primary/site-header-input-port"
 import SiteHeaderUseCase from "@/lib/core/use-case/site-header-usecase";
 import SiteHeaderController, { ISiteHeaderController } from "../../controller/site-header-controller";
 import SiteHeaderPresenter from "../../presenter/site-header-presenter";
+import SwitchAccountInputPort from "@/lib/core/port/primary/switch-account-input-port";
+import SwitchAccountUseCase from "@/lib/core/use-case/switch-account-usecase";
+import SwitchAccountController, { ISwitchAccountController } from "../../controller/switch-account-controller";
+import SwitchAccountOutputPort from "@/lib/core/port/primary/switch-account-output-port";
+import SwitchAccountPresenter from "../../presenter/switch-account-presenter";
 
 /**
  * IoC Container configuration for the application.
@@ -91,6 +96,15 @@ appContainer.bind<interfaces.Factory<SiteHeaderInputPort>>(USECASE_FACTORY.SITE_
         const envConfigGateway: EnvConfigGatewayOutputPort = appContainer.get(GATEWAYS.ENV_CONFIG)
         const presenter = new SiteHeaderPresenter(response)
         return new SiteHeaderUseCase(presenter, envConfigGateway);
+    }
+);
+
+appContainer.bind<SwitchAccountInputPort>(INPUT_PORT.SWITCH_ACCOUNT).to(SwitchAccountUseCase).inRequestScope();
+appContainer.bind<ISwitchAccountController>(CONTROLLERS.SWITCH_ACCOUNT).to(SwitchAccountController);
+appContainer.bind<interfaces.Factory<SwitchAccountInputPort>>(USECASE_FACTORY.SWITCH_ACCOUNT).toFactory<SwitchAccountUseCase, [NextApiResponse]>((context: interfaces.Context) =>
+    (response: NextApiResponse) => {
+        const switchAccountPresenter = new SwitchAccountPresenter(response)
+        return new SwitchAccountUseCase(switchAccountPresenter);
     }
 );
 

--- a/src/lib/infrastructure/config/ioc/ioc-symbols-controllers.ts
+++ b/src/lib/infrastructure/config/ioc/ioc-symbols-controllers.ts
@@ -9,6 +9,7 @@ const CONTROLLERS = {
     SET_X509_LOGIN_SESSION: Symbol.for("SetX509LoginSessionController"),
     SITE_HEADER: Symbol.for("SiteHeaderController"),
     STREAM: Symbol.for("StreamController"),
+    SWITCH_ACCOUNT: Symbol.for("SwitchAccountController"),
     USERPASS_LOGIN: Symbol.for("UserPassLoginController"),
 }
 

--- a/src/lib/infrastructure/config/ioc/ioc-symbols-usecase-factory.ts
+++ b/src/lib/infrastructure/config/ioc/ioc-symbols-usecase-factory.ts
@@ -9,6 +9,7 @@ const USECASE_FACTORY = {
     SET_X509_LOGIN_SESSION: Symbol.for("Factory<SetX509LoginSessionUseCase>"),
     SITE_HEADER: Symbol.for("Factory<SiteHeaderUseCase>"),
     STREAM: Symbol.for("Factory<StreamUseCase>"),
+    SWITCH_ACCOUNT: Symbol.for("Factory<SwitchAccountUseCase>"),
     USERPASS_LOGIN: Symbol.for("Factory<UserPassLoginUseCase>"),
 
 }

--- a/src/lib/infrastructure/controller/switch-account-controller.ts
+++ b/src/lib/infrastructure/controller/switch-account-controller.ts
@@ -1,0 +1,36 @@
+import { SwitchAccountRequest } from "@/lib/core/data/switch-account-usecase-models";
+import { AuthType } from "@/lib/core/entity/auth-models";
+import type SwitchAccountInputPort from "@/lib/core/port/primary/switch-account-input-port";
+import { inject, injectable } from "inversify";
+import { IronSession } from "iron-session";
+import { NextApiResponse } from "next";
+import USECASE_FACTORY from "../config/ioc/ioc-symbols-usecase-factory";
+
+export interface ISwitchAccountController {
+    handle(session: IronSession, response: NextApiResponse, rucioIdentity: string, rucioAccount: string, rucioAuthType: AuthType, redirectTo: string): Promise<void>;
+}
+
+
+@injectable()
+class SwitchAccountController implements ISwitchAccountController {
+    constructor(
+        @inject(USECASE_FACTORY.SWITCH_ACCOUNT) private useCaseFactory: (response: NextApiResponse) => SwitchAccountInputPort,
+    ){
+        this.useCaseFactory = useCaseFactory;
+    }
+    
+    async handle(session: IronSession, response: NextApiResponse, rucioIdentity: string, rucioAccount: string, rucioAuthType: AuthType, redirectTo: string) {
+        const switchAccountUseCase: SwitchAccountInputPort = this.useCaseFactory(response);
+        const switchAccountRequest: SwitchAccountRequest = {
+            rucioIdentity: rucioIdentity,
+            rucioAccount: rucioAccount,
+            rucioAuthType: rucioAuthType,
+        }
+
+        redirectTo? switchAccountRequest.redirectTo = redirectTo : null;
+
+        await switchAccountUseCase.switchAccount(switchAccountRequest, session);
+    }
+}
+
+export default SwitchAccountController;

--- a/src/lib/infrastructure/data/auth/auth.d.ts
+++ b/src/lib/infrastructure/data/auth/auth.d.ts
@@ -7,7 +7,7 @@ export type AuthViewModel = {
     redirectTo?: string;
     rucioIdentity: string;
     rucioAccount: string;
-    rucioAuthType: AuthType;
+    rucioAuthType: AuthType | '';
     rucioAuthToken: string;
     rucioAuthTokenExpires: string;
     role: Role | undefined;

--- a/src/lib/infrastructure/data/auth/auth.d.ts
+++ b/src/lib/infrastructure/data/auth/auth.d.ts
@@ -1,4 +1,4 @@
-import { Role } from "@/lib/core/entity/auth-models";
+import { AuthType, Role } from "@/lib/core/entity/auth-models";
 
 export type AuthViewModel = {
     status: 'success' | 'error' | 'multiple_accounts' | 'cannot_determine_account_role';
@@ -7,7 +7,7 @@ export type AuthViewModel = {
     redirectTo?: string;
     rucioIdentity: string;
     rucioAccount: string;
-    rucioAuthType: string;
+    rucioAuthType: AuthType;
     rucioAuthToken: string;
     rucioAuthTokenExpires: string;
     role: Role | undefined;

--- a/src/lib/infrastructure/presenter/set-x509-login-session-presenter.ts
+++ b/src/lib/infrastructure/presenter/set-x509-login-session-presenter.ts
@@ -1,5 +1,5 @@
 import { SetX509LoginSessionError, SetX509LoginSessionResponse } from "@/lib/core/data/set-x509-login-session-usecase-models";
-import { Role, SessionUser } from "@/lib/core/entity/auth-models";
+import { AuthType, Role, SessionUser } from "@/lib/core/entity/auth-models";
 import SetX509LoginSessionOutputPort from "@/lib/core/port/primary/set-x509-login-session-output-port";
 import { IronSession } from "iron-session";
 import { NextApiResponse } from "next";
@@ -21,7 +21,7 @@ export default class SetX509LoginSessionPresenter implements SetX509LoginSession
             rucioAuthToken: responseModel.rucioAuthToken,
             rucioAuthTokenExpires: responseModel.rucioAuthTokenExpires,
             rucioIdentity: responseModel.rucioIdentity,
-            rucioAuthType: 'x509',
+            rucioAuthType: AuthType.x509,
             rucioVO: responseModel.shortVOName,
             rucioAccount: responseModel.rucioAccount,
             rucioOIDCProvider: '',
@@ -36,7 +36,7 @@ export default class SetX509LoginSessionPresenter implements SetX509LoginSession
         const viewModel: AuthViewModel = {
             status: 'success',
             rucioAccount: responseModel.rucioAccount,
-            rucioAuthType: 'x509',
+            rucioAuthType: AuthType.x509,
             rucioAuthToken: responseModel.rucioAuthToken,
             rucioAuthTokenExpires: responseModel.rucioAuthTokenExpires,
             rucioIdentity: responseModel.rucioIdentity,

--- a/src/lib/infrastructure/presenter/switch-account-presenter.ts
+++ b/src/lib/infrastructure/presenter/switch-account-presenter.ts
@@ -1,10 +1,9 @@
 import { SwitchAccountResponse, SwitchAccountError } from "@/lib/core/data/switch-account-usecase-models";
 import SwitchAccountOutputPort from "@/lib/core/port/primary/switch-account-output-port";
-import { IronSession } from "iron-session";
 import { NextApiResponse } from "next";
 
 export default class SwitchAccountPresenter implements SwitchAccountOutputPort<NextApiResponse> {
-    response: NextApiResponse;
+    response: NextApiResponse<any>;
 
     constructor(response: NextApiResponse) {
         this.response = response;
@@ -26,15 +25,16 @@ export default class SwitchAccountPresenter implements SwitchAccountOutputPort<N
             case'bad request':{
                 this.response.status(400).json({
                     error: 'Bad request',
-                    message: error
+                    message: error.message
                 })
                 break;
             }
             case 'cannot_switch_account': {
                 this.response.status(500).json({
-                    error: 'Cannot switch account',
+                    error: 'Cannot switch to non-existing/logged-in account',
                     message: error.message
                 })
+                break;
             }
             default: {
                 this.response.status(500).json({

--- a/src/lib/infrastructure/presenter/switch-account-presenter.ts
+++ b/src/lib/infrastructure/presenter/switch-account-presenter.ts
@@ -1,0 +1,48 @@
+import { SwitchAccountResponse, SwitchAccountError } from "@/lib/core/data/switch-account-usecase-models";
+import SwitchAccountOutputPort from "@/lib/core/port/primary/switch-account-output-port";
+import { IronSession } from "iron-session";
+import { NextApiResponse } from "next";
+
+export default class SwitchAccountPresenter implements SwitchAccountOutputPort<NextApiResponse> {
+    response: NextApiResponse;
+
+    constructor(response: NextApiResponse) {
+        this.response = response;
+    }
+    
+    async presentSuccess(responseModel: SwitchAccountResponse): Promise<void> {
+        this.response.redirect(responseModel.redirectTo);
+    }
+
+    async presentError(error: SwitchAccountError): Promise<void> {
+        switch(error.type) {
+            case 'invalid_auth_type': {
+                this.response.status(400).json({
+                    error: 'Invalid auth type. Must be one of: userpass, x509, oidc',
+                    message: error.message
+                })
+                break;
+            }
+            case'bad request':{
+                this.response.status(400).json({
+                    error: 'Bad request',
+                    message: error
+                })
+                break;
+            }
+            case 'cannot_switch_account': {
+                this.response.status(500).json({
+                    error: 'Cannot switch account',
+                    message: error.message
+                })
+            }
+            default: {
+                this.response.status(500).json({
+                    message: 'Could not switch account, this is possibly a bug. Please report to the developers!'
+                })
+            }
+        }
+
+    }
+
+}

--- a/src/lib/infrastructure/presenter/usepass-login-presenter.ts
+++ b/src/lib/infrastructure/presenter/usepass-login-presenter.ts
@@ -1,5 +1,5 @@
 import { UserpassLoginError, UserpassLoginResponse } from "@/lib/core/data/userpass-login-usecase-models";
-import { Role, SessionUser } from "@/lib/core/entity/auth-models";
+import { AuthType, Role, SessionUser } from "@/lib/core/entity/auth-models";
 import UserPassLoginOutputPort from "@/lib/core/port/primary/userpass-login-output-port";
 import { IronSession } from "iron-session";
 import { NextApiResponse } from "next";
@@ -24,7 +24,7 @@ export default class UserPassLoginPresenter implements UserPassLoginOutputPort<N
         const viewModel: AuthViewModel = {
             rucioIdentity: responseModel.rucioIdentity,
             rucioAccount: responseModel.rucioAccount,
-            rucioAuthType: 'userpass',
+            rucioAuthType: AuthType.USERPASS,
             rucioAuthToken: responseModel.rucioAuthToken,
             status: 'success',
             role: Role.USER,
@@ -41,7 +41,7 @@ export default class UserPassLoginPresenter implements UserPassLoginOutputPort<N
         const sessionUser: SessionUser = {
             rucioIdentity: responseModel.rucioIdentity,
             rucioAccount: responseModel.rucioAccount,
-            rucioAuthType: 'userpass',
+            rucioAuthType: AuthType.USERPASS,
             rucioAuthToken: responseModel.rucioAuthToken,
             rucioOIDCProvider: null,
             rucioVO: responseModel.vo,

--- a/src/pages/api/account/switch.ts
+++ b/src/pages/api/account/switch.ts
@@ -1,0 +1,16 @@
+import { withSessionRoute } from "@/lib/infrastructure/auth/session-utils"
+import appContainer from "@/lib/infrastructure/config/ioc/container-config"
+import CONTROLLERS from "@/lib/infrastructure/config/ioc/ioc-symbols-controllers"
+import SwitchAccountController from "@/lib/infrastructure/controller/switch-account-controller"
+import { IronSession } from "iron-session"
+import { NextApiRequest, NextApiResponse } from "next"
+
+async function switchAccounts(req: NextApiRequest, res: NextApiResponse) {
+    const session: IronSession = req.session
+    const { rucioIdentity, rucioAccount, rucioAuthType, redirectTo } = req.body
+    const redirectUrl = redirectTo || '/dashboard'
+    const switchAccountController: SwitchAccountController = appContainer.get(CONTROLLERS.SWITCH_ACCOUNT)
+    switchAccountController.handle(session, res, rucioIdentity, rucioAccount, rucioAuthType, redirectUrl)
+}
+
+export default withSessionRoute(switchAccounts)

--- a/test/api/account/switch.test.ts
+++ b/test/api/account/switch.test.ts
@@ -1,0 +1,129 @@
+import { AuthType, Role, SessionUser } from "@/lib/core/entity/auth-models";
+import { addOrUpdateSessionUser } from "@/lib/infrastructure/auth/session-utils";
+import appContainer from "@/lib/infrastructure/config/ioc/container-config";
+import CONTROLLERS from "@/lib/infrastructure/config/ioc/ioc-symbols-controllers";
+import { ISwitchAccountController } from "@/lib/infrastructure/controller/switch-account-controller";
+import { getIronSession } from "iron-session";
+import { createMocks } from "node-mocks-http";
+
+describe('Switch Account API Test', () => {
+    it('should switch to existing account in the session and redirect', async () => {
+        const { req, res } = createMocks({
+            url: 'http://testhost:3000/api/site-header',
+        });
+        const session = await getIronSession(req, res, {
+            password: 'passwordpasswordpasswordpasswordpassword',
+            cookieName: 'test-request-session',
+            cookieOptions: {
+                secure: false,
+            },
+        })
+
+        res.redirect = jest.fn()
+
+        const mockUser: SessionUser = {
+            rucioIdentity: 'ddmlab',
+            rucioAccount: 'root',
+            rucioAuthToken: 'rucio-ddmlab-askdjljioj',
+            rucioAuthTokenExpires: '2021-09-01T00:00:00.000Z',
+            rucioAuthType: AuthType.USERPASS,
+            rucioOIDCProvider: '',
+            rucioVO: 'def',
+            country: 'US',
+            role: Role.ADMIN,
+            countryRole: Role.ADMIN,
+            isLoggedIn: true,
+        }
+
+        const mockUser2: SessionUser = {
+            rucioIdentity: 'maany',
+            rucioAccount: 'dev',
+            rucioAuthToken: 'rucio-maany-askdjljioj',
+            rucioAuthTokenExpires: '2021-09-01T00:00:00.000Z',
+            rucioAuthType: AuthType.x509,
+            rucioOIDCProvider: '',
+            rucioVO: 'def',
+            country: 'US',
+            role: Role.ADMIN,
+            countryRole: Role.ADMIN,
+            isLoggedIn: true,
+        }
+
+        await addOrUpdateSessionUser(session, mockUser2)
+        await addOrUpdateSessionUser(session, mockUser)
+
+        expect(session.user?.rucioIdentity).toBe('ddmlab')
+
+        const switchAccountController: ISwitchAccountController = appContainer.get(CONTROLLERS.SWITCH_ACCOUNT)
+        await switchAccountController.handle(
+            session,
+            res as undefined as NextApiRequest,
+            mockUser2.rucioIdentity,
+            mockUser2.rucioAccount,
+            mockUser2.rucioAuthType, 
+            '/rse'
+        );
+        
+        expect(session.user?.rucioIdentity).toBe('maany')
+        expect(res.redirect).toBeCalledWith('/rse')
+    });
+    it('should not switch to non-existing account', async() => {
+        const { req, res } = createMocks({
+            url: 'http://testhost:3000/api/site-header',
+        });
+        const session = await getIronSession(req, res, {
+            password: 'passwordpasswordpasswordpasswordpassword',
+            cookieName: 'test-request-session',
+            cookieOptions: {
+                secure: false,
+            },
+        })
+
+        res.redirect = jest.fn()
+
+        const mockUser: SessionUser = {
+            rucioIdentity: 'ddmlab',
+            rucioAccount: 'root',
+            rucioAuthToken: 'rucio-ddmlab-askdjljioj',
+            rucioAuthTokenExpires: '2021-09-01T00:00:00.000Z',
+            rucioAuthType: AuthType.USERPASS,
+            rucioOIDCProvider: '',
+            rucioVO: 'def',
+            country: 'US',
+            role: Role.ADMIN,
+            countryRole: Role.ADMIN,
+            isLoggedIn: true,
+        }
+
+        const mockUser2: SessionUser = {
+            rucioIdentity: 'maany',
+            rucioAccount: 'dev',
+            rucioAuthToken: 'rucio-maany-askdjljioj',
+            rucioAuthTokenExpires: '2021-09-01T00:00:00.000Z',
+            rucioAuthType: AuthType.x509,
+            rucioOIDCProvider: '',
+            rucioVO: 'def',
+            country: 'US',
+            role: Role.ADMIN,
+            countryRole: Role.ADMIN,
+            isLoggedIn: true,
+        }
+
+        await addOrUpdateSessionUser(session, mockUser)
+
+        const switchAccountController: ISwitchAccountController = appContainer.get(CONTROLLERS.SWITCH_ACCOUNT)
+        await switchAccountController.handle(
+            session,
+            res as undefined as NextApiRequest,
+            mockUser2.rucioIdentity,
+            mockUser2.rucioAccount,
+            mockUser2.rucioAuthType, 
+            '/rse'
+        );
+
+        expect(res._getStatusCode()).toBe(500)
+        const data = JSON.parse(res._getData())
+        expect(data.error).toBe('Cannot switch to non-existing/logged-in account')
+
+    })
+});


### PR DESCRIPTION
Add a `/api/accounts/switch` endpoint
Fix #166 