### PR TITLE
Feature 206 tests list did

### DIFF
--- a/src/component-library/components/Button/Button.tsx
+++ b/src/component-library/components/Button/Button.tsx
@@ -2,26 +2,22 @@ import { twMerge } from "tailwind-merge"
 import { Collapsible } from "../Helpers/Collapsible"
 import { forwardRef } from "react"
 
-interface ButtonProps {
+type ButtonProps = JSX.IntrinsicElements["button"] & {
+    label?: string
+    icon?: any
+    type?: 'button' | 'submit' | 'reset'
+    disabled?: boolean
+    theme?: 'blue' | 'orange',
+    fullwidth?: boolean
+    onClick?: (args: unknown) => void
 }
 
-export const Button = forwardRef(function Button
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     (
-        props: {
-            label?: string
-            icon?: any
-            type?: 'button' | 'submit' | 'reset'
-            disabled?: boolean
-            theme?: 'blue' | 'orange',
-            fullwidth?: boolean
-            onClick?: (args: unknown) => void
-            id?: string
-        },
-        ref?: React.ForwardedRef<HTMLButtonElement>
+        props,
+        ref,
     ) {
-    const type = props.type ?? "button"
-    const theme = props.theme ?? "blue"
-    const fullwidth = props.fullwidth ?? true
+    const { className, label, icon, type, disabled, theme, fullwidth, onClick, ...otherprops } = props
 
     const handleOnClick = props.disabled ? undefined : props.onClick
     var classes: string[] = ["font-bold rounded py-1 px-3 cursor-pointer"]
@@ -34,15 +30,17 @@ export const Button = forwardRef(function Button
                     "py-1 px-3 h-8 rounded",
                     type === "submit" ? "bg-green-500 hover:bg-green-600 text-white" : "",
                     type === "reset" ? "bg-red-500 hover:bg-red-600 text-white" : "",
-                    type === "button" ? "bg-blue-500 hover:bg-blue-600 text-white" : "",
-                    theme === "orange" ? "bg-amber-500 hover:bg-amber-600 text-black" : "",
+                    type ?? "button" === "button" ? "bg-blue-500 hover:bg-blue-600 text-white" : "",
+                    theme  === "orange" ? "bg-amber-500 hover:bg-amber-600 text-black" : "",
                     props.disabled ? "cursor-not-allowed bg-gray-500 hover:bg-gray-500 text-gray-200" : "cursor-pointer",
-                    fullwidth ? "w-full" : "",
+                    fullwidth ?? true ? "w-full" : "",
                     "font-bold",
+                    className ?? ""
                 )}
                 onClick={handleOnClick}
                 id={props.id}
                 ref={ref}
+                {...otherprops}
             >
                 <div className={twMerge(
                     "flex justify-center",
@@ -69,15 +67,17 @@ export const Button = forwardRef(function Button
                     "py-1 px-3 rounded",
                     type === "submit" ? "bg-green-500 hover:bg-green-600 text-white" : "",
                     type === "reset" ? "bg-red-500 hover:bg-red-600 text-white" : "",
-                    type === "button" ? "bg-blue-500 hover:bg-blue-600 text-white" : "",
+                    type ?? "button" === "button" ? "bg-blue-500 hover:bg-blue-600 text-white" : "",
                     theme === "orange" ? "bg-amber-500 hover:bg-amber-600 text-black" : "",
                     props.disabled ? "cursor-not-allowed bg-gray-500 hover:bg-gray-500 text-gray-200" : "cursor-pointer",
-                    fullwidth ? "w-full" : "",
+                    fullwidth ?? true ? "w-full" : "",
                     "font-bold",
+                    className ?? ""
                 )}
                 onClick={handleOnClick}
                 id={props.id}
                 ref={ref}
+                {...otherprops}
             >
                 <label htmlFor={props.id} className="flex justify-center cursor-pointer">
                     {props.icon}

--- a/src/component-library/components/Input/NumInput.tsx
+++ b/src/component-library/components/Input/NumInput.tsx
@@ -1,31 +1,20 @@
 import { useState, useEffect } from "react";
 
-export const NumInput = (
-    props: {
-        value: number,
-        children?: any,
-        placeholder?: string,
-        onBlur?: (event: any) => void,
-        onChange?: (event: any) => void,
-        onEnterkey?: (event: any) => void,
-        max?: number,
-        min?: number,
-        id?: string,
-        disabled?: boolean
+export const NumInput: (
+    React.FC<
+        Omit<JSX.IntrinsicElements["input"], "value"> &
+        {value: number, onEnterkey?: (event: any) => void}
+    >
+) = (
+    {
+        value,
+        ...props
     }
 ) => {
-    const [numvalue, setNumvalue] = useState<number>(props.value);
+    const [numvalue, setNumvalue] = useState<number>(value);
     useEffect(() => {
-        setNumvalue(props.value);
-    }, [props.value]);
-    const onBlur = (event: any) => {
-        setNumvalue(event.target.value);
-        props.onBlur?.(event);
-    }
-    const onChange = (event: any) => {
-        setNumvalue(event.target.value);
-        props.onChange?.(event);
-    }
+        setNumvalue(value);
+    }, [value]);
     const onEnterkey = (event: any) => {
         setNumvalue(event.target.value);
         if (event.key === "Enter") {
@@ -36,15 +25,9 @@ export const NumInput = (
         <input
             type="number"
             value={numvalue > 0 ? numvalue : ""}
-            placeholder={props.placeholder}
-            max={props.max ? props.max.toString() : ""}
-            min={props.min ? props.min.toString() : ""}
-            id={props.id}
             className="w-full border dark:border-gray-400 rounded-sm px-2 pt-2 dark:bg-gray-800 dark:text-white dark:border-2"
-            onBlur={onBlur}
-            onChange={onChange}
             onKeyDown={onEnterkey}
-            disabled={props.disabled}
+            {...props}
         >
             {props.children}
         </input>

--- a/src/component-library/components/Pages/ListDID/DIDListTable.tsx
+++ b/src/component-library/components/Pages/ListDID/DIDListTable.tsx
@@ -182,7 +182,7 @@ export const DIDListTable = (
                         </th>
                     </tr>
                 </thead>
-                <tbody className="w-full">
+                <tbody className="w-full" aria-label="DID Table Body">
                     {table.getRowModel().rows.map((row) => {
                         const did_scopename = row.original.scope + ":" + row.original.name
                         const isDIDSelected = selected === did_scopename
@@ -200,6 +200,8 @@ export const DIDListTable = (
                                     setSelected(did_scopename)
                                     props.onSelect(did_scopename)
                                 }}
+                                aria-rowindex={row.index}
+                                aria-label="DID Table Row"
                             >
                                 {row.getVisibleCells().map((cell) => {
                                     return (

--- a/src/component-library/components/Pages/ListDID/DIDListTable.tsx
+++ b/src/component-library/components/Pages/ListDID/DIDListTable.tsx
@@ -12,6 +12,7 @@ import { Filter } from "../../StreamedTables/Filter";
 import { NumInput } from "../../Input/NumInput";
 import { HiChevronDoubleLeft, HiChevronLeft, HiChevronRight, HiChevronDoubleRight, HiSearch, HiCheck } from "react-icons/hi"
 import { DIDTypeTag } from "../../Tags/DIDTypeTag";
+import { PaginationDiv } from "../../StreamedTables/PaginationDiv";
 
 export const DIDListTable = (
     props: {
@@ -221,57 +222,7 @@ export const DIDListTable = (
                     )}
                 </tbody>
             </table>
-            <div className="w-full flex justify-center space-x-2 pt-2 border-t dark:border-gray-400 dark:border-t-2">
-                <nav className="w-[400px] flex justify-center space-x-2">
-                    <span className="w-1/3 flex space-x-2">
-                        <Button
-                            onClick={() => {
-                                table.setPageIndex(0)
-                            }}
-                            disabled={!table.getCanPreviousPage()}
-                            icon={<HiChevronDoubleLeft />}
-                        />
-                        <Button
-                            onClick={() => {
-                                table.previousPage()
-                            }}
-                            disabled={!table.getCanPreviousPage()}
-                            icon={<HiChevronLeft />}
-                        />
-                    </span>
-                    <span className="w-1/3 inline-flex space-x-2 items-end">
-                        <NumInput
-                            value={pageIndex + 1}
-                            onChange={(event) => {
-                                setPageIndex(event.target.value - 1)
-                            }}
-                            min={1}
-                            max={table.getPageCount()}
-                        />
-                        <span className="w-full">
-                            <P>
-                                of {table.getPageCount()}
-                            </P>
-                        </span>
-                    </span>
-                    <span className="w-1/3 space-x-2 flex">
-                        <Button
-                            onClick={() => {
-                                table.nextPage()
-                            }}
-                            disabled={!table.getCanNextPage()}
-                            icon={<HiChevronRight />}
-                        />
-                        <Button
-                            onClick={() => {
-                                table.setPageIndex(table.getPageCount() - 1)
-                            }}
-                            disabled={!table.getCanNextPage()}
-                            icon={<HiChevronDoubleRight />}
-                        />
-                    </span>
-                </nav>
-            </div>
+            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/ListDID/DIDMetaView.tsx
+++ b/src/component-library/components/Pages/ListDID/DIDMetaView.tsx
@@ -21,6 +21,7 @@ export const DIDMetaView = (
                     "font-bold w-32 pl-1 dark:text-white",
                     className ?? ""
                 )}
+                aria-label="Key"
                 {...otherprops}
             >
                 {props.children}
@@ -35,6 +36,7 @@ export const DIDMetaView = (
                     "break-all dark:text-gray-100",
                     className ?? ""
                 )}
+                aria-label="Value"
                 {...otherprops}
             >
                 {props.children}
@@ -48,43 +50,49 @@ export const DIDMetaView = (
                 !props.horizontal ?? false ? "flex flex-col space-y-2" : "grid grid-cols-1 lg:grid-cols-2 lg:gap-x-2 gap-y-2",
                 props.show ? "" : "hidden",
             )}
+            aria-label="DID Metadata Quick Summary"
         >
             <table
                 className={twMerge(
                     "bg-white dark:bg-gray-700",
                     "w-full rounded border-separate border-spacing-y-1"
                 )}
+                aria-label="DID Scopename"
             >
-                <tbody className="w-full">
-                    <tr>
+                <tbody className="w-full" aria-label="DID Scopename">
+                    <tr aria-label="Scope">
                         <Titletd>Scope</Titletd>
                         <Contenttd>{meta.scope}</Contenttd>
                     </tr>
-                    <tr>
+                    <tr aria-label="Name">
                         <Titletd>Name</Titletd>
                         <Contenttd>{meta.name}</Contenttd>
                     </tr>
                 </tbody>
             </table>
-            <table className={twMerge(
-                "bg-white dark:bg-gray-700",
-                "w-full rounded border-separate border-spacing-y-1",
-                meta.did_type === "File" ? "table" : "hidden"
-            )}>
-                <tbody className="w-full">
-                    <tr>
+            <table
+                className={twMerge(
+                    "bg-white dark:bg-gray-700",
+                    "w-full rounded border-separate border-spacing-y-1",
+                    meta.did_type === "File" ? "table" : "hidden"
+                )}
+                aria-label="File Information"
+                aria-hidden={meta.did_type !== "File"}
+            >
+                <tbody className="w-full" aria-label="File Information">
+                    <tr aria-label="Size">
                         <Titletd>Size</Titletd>
                         <Contenttd><Number number={meta.filesize as number} /></Contenttd>
                     </tr>
-                    <tr>
+                    <tr aria-label="GUID">
                         <Titletd>GUID</Titletd>
                         <Contenttd>{meta.guid as string}</Contenttd>
                     </tr>
-                    <tr>
+                    <tr aria-label="Adler32 Checksum">
                         <Titletd>Adler32</Titletd>
                         <Contenttd>{meta.adler32 as string}</Contenttd>
                     </tr>
-                    <tr>
+                    <tr aria-label="MD5 Checksum">
                         <Titletd>MD5</Titletd>
                         <Contenttd>{meta.md5 as string}</Contenttd>
                     </tr>
@@ -95,13 +103,14 @@ export const DIDMetaView = (
                     "bg-white dark:bg-gray-700",
                     "w-full rounded border-separate border-spacing-y-1"
                 )}
+                aria-label="Date Information"
             >
-                <tbody className="w-full">
-                    <tr>
+                <tbody className="w-full" aria-label="Date Information">
+                    <tr aria-label="Date of DID Creation">
                         <Titletd>Created At</Titletd>
                         <Contenttd>{format("yyyy-MM-dd", meta.created_at)}</Contenttd>
                     </tr>
-                    <tr>
+                    <tr aria-label="Last Updated at">
                         <Titletd>Updated At</Titletd>
                         <Contenttd>{format("yyyy-MM-dd", meta.updated_at)}</Contenttd>
                     </tr>
@@ -112,23 +121,27 @@ export const DIDMetaView = (
                     "bg-white dark:bg-gray-700",
                     "w-full rounded border-separate border-spacing-y-1"
                 )}
+                aria-label="DID Information"
             >
-                <tbody className="w-full">
-                    <tr>
+                <tbody className="w-full" aria-label="DID Information">
+                    <tr aria-label="DID Type">
                         <Titletd>DID Type</Titletd>
                         <td><DIDTypeTag didtype={meta.did_type} neversmall /></td>
                     </tr>
-                    <tr>
+                    <tr aria-label="Associated Account">
                         <Titletd>Account</Titletd>
                         <Contenttd>{meta.account}</Contenttd>
                     </tr>
-                    <tr className={twMerge(
-                        meta.did_type === "File" ? "collapse" : "visible"
-                    )}>
+                    <tr
+                        className={twMerge(
+                            meta.did_type === "File" ? "collapse" : "visible"
+                        )}
+                        aria-label="Is DID Open"
+                    >
                         <Titletd>Is Open</Titletd>
                         <td><BoolTag val={!!meta.is_open} /></td>
                     </tr>
-                    <tr>
+                    <tr aria-label="Monotonic">
                         <Titletd>Monotonic</Titletd>
                         <td><BoolTag val={meta.monotonic} /></td>
                     </tr>
@@ -139,25 +152,26 @@ export const DIDMetaView = (
                     "bg-white dark:bg-gray-700",
                     "w-full rounded border-separate border-spacing-y-1"
                 )}
+                aria-label="Further DID Information"
             >
-                <tbody className="w-full">
-                    <tr>
+                <tbody className="w-full" aria-label="Further DID Information">
+                    <tr aria-label="DID Obsolete">
                         <Titletd className="w-40">Obsolete</Titletd>
                         <td><BoolTag val={meta.obsolete} /></td>
                     </tr>
-                    <tr>
+                    <tr aria-label="DID Hidden">
                         <Titletd>Hidden</Titletd>
                         <td><BoolTag val={meta.hidden} /></td>
                     </tr>
-                    <tr className="">
+                    <tr className="" aria-label="DID Suppressed">
                         <Titletd>Suppressed</Titletd>
                         <td><BoolTag val={meta.suppressed} /></td>
                     </tr>
-                    <tr className="">
+                    <tr className="" aria-label="Purge DID Replicas">
                         <Titletd>Purge Replicas</Titletd>
                         <td><BoolTag val={meta.purge_replicas} /></td>
                     </tr>
-                    <tr className="">
+                    <tr className="" aria-label="DID Availability">
                         <Titletd>Availability</Titletd>
                         <td><AvailabilityTag availability={meta.availability} /></td>
                     </tr>

--- a/src/component-library/components/Pages/ListDID/ListDID.tsx
+++ b/src/component-library/components/Pages/ListDID/ListDID.tsx
@@ -142,7 +142,7 @@ export const ListDID = (
                     <DIDMetaView data={props.didMetaQueryResponse} show={selectedDID ? true : false} />
                     <div
                         className={twMerge(
-                            "text-gray-800 flex flex-col",
+                            "text-gray-800",
                             !selectedDID ? "block" : "hidden",
                         )}
                         aria-label="Notice: No DID selected"

--- a/src/component-library/components/Pages/ListDID/ListDID.tsx
+++ b/src/component-library/components/Pages/ListDID/ListDID.tsx
@@ -52,6 +52,7 @@ export const ListDID = (
                     className={twMerge(
                         "flex flex-col sm:flex-row sm:space-x-2 sm:items-end w-full",
                     )}
+                    aria-label="DID Search"
                 >
                     <label
                         className={twMerge(
@@ -85,6 +86,7 @@ export const ListDID = (
                             "text-gray-800 dark:text-white"
                         )}
                         id="query-for-didtype-form"
+                        aria-label="Select DID Types to Query"
                     >
                         <label className={twMerge("mr-2")} htmlFor="query-for-didtype-form">Query for DID Types:</label>
                         <Checkbox
@@ -143,15 +145,17 @@ export const ListDID = (
                             "text-gray-800 flex flex-col",
                             !selectedDID ? "block" : "hidden",
                         )}
+                        aria-label="Notice: No DID selected"
                     >
                         <i className="dark:text-gray-200">No DID selected</i>
                     </div>
-                    <div className={twMerge(
-                        "flex flex-col space-y-2",
-                        selectedDID ? "block" : "hidden",
-                    )}
+                    <div
+                        className={twMerge(
+                            selectedDID ? "block" : "hidden",
+                        )}
+                        aria-label="Go To DID Page"
                     >
-                        <Button label="Go To DID Page"/>
+                        <Button label="Go To DID Page" aria-label="Go To DID Page"/>
                     </div>
                 </div>
             </div>

--- a/src/component-library/components/StreamedTables/FetchstatusIndicator.tsx
+++ b/src/component-library/components/StreamedTables/FetchstatusIndicator.tsx
@@ -20,6 +20,7 @@ export const FetchstatusIndicator = (props: {
                         "flex justify-between items-center border p-1 rounded-md w-32",
                         "bg-amber-200"
                     )}
+                    aria-label="FetchStatus Indicator: Fetching"
                 >
                     <div
                         className={twMerge(
@@ -60,6 +61,7 @@ export const FetchstatusIndicator = (props: {
                         "relative",
                         "animate-fadeout fill-mode-forwards"
                     )}
+                    aria-label="FetchStatus Indicator: Idle"
                 >
                     <div
                         className={twMerge(
@@ -98,6 +100,7 @@ export const FetchstatusIndicator = (props: {
                         "flex justify-between items-center border p-1 rounded-md w-32",
                         "bg-stone-200"
                     )}
+                    aria-label="FetchStatus Indicator: Paused"
                 >
                     <div
                         className={twMerge(

--- a/src/component-library/components/StreamedTables/PaginationDiv.tsx
+++ b/src/component-library/components/StreamedTables/PaginationDiv.tsx
@@ -6,10 +6,10 @@ import { P } from "../Text/Content/P";
 import { twMerge } from "tailwind-merge";
 
 export const PaginationDiv: React.FC<JSX.IntrinsicElements["div"] & {
-        table: any;
-        pageIndex: number;
-        setPageIndex: (pageIndex: number) => void;
-    }> = (
+    table: any;
+    pageIndex: number;
+    setPageIndex: (pageIndex: number) => void;
+}> = (
     {
         table,
         pageIndex,
@@ -17,58 +17,67 @@ export const PaginationDiv: React.FC<JSX.IntrinsicElements["div"] & {
         ...props
     }
 ) => {
-    const { className, ...otherprops } = props
-    return (
-        <div className="w-full flex justify-center space-x-2 pt-2 border-t dark:border-gray-400 dark:border-t-2">
-            <nav className="w-[400px] flex justify-center space-x-2">
-                <span className="w-1/3 flex space-x-2">
-                    <Button
-                        onClick={() => {
-                            table.setPageIndex(0)
-                        }}
-                        disabled={!table.getCanPreviousPage()}
-                        icon={<HiChevronDoubleLeft />}
-                    />
-                    <Button
-                        onClick={() => {
-                            table.previousPage()
-                        }}
-                        disabled={!table.getCanPreviousPage()}
-                        icon={<HiChevronLeft />}
-                    />
-                </span>
-                <span className="w-1/3 inline-flex space-x-2 items-end">
-                    <NumInput
-                        value={pageIndex + 1}
-                        onChange={(event) => {
-                            setPageIndex(event.target.value - 1)
-                        }}
-                        min={1}
-                        max={table.getPageCount()}
-                    />
-                    <span className="w-full">
-                        <P>
-                            of {table.getPageCount()}
-                        </P>
+        const { className, ...otherprops } = props
+        return (
+            <div className="w-full flex justify-center space-x-2 pt-2 border-t dark:border-gray-400 dark:border-t-2">
+                <nav
+                    className="w-[400px] flex justify-center space-x-2"
+                    aria-label="Table Pagination"
+                >
+                    <span className="w-1/3 flex space-x-2">
+                        <Button
+                            onClick={() => {
+                                table.setPageIndex(0)
+                            }}
+                            disabled={!table.getCanPreviousPage()}
+                            icon={<HiChevronDoubleLeft />}
+                            aria-label="First Page"
+                        />
+                        <Button
+                            onClick={() => {
+                                table.previousPage()
+                            }}
+                            disabled={!table.getCanPreviousPage()}
+                            icon={<HiChevronLeft />}
+                            aria-label="Previous Page"
+                        />
                     </span>
-                </span>
-                <span className="w-1/3 space-x-2 flex">
-                    <Button
-                        onClick={() => {
-                            table.nextPage()
-                        }}
-                        disabled={!table.getCanNextPage()}
-                        icon={<HiChevronRight />}
-                    />
-                    <Button
-                        onClick={() => {
-                            table.setPageIndex(table.getPageCount() - 1)
-                        }}
-                        disabled={!table.getCanNextPage()}
-                        icon={<HiChevronDoubleRight />}
-                    />
-                </span>
-            </nav>
-        </div>
-    )
-}
+                    <span className="w-1/3 inline-flex space-x-2 items-end">
+                        <NumInput
+                            value={pageIndex + 1}
+                            onChange={(event) => {
+                                setPageIndex(Number(event.target.value) - 1)
+                            }}
+                            min={1}
+                            max={table.getPageCount()}
+                            aria-label="Current Page Number"
+                        />
+                        <span
+                            className="w-full dark:text-white"
+                            aria-label="Total Page Count"
+                        >
+                            of {table.getPageCount()}
+                        </span>
+                    </span>
+                    <span className="w-1/3 space-x-2 flex">
+                        <Button
+                            onClick={() => {
+                                table.nextPage()
+                            }}
+                            disabled={!table.getCanNextPage()}
+                            icon={<HiChevronRight />}
+                            aria-label="Next Page"
+                        />
+                        <Button
+                            onClick={() => {
+                                table.setPageIndex(table.getPageCount() - 1)
+                            }}
+                            disabled={!table.getCanNextPage()}
+                            icon={<HiChevronDoubleRight />}
+                            aria-label="Last Page"
+                        />
+                    </span>
+                </nav>
+            </div>
+        )
+    }

--- a/test/component/ListDID.test.tsx
+++ b/test/component/ListDID.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, act, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ListDID as ListDIDStory } from "@/component-library/components/Pages/ListDID/ListDID";
+import { DIDMeta } from "@/lib/core/entity/rucio";
+var format = require("date-format")
+
+describe("ListDID Story Test", () => {
+    it("Checks empty render of the story", async () => {
+        await act(async () => render(
+            <ListDIDStory
+                didSearch={jest.fn(x => console.log(x))}
+                didResponse={{ data: [], fetchStatus: "idle" }}
+                didMetaQuery={jest.fn(x => console.log(x))}
+                didMetaQueryResponse={{} as DIDMeta}
+            />
+        ))
+        // check if DID Search Pattern Input exists
+        const searchPatternInput = screen.getByLabelText("DID Search Pattern")
+        expect(searchPatternInput).toHaveValue("")
+        // check if query is set to Containers and Datasets
+        const containersButton = screen.getByLabelText("Containers")
+        const filesButton = screen.getByLabelText("Files (Warning: large query)")
+        expect(containersButton).toBeChecked()
+        expect(filesButton).not.toBeChecked()
+        // Check that `No DID selected` is shown instead of the DIDMetaView, etc
+        const noDIDSelectedDiv = screen.getByText("No DID selected").closest("div")
+        expect(noDIDSelectedDiv).toHaveClass("block")
+        const goDIDViewButton = screen.getByText("Go To DID Page").closest("button")
+        expect(goDIDViewButton?.parentElement).toHaveClass("hidden")
+        // Check that the DID Table Search is empty
+        const didFilterInputs = screen.getAllByPlaceholderText("Filter Results")
+        didFilterInputs.map((didFilterInput) => { expect(didFilterInput).toHaveValue("") })
+        // Check that we are on page 1 of 0 (I know, technically this is a bug)
+        const paginationNav = screen.getByRole("navigation", { name: "Table Pagination" })
+        expect(paginationNav).toBeInTheDocument()
+        const totalPageCountSpan = screen.getByRole("generic", { name: "Total Page Count" })
+        expect(totalPageCountSpan).toHaveTextContent("0")
+        const currentPageInput = screen.getByRole("spinbutton", { name: "Current Page Number" }) // refers to the input element (with restricted values)
+        expect(currentPageInput).toHaveValue(1)
+        // check pagination buttons
+        const firstPageButton = screen.getByRole("button", { name: "First Page" })
+        expect(firstPageButton).toBeDisabled()
+        const previousPageButton = screen.getByRole("button", { name: "Previous Page" })
+        expect(previousPageButton).toBeDisabled()
+        const nextPageButton = screen.getByRole("button", { name: "Next Page" })
+        expect(nextPageButton).toBeDisabled()
+        const lastPageButton = screen.getByRole("button", { name: "Last Page" })
+        expect(lastPageButton).toBeDisabled()
+    })
+    it("Checks render with data and user input", async () => {
+        const mockDIDMeta = {
+            "name": "dataset-YSytZjXJMdiCsSiiUwXx",
+            "scope": "Lawrence.Myers",
+            "account": "Lawrence_Myers",
+            "did_type": "Dataset",
+            "created_at": new Date(2021, 3),
+            "updated_at": new Date(2022, 10),
+            "availability": "Deleted",
+            "obsolete": false,
+            "hidden": true,
+            "suppressed": true,
+            "purge_replicas": true,
+            "monotonic": true,
+            "is_open": true,
+            "adler32": null,
+            "guid": null,
+            "md5": null,
+            "filesize": null
+        } as DIDMeta
+        await act(async () => render(
+            <ListDIDStory
+                didSearch={jest.fn(x => console.log(x))}
+                didResponse={{
+                    data: [
+                        { "scope": "user.LindaMiller", "name": "dataset-ojTcChlQGtvpWBAnUcNn", "did_type": "Container", "bytes": 57855156, "length": 35878152 },
+                        { "scope": "user.TravisRoberts", "name": "file-DfIbGGDiGWyJhrvRYwtw", "did_type": "Container", "bytes": 42245800, "length": 45289199 },
+                        { "scope": "user.DonnaBennett", "name": "dataset-RiwBaeaxTMYxOHEzAgdG", "did_type": "Container", "bytes": 51337255, "length": 87665604 },
+                        { "scope": "user.DonnaFrazier", "name": "container-gkcouVjJHfbirKsFeruw", "did_type": "File", "bytes": 10559288, "length": 94198083 },
+                        { "scope": "user.NatashaBaker", "name": "dataset-BFesxCNVirxzoXAZZfIo", "did_type": "File", "bytes": 53858564, "length": 53898582 },
+                    ], fetchStatus: "idle"
+                }}
+                didMetaQuery={jest.fn(x => console.log(x))}
+                didMetaQueryResponse={mockDIDMeta}
+            />
+        ))
+        const tableRows = screen.getAllByRole("row", { name: "DID Table Row" })
+        expect(tableRows).toHaveLength(5)
+        expect(tableRows[0]).toBeInTheDocument()
+        // check that metaview is still invisible
+        const noDIDSelectedDiv = screen.getByText("No DID selected").closest("div")
+        expect(noDIDSelectedDiv).toHaveClass("block")
+        // click the first row
+        fireEvent.click(tableRows[0])
+        expect(noDIDSelectedDiv).not.toHaveClass("block")
+        const metaDataDiv = screen.getByRole("generic", { name: "DID Metadata Quick Summary" })
+        expect(metaDataDiv).toHaveClass("flex")
+        const goDIDViewButton = screen.getByRole("generic", { name: "Go To DID Page" })
+        expect(goDIDViewButton).toHaveClass("block")
+        const didCreationRow = screen.getByRole("row", { name: "Date of DID Creation" })
+        expect(didCreationRow).toHaveTextContent(format("yyyy-MM-dd", mockDIDMeta.created_at))
+        const didObsoleteRow = screen.getByRole("row", { name: "DID Obsolete" })
+        expect(didObsoleteRow).toHaveTextContent(mockDIDMeta.obsolete ? "True" : "False")
+    })
+})


### PR DESCRIPTION
Wrote tests for empty story (i.e. no table data passed) and with table data, incl. user interaction. In the case of the user interaction, the testing library clicks on one of the table rows and asserts that the `DIDMetaView` is unhidden.

In writing these tests, refactored the components `Button`, `NumInput` and `PaginationDiv` to inherit their props from `JSX.IntrinsicElements`. This was overdue for a long time, but it became necessary so that I could add the `aria-*` tags. This increased *accessibility* of the altered components. In addition, it meant that the tests (using `testing-library`) could make use of querying [`byRole`](https://testing-library.com/docs/queries/byrole)