### PR TITLE
Feature 205 create rule page (+ Generic `StreamedTable`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.12",
+        "@faker-js/faker": "^8.0.1",
         "@inrupt/jest-jsdom-polyfills": "^1.5.5",
         "@storybook/addon-actions": "^7.0.0-beta.49",
         "@storybook/addon-essentials": "^7.0.0-beta.49",
@@ -2663,6 +2664,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
+      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@fal-works/esbuild-plugin-global-externals": {
@@ -23001,6 +23018,12 @@
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
+    },
+    "@faker-js/faker": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.0.1.tgz",
+      "integrity": "sha512-kbh5MenpTN9U0B4QcOI1NoTPlZHniSYQ3BHbhAnPjJGAmmFqxoxTE4sGdpy7ZOO9038DPGCuhXyMkjOr05uVwA==",
+      "dev": true
     },
     "@fal-works/esbuild-plugin-global-externals": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.12",
+    "@faker-js/faker": "^8.0.1",
     "@inrupt/jest-jsdom-polyfills": "^1.5.5",
     "@storybook/addon-actions": "^7.0.0-beta.49",
     "@storybook/addon-essentials": "^7.0.0-beta.49",

--- a/src/component-library/components/Helpers/SubPage.tsx
+++ b/src/component-library/components/Helpers/SubPage.tsx
@@ -1,0 +1,24 @@
+import { twMerge } from "tailwind-merge";
+
+export const SubPage: (
+    React.FC<JSX.IntrinsicElements["div"] & { show: boolean; children?: any }>
+) = (
+    {
+        show = false,
+        ...allprops
+    }
+) => {
+        const { className, children, ...props } = allprops
+        return (
+            <div
+                className={twMerge(
+                    show ? "block" : "hidden",
+                    "grow rounded-b-md",
+                    className
+                )}
+                {...props}
+            >
+                {children}
+            </div>
+        )
+    }

--- a/src/component-library/components/Pages/CreateRule/CreateRule.tsx
+++ b/src/component-library/components/Pages/CreateRule/CreateRule.tsx
@@ -253,8 +253,7 @@ export const CreateRule = (
                     <Tabs
                         tabs={["DID Search Pattern", "List of DIDs"]}
                         active={Page0State.selectDIDMethod}
-                        handleClick={(event: any) => { console.log(event.target.dataset.id); setPage0State({ ...Page0State, selectDIDMethod: Number(event.target.dataset.id) }) }}
-                        dataTestid="selectDIDMethod"
+                        updateActive={(active: number) => { setPage0State({ ...Page0State, selectDIDMethod: active }) }}
                     />
                     <Collapsible showIf={Page0State.selectDIDMethod === 0}>
                         <div className="flex flex-col space-y-2 m-2">

--- a/src/component-library/components/Pages/ListDID/DIDListTable.tsx
+++ b/src/component-library/components/Pages/ListDID/DIDListTable.tsx
@@ -222,7 +222,7 @@ export const DIDListTable = (
                     )}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/Login/Login.tsx
+++ b/src/component-library/components/Pages/Login/Login.tsx
@@ -68,7 +68,11 @@ export const Login = ({
 
             <div className="flex flex-col space-y-2">
                 <Collapsible id="vo-tabs" showIf={loginViewModel.multiVOEnabled}>
-                    <Tabs tabs={loginViewModel.voList.map((vo) => vo.name)} active={1} handleClick={(event: any) => { setSelectedVOTab(event.target.dataset.id) }} />
+                    <Tabs
+                        tabs={loginViewModel.voList.map((vo) => vo.name)}
+                        active={1}
+                        updateActive={(active: number) => { setSelectedVOTab(active) }}
+                    />
                 </Collapsible>
 
                 <div className="flex justify-center flex-col space-y-4">

--- a/src/component-library/components/Pages/PageDID/PageDID.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDID.tsx
@@ -3,6 +3,7 @@ import { DIDMetaView } from "@/component-library/components/Pages/ListDID/DIDMet
 import { Tabs } from "../../Tabs/Tabs";
 import { DIDTypeTag } from "../../Tags/DIDTypeTag";
 import { H3 } from "../../Text/Headings/H3";
+import { SubPage } from "../../Helpers/SubPage";
 
 // misc packages, react
 import { twMerge } from "tailwind-merge";
@@ -48,28 +49,6 @@ export interface PageDIDPageProps {
     didDatasetReplicasResponse: { data: any; fetchStatus: FetchStatus }
 }
 
-const SubPage: (
-    React.FC<JSX.IntrinsicElements["div"] & { show: boolean; children?: any }>
-) = (
-    {
-        show = false,
-        ...allprops
-    }
-) => {
-        const { className, children, ...props } = allprops
-        return (
-            <div
-                className={twMerge(
-                    show ? "block" : "hidden",
-                    "grow rounded-b-md",
-                    className
-                )}
-                {...props}
-            >
-                {children}
-            </div>
-        )
-    }
 
 
 export const PageDID = (

--- a/src/component-library/components/Pages/PageDID/PageDID.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDID.tsx
@@ -126,7 +126,7 @@ export const PageDID = (
                             )
                     } // remember difference between collections and files
                     active={0}
-                    handleClick={(event: any) => { console.log(event.target.dataset.id); setSubpageIndex(Number(event.target.dataset.id)) }}
+                    updateActive={(id: number) => { setSubpageIndex(id) }}
                 />
                 <SubPage
                     show={didtype === "File" ? false : didtype === "Dataset" ? subpageIndex === 0 : subpageIndex === 1}

--- a/src/component-library/components/Pages/PageDID/PageDIDContents.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDIDContents.tsx
@@ -235,7 +235,7 @@ export const PageDIDContents = (
                     )}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/PageDID/PageDIDDatasetReplicas.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDIDDatasetReplicas.tsx
@@ -481,7 +481,7 @@ export const PageDIDDatasetReplicas = (
                     )}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/PageDID/PageDIDFilereplicas.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDIDFilereplicas.tsx
@@ -245,7 +245,7 @@ export const PageDIDFilereplicas = (
                     )}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex}/>
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/PageDID/PageDIDFilereplicasD.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDIDFilereplicasD.tsx
@@ -224,7 +224,7 @@ export const PageDIDFilereplicasD = (
                             )}
                         </tbody>
                     </table>
-                    <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+                    <PaginationDiv table={table}/>
                     <div
                         className={twMerge(
                             "absolute",

--- a/src/component-library/components/Pages/PageDID/PageDIDMetadata.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDIDMetadata.tsx
@@ -214,7 +214,7 @@ export const PageDIDMetadata = (
                     )}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/PageDID/PageDIDParents.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDIDParents.tsx
@@ -236,7 +236,7 @@ export const PageDIDParents = (
                     )}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/PageDID/PageDIDRules.tsx
+++ b/src/component-library/components/Pages/PageDID/PageDIDRules.tsx
@@ -310,7 +310,7 @@ export const PageDIDRules = (
                     )}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
@@ -1,6 +1,8 @@
 import { RuleNotification, RuleState } from "@/lib/core/entity/rucio";
+import { TableData } from "@/lib/infrastructure/data/view-model/streamedtables";
 import { StoryFn, Meta } from "@storybook/react";
-import { PageRule as P } from "./PageRule";
+import { createRandomRulePageLockEntry } from "test/fixtures/table-fixtures";
+import { PageRule as P, RulePageLockEntry } from "./PageRule";
 
 export default {
     title: 'Components/Pages/PageRule',
@@ -35,5 +37,10 @@ PageRule.args = {
         split_container: false,
         state: RuleState.OK,
         updated_at: new Date(2023, 1, 1),
-    }
+    },
+    ruleLocks: {
+        data: Array.from({length: 100}, (_, i) => createRandomRulePageLockEntry()),
+        fetchStatus: "idle",
+        pageSize: 10,
+    } as TableData<RulePageLockEntry>
 };

--- a/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
@@ -1,7 +1,7 @@
 import { RuleNotification, RuleState } from "@/lib/core/entity/rucio";
 import { TableData } from "@/lib/infrastructure/data/view-model/streamedtables";
 import { StoryFn, Meta } from "@storybook/react";
-import { createRandomRulePageLockEntry } from "test/fixtures/table-fixtures";
+import { createRandomRulePageLockEntry, createRuleMeta } from "test/fixtures/table-fixtures";
 import { PageRule as P, RulePageLockEntry } from "./PageRule";
 
 export default {
@@ -13,31 +13,7 @@ const Template: StoryFn<typeof P> = (args) => <P {...args} />;
 
 export const PageRule = Template.bind({});
 PageRule.args = {
-    ruleMeta: {
-        account: "root",
-        activity: "Production Input",
-        copies: 1,
-        created_at: new Date(2022, 1, 1),
-        did_type: "Dataset",
-        expires_at: new Date(2024, 1, 1),
-        grouping: "File",
-        id: "f7ea6abe1f9841ff83dd6d6ece32d8e0",
-        ignore_account_limit: false,
-        ignore_availability: false,
-        locked: false,
-        locks_ok_cnt: 1,
-        locks_replicating_cnt: 0,
-        locks_stuck_cnt: 0,
-        name: "user.mlassnig.pilot.test.single.hits",
-        notification: RuleNotification.No,
-        priority: 3,
-        purge_replicas: false,
-        rse_expression: "AGLT2_LOCALGROUPDISK",
-        scope: "user.mlassnig",
-        split_container: false,
-        state: RuleState.OK,
-        updated_at: new Date(2023, 1, 1),
-    },
+    ruleMeta: createRuleMeta(),
     ruleLocks: {
         data: Array.from({length: 100}, (_, i) => createRandomRulePageLockEntry()),
         fetchStatus: "idle",

--- a/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
@@ -1,4 +1,4 @@
-import { RuleState } from "@/lib/core/entity/rucio";
+import { RuleNotification, RuleState } from "@/lib/core/entity/rucio";
 import { StoryFn, Meta } from "@storybook/react";
 import { PageRule as P } from "./PageRule";
 
@@ -27,7 +27,7 @@ PageRule.args = {
         locks_replicating_cnt: 0,
         locks_stuck_cnt: 0,
         name: "user.mlassnig.pilot.test.single.hits",
-        notification: "NO",
+        notification: RuleNotification.No,
         priority: 3,
         purge_replicas: false,
         rse_expression: "AGLT2_LOCALGROUPDISK",

--- a/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.stories.tsx
@@ -1,0 +1,39 @@
+import { RuleState } from "@/lib/core/entity/rucio";
+import { StoryFn, Meta } from "@storybook/react";
+import { PageRule as P } from "./PageRule";
+
+export default {
+    title: 'Components/Pages/PageRule',
+    component: P,
+} as Meta<typeof P>;
+
+const Template: StoryFn<typeof P> = (args) => <P {...args} />;
+
+export const PageRule = Template.bind({});
+PageRule.args = {
+    ruleMeta: {
+        account: "root",
+        activity: "Production Input",
+        copies: 1,
+        created_at: new Date(2022, 1, 1),
+        did_type: "Dataset",
+        expires_at: new Date(2024, 1, 1),
+        grouping: "File",
+        id: "f7ea6abe1f9841ff83dd6d6ece32d8e0",
+        ignore_account_limit: false,
+        ignore_availability: false,
+        locked: false,
+        locks_ok_cnt: 1,
+        locks_replicating_cnt: 0,
+        locks_stuck_cnt: 0,
+        name: "user.mlassnig.pilot.test.single.hits",
+        notification: "NO",
+        priority: 3,
+        purge_replicas: false,
+        rse_expression: "AGLT2_LOCALGROUPDISK",
+        scope: "user.mlassnig",
+        split_container: false,
+        state: RuleState.OK,
+        updated_at: new Date(2023, 1, 1),
+    }
+};

--- a/src/component-library/components/Pages/PageRule/PageRule.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.tsx
@@ -225,12 +225,16 @@ export const PageRule = (
                     tabs={
                         ["Metadata", "Locks"]
                     } // remember difference between collections and files
+                    _ariaControls={
+                        ["subpage-metadata", "subpage-locks"]
+                    }
                     active={0}
-                    handleClick={(event: any) => { console.log(event.target.dataset.id); setSubpageIndex(Number(event.target.dataset.id)) }}
+                    updateActive={(active) => {setSubpageIndex(active)}}
                 />
                 <SubPage
                     show={subpageIndex === 0}
                     id="subpage-metadata"
+                    aria-labelledby="tab-0"
                 >
                     <div
                         className={twMerge(
@@ -364,6 +368,7 @@ export const PageRule = (
 
                     show={subpageIndex === 1}
                     id="subpage-locks"
+                    aria-labelledby="tab-1"
                 >
                     <StreamedTable
                         tableData={props.ruleLocks}

--- a/src/component-library/components/Pages/PageRule/PageRule.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.tsx
@@ -91,7 +91,7 @@ export const PageRule = (
     const meta = props.ruleMeta;
 
     const columnHelper = createColumnHelper<RulePageLockEntry>()
-    const tableColumns = [
+    const tablecolumns = [
         columnHelper.accessor(row => `${row.scope}:${row.name}`, {
             id: "did",
             header: info => {
@@ -373,9 +373,9 @@ export const PageRule = (
                     role="tabpanel"
                 >
                     <StreamedTable
-                        tableData={props.ruleLocks}
-                        tableColumns={tableColumns}
-                        tableStyling={{
+                        tabledata={props.ruleLocks}
+                        tablecolumns={tablecolumns}
+                        tablestyling={{
                             visibility: {
                                 // "state": windowSize[0] > 768,
                                 "links": windowSize[0] > 768

--- a/src/component-library/components/Pages/PageRule/PageRule.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.tsx
@@ -3,13 +3,16 @@ import { useState, useEffect } from "react"
 import { twMerge } from "tailwind-merge";
 var format = require("date-format")
 
-import { RuleMeta } from "@/lib/core/entity/rucio";
+import { RuleMeta, RuleNotification } from "@/lib/core/entity/rucio";
+import { LockState } from "@/lib/core/entity/rucio";
 import { Tabs } from "../../Tabs/Tabs";
 import { SubPage } from "../../Helpers/SubPage";
 import { H3 } from "../../Text/Headings/H3";
 import { BoolTag } from "../../Tags/BoolTag";
 import { DIDTypeTag } from "../../Tags/DIDTypeTag";
 import { RuleStateTag } from "../../Tags/RuleStateTag";
+import { LockStateTag } from "../../Tags/LockStateTag";
+import { RuleNotificationTag } from "../../Tags/RuleNotificationTag";
 
 export interface PageRulePageProps {
     ruleMeta: RuleMeta;
@@ -20,7 +23,7 @@ const Titletd: React.FC<JSX.IntrinsicElements["td"]> = ({ ...props }) => {
     return (
         <td
             className={twMerge(
-                "font-bold w-48 pl-1 dark:text-white",
+                "font-bold w-28 md:w-48 pl-1 dark:text-white",
                 className ?? ""
             )}
             {...otherprops}
@@ -34,7 +37,7 @@ const Contenttd: React.FC<JSX.IntrinsicElements["td"]> = ({ ...props }) => {
     return (
         <td
             className={twMerge(
-                "break-all dark:text-gray-100",
+                "break-all dark:text-gray-100 pr-1",
                 className ?? ""
             )}
             {...otherprops}
@@ -111,125 +114,144 @@ export const PageRule = (
                 <SubPage
                     show={subpageIndex === 0}
                     id="subpage-metadata"
-                    className={twMerge(
-                        "bg-stone-100 p-2 mt-2 rounded-t-md",
-                        "flex flex-col space-y-2"
-                    )}
                 >
-                    <Ruletable>
-                        <tr>
-                            <Titletd>Scope</Titletd>
-                            <Contenttd>{meta.scope}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Name</Titletd>
-                            <Contenttd>{meta.name}</Contenttd>
-                        </tr>
-                    </Ruletable>
-                    <Ruletable>
-                        <tr>
-                            <Titletd>Created At</Titletd>
-                            <Contenttd>{format("yyyy-MM-dd", meta.created_at)}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Updated At</Titletd>
-                            <Contenttd>{format("yyyy-MM-dd", meta.updated_at)}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Expires At</Titletd>
-                            <Contenttd>
-                                {
-                                    format("yyyy-MM-dd", meta.expires_at)
-                                    // add ability to extend lifetime here
-                                }
-                            </Contenttd>
-                        </tr>
-                    </Ruletable>
-                    <Ruletable>
-                        <tr>
-                            <Titletd>Locks OK</Titletd>
-                            <Contenttd>{meta.locks_ok_cnt}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Locks Replicating</Titletd>
-                            <Contenttd>{meta.locks_replicating_cnt}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Locks Stuck</Titletd>
-                            <Contenttd>{meta.locks_stuck_cnt}</Contenttd>
-                        </tr>
-                    </Ruletable>
-                    <Ruletable>
-                        <tr>
-                            <Titletd>Purge Replicas</Titletd>
-                            <Contenttd>{<BoolTag val={meta.purge_replicas}/>}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Split Container</Titletd>
-                            <Contenttd>{<BoolTag val={meta.split_container}/>}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Ignore Account Limit</Titletd>
-                            <Contenttd>{<BoolTag val={meta.ignore_account_limit}/>}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Ignore Availability</Titletd>
-                            <Contenttd>{<BoolTag val={meta.ignore_availability}/>}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Locked</Titletd>
-                            <Contenttd>{<BoolTag val={meta.locked}/>}</Contenttd>
-                        </tr>
-                    </Ruletable>
-                    <Ruletable>
-                        <tr>
-                            <Titletd>Copies</Titletd>
-                            <Contenttd>{meta.copies}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>ID</Titletd>
-                            <Contenttd>{meta.id}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>DID Type</Titletd>
-                            <Contenttd><DIDTypeTag didtype={meta.did_type}/></Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Grouping</Titletd>
-                            <Contenttd><DIDTypeTag didtype={meta.grouping}/></Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Priority</Titletd>
-                            <Contenttd>{meta.priority}</Contenttd>
-                        </tr>
-                    </Ruletable>
-                    <Ruletable>
-                        <tr>
-                            <Titletd>RSE Expression</Titletd>
-                            <Contenttd>{meta.rse_expression}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Notification</Titletd>
-                            <Contenttd>{meta.notification}</Contenttd>
-                        </tr>
-                    </Ruletable>
-                    <Ruletable>
-                        <tr>
-                            <Titletd>Account</Titletd>
-                            <Contenttd>{meta.account}</Contenttd>
-                        </tr>
-                        <tr>
-                            <Titletd>Activity</Titletd>
-                            <Contenttd>{meta.activity}</Contenttd>
-                        </tr>
-                    </Ruletable>
-                    <Ruletable>
-                        <tr>
-                            <Titletd>State</Titletd>
-                            <Contenttd><RuleStateTag state={meta.state}/></Contenttd>
-                        </tr>
-                    </Ruletable>
-                </SubPage>
+                    <div
+                        className={twMerge(
+                            "bg-stone-100 p-2 mt-2 rounded-md",
+                            "flex flex-col space-y-2"
+                        )}
+                    >
+
+                        <Ruletable>
+                            <tr>
+                                <Titletd>Scope</Titletd>
+                                <Contenttd>{meta.scope}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Name</Titletd>
+                                <Contenttd>{meta.name}</Contenttd>
+                            </tr>
+                        </Ruletable>
+                        <Ruletable>
+                            <tr>
+                                <Titletd>Created At</Titletd>
+                                <Contenttd>{format("yyyy-MM-dd", meta.created_at)}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Updated At</Titletd>
+                                <Contenttd>{format("yyyy-MM-dd", meta.updated_at)}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Expires At</Titletd>
+                                <Contenttd>
+                                    {
+                                        format("yyyy-MM-dd", meta.expires_at)
+                                        // add ability to extend lifetime here
+                                    }
+                                </Contenttd>
+                            </tr>
+                        </Ruletable>
+                        <Ruletable>
+                            <tr>
+                                <Titletd>Locks OK</Titletd>
+                                <Contenttd>
+                                    <span className="flex flex-row space-x-2 justify-end">
+                                        <LockStateTag lockState={LockState.OK} tiny className={meta.locks_ok_cnt > 0 ? "" : "hidden"}/>
+                                        <span className="font-mono">{meta.locks_ok_cnt}</span>
+                                    </span>
+                                </Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Locks Replicating</Titletd>
+                                <Contenttd>
+                                    <span className="flex flex-row space-x-2 justify-end">
+                                        <LockStateTag lockState={LockState.Replicating} tiny className={meta.locks_replicating_cnt > 0 ? "" : "hidden"}/>
+                                        <span className="font-mono">{meta.locks_replicating_cnt}</span>
+                                    </span>
+                                </Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Locks Stuck</Titletd>
+                                <Contenttd>
+                                    <span className="flex flex-row space-x-2 justify-end">
+                                        <LockStateTag lockState={LockState.Stuck} tiny className={meta.locks_stuck_cnt > 0 ? "" : "hidden"}/>
+                                        <span className="font-mono">{meta.locks_stuck_cnt}</span>
+                                    </span>
+                                </Contenttd>
+                            </tr>
+                        </Ruletable>
+                        <Ruletable>
+                            <tr>
+                                <Titletd>Purge Replicas</Titletd>
+                                <Contenttd>{<BoolTag val={meta.purge_replicas} />}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Split Container</Titletd>
+                                <Contenttd>{<BoolTag val={meta.split_container} />}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Ignore Account Limit</Titletd>
+                                <Contenttd>{<BoolTag val={meta.ignore_account_limit} />}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Ignore Availability</Titletd>
+                                <Contenttd>{<BoolTag val={meta.ignore_availability} />}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Locked</Titletd>
+                                <Contenttd>{<BoolTag val={meta.locked} />}</Contenttd>
+                            </tr>
+                        </Ruletable>
+                        <Ruletable>
+                            <tr>
+                                <Titletd>Copies</Titletd>
+                                <Contenttd>{meta.copies}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>ID</Titletd>
+                                <Contenttd className="font-mono">{meta.id}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>DID Type</Titletd>
+                                <Contenttd><DIDTypeTag didtype={meta.did_type} /></Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Grouping</Titletd>
+                                <Contenttd><DIDTypeTag didtype={meta.grouping} /></Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Priority</Titletd>
+                                <Contenttd>{meta.priority}</Contenttd>
+                            </tr>
+                        </Ruletable>
+                        <Ruletable>
+                            <tr>
+                                <Titletd>RSE Expression</Titletd>
+                                <Contenttd className="font-mono">{meta.rse_expression}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Notification</Titletd>
+                                <Contenttd><RuleNotificationTag notificationState={meta.notification}/></Contenttd>
+                            </tr>
+                        </Ruletable>
+                        <Ruletable>
+                            <tr>
+                                <Titletd>Account</Titletd>
+                                <Contenttd>{meta.account}</Contenttd>
+                            </tr>
+                            <tr>
+                                <Titletd>Activity</Titletd>
+                                <Contenttd>{meta.activity}</Contenttd>
+                            </tr>
+                        </Ruletable>
+                        <Ruletable>
+                            <tr>
+                                <Titletd>State</Titletd>
+                                <Contenttd><RuleStateTag state={meta.state} /></Contenttd>
+                            </tr>
+                        </Ruletable>
+
+                    </div></SubPage>
                 <SubPage
 
                     show={subpageIndex === 1}

--- a/src/component-library/components/Pages/PageRule/PageRule.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.tsx
@@ -1,0 +1,245 @@
+import { useState, useEffect } from "react"
+
+import { twMerge } from "tailwind-merge";
+var format = require("date-format")
+
+import { RuleMeta } from "@/lib/core/entity/rucio";
+import { Tabs } from "../../Tabs/Tabs";
+import { SubPage } from "../../Helpers/SubPage";
+import { H3 } from "../../Text/Headings/H3";
+import { BoolTag } from "../../Tags/BoolTag";
+import { DIDTypeTag } from "../../Tags/DIDTypeTag";
+import { RuleStateTag } from "../../Tags/RuleStateTag";
+
+export interface PageRulePageProps {
+    ruleMeta: RuleMeta;
+}
+
+const Titletd: React.FC<JSX.IntrinsicElements["td"]> = ({ ...props }) => {
+    const { className, ...otherprops } = props
+    return (
+        <td
+            className={twMerge(
+                "font-bold w-48 pl-1 dark:text-white",
+                className ?? ""
+            )}
+            {...otherprops}
+        >
+            {props.children}
+        </td>
+    )
+}
+const Contenttd: React.FC<JSX.IntrinsicElements["td"]> = ({ ...props }) => {
+    const { className, ...otherprops } = props
+    return (
+        <td
+            className={twMerge(
+                "break-all dark:text-gray-100",
+                className ?? ""
+            )}
+            {...otherprops}
+        >
+            {props.children}
+        </td>
+    )
+}
+
+const Ruletable: React.FC<JSX.IntrinsicElements["table"]> = ({ ...props }) => {
+    const { className, ...otherprops } = props
+    return (
+        <table
+            className={twMerge(
+                "bg-white dark:bg-gray-700",
+                "w-full rounded border-separate border-spacing-y-1",
+                className ?? ""
+            )}
+            {...otherprops}
+        >
+            <tbody className="w-full">
+                {props.children}
+            </tbody>
+        </table>
+    )
+}
+
+export const PageRule = (
+    props: PageRulePageProps
+) => {
+    const [subpageIndex, setSubpageIndex] = useState(0);
+    const meta = props.ruleMeta;
+    return (
+        <div
+            className={twMerge(
+                "flex flex-col space-y-2 w-full"
+            )}
+        >
+            <div
+                className={twMerge(
+                    "rounded-md w-full",
+                    "border dark:border-2 dark:border-gray-200 p-2",
+                    "flex flex-col items-start space-y-2",
+                    "bg-white dark:bg-gray-800"
+                )}
+            >
+                <div
+                    className={twMerge(
+                        "flex flex-col space-y-2 lg:flex-row lg:justify-between lg:items-baseline lg:space-y-0 w-full",
+                        "bg-white dark:bg-gray-800"
+                    )}
+                >
+                    <span className="flex flex-row justify-between space-x-4">
+                        <H3>Rule Page for {props.ruleMeta.scope}:{props.ruleMeta.name}</H3>
+                    </span>
+                </div>
+
+            </div>
+            <div
+                className={twMerge(
+                    "min-w-0",
+                    "lg:col-span-2",
+                    "flex flex-col",
+                    "rounded-md p-2 border"
+                )}
+            >
+                <Tabs
+                    tabs={
+                        ["Metadata", "Locks"]
+                    } // remember difference between collections and files
+                    active={0}
+                    handleClick={(event: any) => { console.log(event.target.dataset.id); setSubpageIndex(Number(event.target.dataset.id)) }}
+                />
+                <SubPage
+                    show={subpageIndex === 0}
+                    id="subpage-metadata"
+                    className={twMerge(
+                        "bg-stone-100 p-2 mt-2 rounded-t-md",
+                        "flex flex-col space-y-2"
+                    )}
+                >
+                    <Ruletable>
+                        <tr>
+                            <Titletd>Scope</Titletd>
+                            <Contenttd>{meta.scope}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Name</Titletd>
+                            <Contenttd>{meta.name}</Contenttd>
+                        </tr>
+                    </Ruletable>
+                    <Ruletable>
+                        <tr>
+                            <Titletd>Created At</Titletd>
+                            <Contenttd>{format("yyyy-MM-dd", meta.created_at)}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Updated At</Titletd>
+                            <Contenttd>{format("yyyy-MM-dd", meta.updated_at)}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Expires At</Titletd>
+                            <Contenttd>
+                                {
+                                    format("yyyy-MM-dd", meta.expires_at)
+                                    // add ability to extend lifetime here
+                                }
+                            </Contenttd>
+                        </tr>
+                    </Ruletable>
+                    <Ruletable>
+                        <tr>
+                            <Titletd>Locks OK</Titletd>
+                            <Contenttd>{meta.locks_ok_cnt}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Locks Replicating</Titletd>
+                            <Contenttd>{meta.locks_replicating_cnt}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Locks Stuck</Titletd>
+                            <Contenttd>{meta.locks_stuck_cnt}</Contenttd>
+                        </tr>
+                    </Ruletable>
+                    <Ruletable>
+                        <tr>
+                            <Titletd>Purge Replicas</Titletd>
+                            <Contenttd>{<BoolTag val={meta.purge_replicas}/>}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Split Container</Titletd>
+                            <Contenttd>{<BoolTag val={meta.split_container}/>}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Ignore Account Limit</Titletd>
+                            <Contenttd>{<BoolTag val={meta.ignore_account_limit}/>}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Ignore Availability</Titletd>
+                            <Contenttd>{<BoolTag val={meta.ignore_availability}/>}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Locked</Titletd>
+                            <Contenttd>{<BoolTag val={meta.locked}/>}</Contenttd>
+                        </tr>
+                    </Ruletable>
+                    <Ruletable>
+                        <tr>
+                            <Titletd>Copies</Titletd>
+                            <Contenttd>{meta.copies}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>ID</Titletd>
+                            <Contenttd>{meta.id}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>DID Type</Titletd>
+                            <Contenttd><DIDTypeTag didtype={meta.did_type}/></Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Grouping</Titletd>
+                            <Contenttd><DIDTypeTag didtype={meta.grouping}/></Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Priority</Titletd>
+                            <Contenttd>{meta.priority}</Contenttd>
+                        </tr>
+                    </Ruletable>
+                    <Ruletable>
+                        <tr>
+                            <Titletd>RSE Expression</Titletd>
+                            <Contenttd>{meta.rse_expression}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Notification</Titletd>
+                            <Contenttd>{meta.notification}</Contenttd>
+                        </tr>
+                    </Ruletable>
+                    <Ruletable>
+                        <tr>
+                            <Titletd>Account</Titletd>
+                            <Contenttd>{meta.account}</Contenttd>
+                        </tr>
+                        <tr>
+                            <Titletd>Activity</Titletd>
+                            <Contenttd>{meta.activity}</Contenttd>
+                        </tr>
+                    </Ruletable>
+                    <Ruletable>
+                        <tr>
+                            <Titletd>State</Titletd>
+                            <Contenttd><RuleStateTag state={meta.state}/></Contenttd>
+                        </tr>
+                    </Ruletable>
+                </SubPage>
+                <SubPage
+
+                    show={subpageIndex === 1}
+                    id="subpage-locks"
+                >
+                    subpage locks
+                </SubPage>
+
+            </div>
+        </div>
+
+    );
+};

--- a/src/component-library/components/Pages/PageRule/PageRule.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.tsx
@@ -235,6 +235,7 @@ export const PageRule = (
                     show={subpageIndex === 0}
                     id="subpage-metadata"
                     aria-labelledby="tab-0"
+                    role="tabpanel"
                 >
                     <div
                         className={twMerge(
@@ -369,6 +370,7 @@ export const PageRule = (
                     show={subpageIndex === 1}
                     id="subpage-locks"
                     aria-labelledby="tab-1"
+                    role="tabpanel"
                 >
                     <StreamedTable
                         tableData={props.ruleLocks}

--- a/src/component-library/components/Pages/PageRule/PageRule.tsx
+++ b/src/component-library/components/Pages/PageRule/PageRule.tsx
@@ -9,6 +9,7 @@ import { LockState } from "@/lib/core/entity/rucio";
 import { Tabs } from "../../Tabs/Tabs";
 import { SubPage } from "../../Helpers/SubPage";
 import { H3 } from "../../Text/Headings/H3";
+import { P } from "../../Text/Content/P";
 import { BoolTag } from "../../Tags/BoolTag";
 import { DIDTypeTag } from "../../Tags/DIDTypeTag";
 import { RuleStateTag } from "../../Tags/RuleStateTag";
@@ -16,8 +17,10 @@ import { LockStateTag } from "../../Tags/LockStateTag";
 import { RuleNotificationTag } from "../../Tags/RuleNotificationTag";
 import { StreamedTable } from "../../StreamedTables/StreamedTable";
 import { createColumnHelper } from "@tanstack/react-table";
-import { HiExternalLink } from "react-icons/hi";
+import { HiDotsHorizontal, HiExternalLink } from "react-icons/hi";
 import { TableExternalLink } from "../../StreamedTables/TableExternalLink";
+import { TableFilterDiscrete } from "../../StreamedTables/TableFilterDiscrete";
+import { TableFilterString } from "../../StreamedTables/TableFilterString";
 
 
 export interface RulePageLockEntry {
@@ -93,31 +96,49 @@ export const PageRule = (
             id: "did",
             header: info => {
                 return (
-                    <H3>DID Name</H3>
+                    <TableFilterString
+                        column={info.column}
+                        name="DID"
+                    />
+                )
+            },
+            cell: info => {
+                return (
+                    <P className="break-all pr-1">{info.getValue()}</P>
                 )
             }
         }),
         columnHelper.accessor("rse", {
             id: "rse",
-            cell: info => <span>{info.getValue()}</span>,
             header: info => {
                 return (
-                    <H3>RSE</H3>
+                    <TableFilterString
+                        column={info.column}
+                        name="RSE"
+                    />
+                )
+            },
+            cell: info => {
+                return (
+                    <P className="break-all">{info.getValue()}</P>
                 )
             }
         }),
         columnHelper.accessor("state", {
             id: "state",
-            cell: info => <LockStateTag lockState={info.getValue()} />,
+            cell: info => <LockStateTag lockState={info.getValue()} tiny={windowSize[0] <= 768} />,
             header: info => {
                 return (
-                    <span className={twMerge("flex flex-row justify-start")}>
-                        <H3>Lock</H3>
-                    </span>
+                    <TableFilterDiscrete<LockState>
+                        name="Lock"
+                        keys={Object.values(LockState)}
+                        renderFunc={state => state === undefined ? <HiDotsHorizontal className="text-2xl text-gray-500 dark:text-gray-200" /> : <LockStateTag lockState={state} tiny />}
+                        column={info.column}
+                    />
                 )
             },
             meta: {
-                style: "w-32"
+                style: "w-6 sm:w-8 md:w-32"
             }
         }),
         columnHelper.display({
@@ -144,7 +165,7 @@ export const PageRule = (
             meta: {
                 style: "w-32"
             }
-        })
+        }),
     ]
 
     const [windowSize, setWindowSize] = useState([
@@ -196,7 +217,8 @@ export const PageRule = (
                     "min-w-0",
                     "lg:col-span-2",
                     "flex flex-col",
-                    "rounded-md p-2 border"
+                    "rounded-md p-2 border",
+                    "bg-white dark:bg-gray-800"
                 )}
             >
                 <Tabs
@@ -207,12 +229,12 @@ export const PageRule = (
                     handleClick={(event: any) => { console.log(event.target.dataset.id); setSubpageIndex(Number(event.target.dataset.id)) }}
                 />
                 <SubPage
-                    show={subpageIndex === 1}
+                    show={subpageIndex === 0}
                     id="subpage-metadata"
                 >
                     <div
                         className={twMerge(
-                            "bg-stone-100 p-2 mt-2 rounded-md",
+                            "bg-stone-100 dark:bg-gray-900 p-2 mt-2 rounded-md",
                             "flex flex-col space-y-2"
                         )}
                     >
@@ -241,7 +263,7 @@ export const PageRule = (
                                 <Contenttd>
                                     {
                                         format("yyyy-MM-dd", meta.expires_at)
-                                        // add ability to extend lifetime here
+                                        // add ability to extend lifetime here => or maybe not?? i think this might be bad UX
                                     }
                                 </Contenttd>
                             </tr>
@@ -250,28 +272,19 @@ export const PageRule = (
                             <tr>
                                 <Titletd>Locks OK</Titletd>
                                 <Contenttd>
-                                    <span className="flex flex-row space-x-2 justify-end">
-                                        <LockStateTag lockState={LockState.OK} tiny className={meta.locks_ok_cnt > 0 ? "" : "hidden"} />
-                                        <span className="font-mono">{meta.locks_ok_cnt}</span>
-                                    </span>
+                                        <P mono>{meta.locks_ok_cnt}</P>
                                 </Contenttd>
                             </tr>
                             <tr>
                                 <Titletd>Locks Replicating</Titletd>
                                 <Contenttd>
-                                    <span className="flex flex-row space-x-2 justify-end">
-                                        <LockStateTag lockState={LockState.Replicating} tiny className={meta.locks_replicating_cnt > 0 ? "" : "hidden"} />
-                                        <span className="font-mono">{meta.locks_replicating_cnt}</span>
-                                    </span>
+                                        <P mono>{meta.locks_replicating_cnt}</P>
                                 </Contenttd>
                             </tr>
                             <tr>
                                 <Titletd>Locks Stuck</Titletd>
                                 <Contenttd>
-                                    <span className="flex flex-row space-x-2 justify-end">
-                                        <LockStateTag lockState={LockState.Stuck} tiny className={meta.locks_stuck_cnt > 0 ? "" : "hidden"} />
-                                        <span className="font-mono">{meta.locks_stuck_cnt}</span>
-                                    </span>
+                                        <P mono>{meta.locks_stuck_cnt}</P>
                                 </Contenttd>
                             </tr>
                         </Ruletable>
@@ -349,14 +362,18 @@ export const PageRule = (
                     </div></SubPage>
                 <SubPage
 
-                    show={subpageIndex === 0}
+                    show={subpageIndex === 1}
                     id="subpage-locks"
                 >
-                    subpage locks
                     <StreamedTable
                         tableData={props.ruleLocks}
                         tableColumns={tableColumns}
-                        tableStyling={{visibility: {"state": windowSize[0] > 768}}}
+                        tableStyling={{
+                            visibility: {
+                                // "state": windowSize[0] > 768,
+                                "links": windowSize[0] > 768
+                            },
+                        }}
                     />
                 </SubPage>
 

--- a/src/component-library/components/StreamedTables/DIDSelectTable.tsx
+++ b/src/component-library/components/StreamedTables/DIDSelectTable.tsx
@@ -347,7 +347,7 @@ export const DIDSelectTable = (
                     })}
                 </tbody>
             </table>
-            <PaginationDiv table={table} pageIndex={pageIndex} setPageIndex={setPageIndex} />
+            <PaginationDiv table={table}/>
             <div
                 className={twMerge(
                     "absolute",

--- a/src/component-library/components/StreamedTables/Filter.tsx
+++ b/src/component-library/components/StreamedTables/Filter.tsx
@@ -1,5 +1,5 @@
 import { Column, Table } from "@tanstack/react-table";
-import { TextInput } from "../Input/TextInput.stories";
+import { TextInput } from "../Input/TextInput";
 
 export const Filter = (
     props: {

--- a/src/component-library/components/StreamedTables/PaginationDiv.stories.tsx
+++ b/src/component-library/components/StreamedTables/PaginationDiv.stories.tsx
@@ -10,14 +10,19 @@ const Template: StoryFn<typeof PD> = (args) => <PD {...args} />
 
 export const PaginationDiv = Template.bind({})
 PaginationDiv.args = {
-    pageIndex: 0,
-    setPageIndex: () => {},
     table: {
         setPageIndex: () => {},
-        getCanPreviousPage: () => true,
+        getCanPreviousPage: () => false,
         previousPage: () => {},
         getPageCount: () => 1,
         nextPage: () => {},
         getCanNextPage: () => true,
+        getState: () => {
+            return {
+                pagination: {
+                    pageIndex: 0
+                }
+            }
+        }
     }
 }

--- a/src/component-library/components/StreamedTables/PaginationDiv.tsx
+++ b/src/component-library/components/StreamedTables/PaginationDiv.tsx
@@ -7,13 +7,9 @@ import { twMerge } from "tailwind-merge";
 
 export const PaginationDiv: React.FC<JSX.IntrinsicElements["div"] & {
     table: any;
-    pageIndex: number;
-    setPageIndex: (pageIndex: number) => void;
 }> = (
     {
         table,
-        pageIndex,
-        setPageIndex,
         ...props
     }
 ) => {
@@ -44,9 +40,9 @@ export const PaginationDiv: React.FC<JSX.IntrinsicElements["div"] & {
                     </span>
                     <span className="w-1/3 inline-flex space-x-2 items-end">
                         <NumInput
-                            value={pageIndex + 1}
+                            value={table.getState().pagination.pageIndex + 1}
                             onChange={(event) => {
-                                setPageIndex(Number(event.target.value) - 1)
+                                table.setPageIndex(Number(event.target.value) - 1)
                             }}
                             min={1}
                             max={table.getPageCount()}

--- a/src/component-library/components/StreamedTables/StreamedTable.stories.tsx
+++ b/src/component-library/components/StreamedTables/StreamedTable.stories.tsx
@@ -1,0 +1,52 @@
+import { DIDType } from "@/lib/core/data/rucio-dto";
+import { DIDContents } from "@/lib/infrastructure/data/view-model/page-did";
+import { TableData } from "@/lib/infrastructure/data/view-model/streamedtables";
+import { StoryFn, Meta } from "@storybook/react";
+import { createColumnHelper, Column} from "@tanstack/react-table";
+import { createRandomDIDContents } from "test/fixtures/table-fixtures";
+import { StreamedTable as S } from "./StreamedTable";
+
+export default {
+    title: 'Components/StreamedTables',
+    component: S,
+} as Meta<typeof S>;
+
+const Template: StoryFn<typeof S> = (args) => <S {...args} />;
+
+const columnHelper = createColumnHelper<DIDContents>()
+
+export const StreamedTable = Template.bind({});
+StreamedTable.args = {
+    tableData: {
+        data: Array.from({length: 100}, (_, i) => createRandomDIDContents()),
+        fetchStatus: "idle",
+        pageSize: 10,
+    } as TableData<DIDContents>,
+    tableColumns: [
+        columnHelper.accessor(row => `${row.scope}:${row.name}`, {
+            id: "did",
+        }),
+        columnHelper.accessor("did_type", {
+            id: "did_type",
+            header: info => {
+                return (
+                    // tidbit: filter column by clicking on the header
+                    <div
+                        onClick={(e) => {
+                            const nextRecord = {
+                                "undefined": "Dataset",
+                                "Dataset": "Container",
+                                "Container": undefined, // default value of tanstack is undefined
+                            }
+                            console.log(info.column.getFilterValue())
+                            const currentFilterValue = String(info.column.getFilterValue()) as keyof typeof nextRecord 
+                            info.column.setFilterValue(nextRecord[currentFilterValue ?? "null"])
+                        }}
+                    >
+                        <span>DID Type</span>
+                    </div>
+                )
+            }
+        })
+    ]
+};

--- a/src/component-library/components/StreamedTables/StreamedTable.stories.tsx
+++ b/src/component-library/components/StreamedTables/StreamedTable.stories.tsx
@@ -17,12 +17,12 @@ const columnHelper = createColumnHelper<DIDContents>()
 
 export const StreamedTable = Template.bind({});
 StreamedTable.args = {
-    tableData: {
+    tabledata: {
         data: Array.from({length: 100}, (_, i) => createRandomDIDContents()),
         fetchStatus: "idle",
         pageSize: 10,
     } as TableData<DIDContents>,
-    tableColumns: [
+    tablecolumns: [
         columnHelper.accessor(row => `${row.scope}:${row.name}`, {
             id: "did",
         }),

--- a/src/component-library/components/StreamedTables/StreamedTable.tsx
+++ b/src/component-library/components/StreamedTables/StreamedTable.tsx
@@ -57,7 +57,8 @@ export function StreamedTable<T>(props: StreamedTableProps<T>) {
                 <tr
                     className={twMerge(
                         "h-16 md:h-12",
-                        "bg-white dark:bg-gray-700"
+                        "bg-white dark:bg-gray-700",
+                        "relative"
                     )}
                 >
                     {table.getLeafHeaders().map(header => {
@@ -111,8 +112,6 @@ export function StreamedTable<T>(props: StreamedTableProps<T>) {
                     <td colSpan={table.getVisibleLeafColumns().length}>
                         <PaginationDiv
                             table={table}
-                            pageIndex={pageIndex}
-                            setPageIndex={setPageIndex}
                         />
                     </td>
                 </tr>

--- a/src/component-library/components/StreamedTables/StreamedTable.tsx
+++ b/src/component-library/components/StreamedTables/StreamedTable.tsx
@@ -1,0 +1,122 @@
+import { StyleMetaColumnDef, TableData } from "@/lib/infrastructure/data/view-model/streamedtables";
+import { ColumnDef, flexRender, getCoreRowModel, getFilteredRowModel, getPaginationRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import { FetchstatusIndicator } from "./FetchstatusIndicator";
+import { useEffect, useState } from "react";
+import { twMerge } from "tailwind-merge";
+import { PaginationDiv } from "./PaginationDiv";
+
+type StreamedTableProps<T> = JSX.IntrinsicElements["table"] & {
+    tableData: TableData<T>
+    tableColumns: any[] // todo type this
+    tableStyling?: Partial<{
+        visibility: Record<string, boolean>
+    }>
+}
+
+export function StreamedTable<T>(props: StreamedTableProps<T>) {
+    const { className, ...otherprops } = props
+
+    const table = useReactTable<T>({
+        data: props.tableData.data || [],
+        columns: props.tableColumns,
+        getCoreRowModel: getCoreRowModel(),
+        getPaginationRowModel: getPaginationRowModel(),
+        getFilteredRowModel: getFilteredRowModel(),
+        getSortedRowModel: getSortedRowModel(),
+        debugTable: true,
+        state: {
+            columnVisibility: props.tableStyling?.visibility,
+        }
+    })
+
+    // Pagination
+    const [pageIndex, setPageIndex] = useState(table.getState().pagination.pageIndex)
+    useEffect(() => {
+        setPageIndex(table.getState().pagination.pageIndex)
+    }, [table])
+    useEffect(() => {
+        table.setPageIndex(pageIndex)
+    }, [pageIndex, table])
+    useEffect(() => {
+        table.setPageSize(props.tableData.pageSize)
+    }, [props.tableData.pageSize, table])
+
+    return (
+        <table
+            className={twMerge(
+                props.tableData.fetchStatus === "fetching" ? "hover:cursor-wait" : "",
+                "bg-white dark:bg-gray-700",
+                "w-full",
+                "relative",
+                "table-fixed",
+                className
+            )}
+            {...otherprops}
+        >
+            <thead>
+                <tr
+                    className={twMerge(
+                        "h-16 md:h-12",
+                        "bg-white dark:bg-gray-700"
+                    )}
+                >
+                    {table.getLeafHeaders().map(header => {
+                        return (
+                            <th
+                                key={header.id}
+                                className={(header.column.columnDef as StyleMetaColumnDef<T>).meta?.style ?? ""}
+                            >
+                                {flexRender(header.column.columnDef.header, header.getContext())}
+                            </th>
+                        )
+                    })}
+                </tr>
+            </thead>
+            <div
+                className={twMerge(
+                    "absolute",
+                    "top-12 right-0 m-2",
+                    "pointer-events-none"
+                )}
+            >
+                <FetchstatusIndicator status={props.tableData.fetchStatus} />
+            </div>
+            <tbody>
+                {table.getRowModel().rows.map(row => {
+                    return (
+                        <tr
+                            key={row.id}
+                            className={twMerge(
+                                "hover:cursor-normal h-16 md:h-8",
+                                "bg-white odd:bg-stone-100",
+                                "dark:bg-gray-700 dark:odd:bg-gray-800",
+                                "hover:bg-gray-200 dark:hover:bg-gray-900",
+                            )}
+                        >
+                            {row.getVisibleCells().map(cell => {
+                                return (
+                                    <td
+                                        key={cell.id}
+                                    >
+                                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                    </td>
+                                )
+                            })}
+                        </tr>
+                    )
+                })}
+            </tbody>
+            <tfoot>
+                <tr>
+                    <td colSpan={table.getVisibleLeafColumns().length}>
+                        <PaginationDiv
+                            table={table}
+                            pageIndex={pageIndex}
+                            setPageIndex={setPageIndex}
+                        />
+                    </td>
+                </tr>
+            </tfoot>
+        </table>
+    )
+}

--- a/src/component-library/components/StreamedTables/StreamedTable.tsx
+++ b/src/component-library/components/StreamedTables/StreamedTable.tsx
@@ -6,9 +6,9 @@ import { twMerge } from "tailwind-merge";
 import { PaginationDiv } from "./PaginationDiv";
 
 type StreamedTableProps<T> = JSX.IntrinsicElements["table"] & {
-    tableData: TableData<T>
-    tableColumns: any[] // todo type this
-    tableStyling?: Partial<{
+    tabledata: TableData<T>
+    tablecolumns: any[] // todo type this
+    tablestyling?: Partial<{
         visibility: Record<string, boolean>
     }>
 }
@@ -17,15 +17,15 @@ export function StreamedTable<T>(props: StreamedTableProps<T>) {
     const { className, ...otherprops } = props
 
     const table = useReactTable<T>({
-        data: props.tableData.data || [],
-        columns: props.tableColumns,
+        data: props.tabledata.data || [],
+        columns: props.tablecolumns,
         getCoreRowModel: getCoreRowModel(),
         getPaginationRowModel: getPaginationRowModel(),
         getFilteredRowModel: getFilteredRowModel(),
         getSortedRowModel: getSortedRowModel(),
         debugTable: true,
         state: {
-            columnVisibility: props.tableStyling?.visibility,
+            columnVisibility: props.tablestyling?.visibility,
         }
     })
 
@@ -38,13 +38,13 @@ export function StreamedTable<T>(props: StreamedTableProps<T>) {
         table.setPageIndex(pageIndex)
     }, [pageIndex, table])
     useEffect(() => {
-        table.setPageSize(props.tableData.pageSize)
-    }, [props.tableData.pageSize, table])
+        table.setPageSize(props.tabledata.pageSize)
+    }, [props.tabledata.pageSize, table])
 
     return (
         <table
             className={twMerge(
-                props.tableData.fetchStatus === "fetching" ? "hover:cursor-wait" : "",
+                props.tabledata.fetchStatus === "fetching" ? "hover:cursor-wait" : "",
                 "bg-white dark:bg-gray-700",
                 "w-full",
                 "relative",
@@ -80,7 +80,7 @@ export function StreamedTable<T>(props: StreamedTableProps<T>) {
                     "pointer-events-none"
                 )}
             >
-                <FetchstatusIndicator status={props.tableData.fetchStatus} />
+                <FetchstatusIndicator status={props.tabledata.fetchStatus} />
             </div>
             <tbody>
                 {table.getRowModel().rows.map(row => {

--- a/src/component-library/components/StreamedTables/TableExternalLink.stories.tsx
+++ b/src/component-library/components/StreamedTables/TableExternalLink.stories.tsx
@@ -1,0 +1,12 @@
+import { StoryFn, Meta } from "@storybook/react";
+import { TableExternalLink as T } from "./TableExternalLink";
+
+export default {
+    title: 'Components/StreamedTables',
+    component: T,
+} as Meta<typeof T>;
+
+const Template: StoryFn<typeof T> = (args) => <T {...args} />;
+
+export const TableExternalLink = Template.bind({});
+TableExternalLink.args = {};

--- a/src/component-library/components/StreamedTables/TableExternalLink.tsx
+++ b/src/component-library/components/StreamedTables/TableExternalLink.tsx
@@ -1,0 +1,27 @@
+import { twMerge } from "tailwind-merge";
+import { HiExternalLink } from "react-icons/hi";
+
+export const TableExternalLink: React.FC<JSX.IntrinsicElements["a"] & { label: string }> = (
+    {
+        label,
+        ...props
+    }
+) => {
+    const { className, children, ...otherprops } = props;
+    return (
+
+        <a
+            className={twMerge(
+                "px-1 rounded",
+                "flex flex-row items-center",
+                "bg-blue-500 hover:bg-blue-600 text-white",
+                className ?? "",
+            )}
+            {...otherprops}
+        >
+            <HiExternalLink />
+            <span>{label}</span>
+            {children}
+        </a>
+    );
+};

--- a/src/component-library/components/StreamedTables/TableFilterDiscrete.stories.tsx
+++ b/src/component-library/components/StreamedTables/TableFilterDiscrete.stories.tsx
@@ -1,0 +1,28 @@
+import { StoryFn, Meta } from "@storybook/react";
+import { Column } from "@tanstack/react-table";
+import { TableFilterDiscrete as T } from "./TableFilterDiscrete";
+
+export default {
+    title: 'Components/StreamedTables',
+    component: T,
+} as Meta<typeof T>;
+
+const Template: StoryFn<typeof T<string>> = (args) => <T<string> {...args} />; // yes this is how you use JSX.Element generics
+
+export const TableFilterDiscrete = Template.bind({});
+TableFilterDiscrete.args = {
+    name: "Label",
+    keys: ["a", "b", "c"],
+    column: {
+        setFilterValue: (filter: string | undefined) => {
+            console.log(filter)
+        }
+    } as Column<unknown, string>,
+    renderFunc: (key: string | undefined) => {
+        return (
+            <span>
+                {key ?? "HOHOHOHO UNDEFINED"}
+            </span>
+        )
+    }
+};

--- a/src/component-library/components/StreamedTables/TableFilterDiscrete.tsx
+++ b/src/component-library/components/StreamedTables/TableFilterDiscrete.tsx
@@ -1,0 +1,57 @@
+import { twMerge } from "tailwind-merge";
+import { H3 } from "../Text/Headings/H3";
+import { useState, useEffect } from "react";
+import { Column } from "@tanstack/react-table";
+
+type TableFilterDiscrete<T> = JSX.IntrinsicElements["div"] & {
+    name: string,
+    keys: T[],
+    renderFunc: (key: T | undefined) => JSX.Element,
+    column: Column<any, T>, // to be a tanstack column
+}
+
+export function TableFilterDiscrete<T> (
+    props: TableFilterDiscrete<T>
+): JSX.Element
+{
+    // split up props
+    const { name, keys, renderFunc, column, ...otherprops } = props
+    const { className, ...otherdivprops } = otherprops
+    
+    /* create a map of next values
+    supposed to be cyclic "undefined" (string) -> keys (T) -> undefined
+    using undefined as a key is not allowed, so we use "undefined" (string) instead
+    also works well with tanstack: undefined is the default value
+    */
+    type ExtendedT = string | T | undefined
+    const extendedkeys = (["undefined"] as ExtendedT[]).concat(keys).concat([undefined])
+    const nextMap = new Map<ExtendedT, ExtendedT>()
+    extendedkeys.slice(0, -1).map((key, i) => {
+        nextMap.set(key, extendedkeys[(i + 1) % extendedkeys.length])
+    })
+
+    // handle state internally
+    const [filter, setFilter] = useState<T | undefined>(undefined)
+    // connect to table
+    useEffect(() => {
+        column.setFilterValue(filter)
+    }, [filter, column])
+    return (
+        <div
+            className={twMerge(
+                "flex flex-row justify-between",
+                "h-6 sm:pr-1",
+                "items-center",
+                "select-none cursor-pointer",
+                className ?? "",
+            )}
+            onClick={e => {
+                setFilter(nextMap.get(filter ?? "undefined") as T | undefined)
+            }}
+            {...otherdivprops}
+        >
+            <H3 className="hidden md:inline">{name}</H3>
+            {renderFunc(filter)}
+        </div>
+    );
+};

--- a/src/component-library/components/StreamedTables/TableFilterString.stories.tsx
+++ b/src/component-library/components/StreamedTables/TableFilterString.stories.tsx
@@ -1,0 +1,20 @@
+import { StoryFn, Meta } from "@storybook/react";
+import { Column } from "@tanstack/react-table";
+import { TableFilterString as T } from "./TableFilterString";
+
+export default {
+    title: 'Components/StreamedTables',
+    component: T,
+} as Meta<typeof T>;
+
+const Template: StoryFn<typeof T> = (args) => <T {...args} />;
+
+export const TableFilterString = Template.bind({});
+TableFilterString.args = {
+    column: {
+        getFilterValue: () => "",
+        setFilterValue: (updater: any) => {},
+        id: "test",
+    } as Column<any, string>,
+    name: "Test"
+};

--- a/src/component-library/components/StreamedTables/TableFilterString.tsx
+++ b/src/component-library/components/StreamedTables/TableFilterString.tsx
@@ -1,0 +1,112 @@
+import { twMerge } from "tailwind-merge";
+import { H3 } from "../Text/Headings/H3";
+import { Column, Table } from "@tanstack/react-table";
+import { useState, useEffect } from "react";
+import { HiCheck, HiSearch } from "react-icons/hi";
+
+
+type TableFilterString = JSX.IntrinsicElements["div"] & {
+    column: Column<any, string>,
+    name: string,
+    placeholder?: string,
+}
+
+const Filter = (props: JSX.IntrinsicElements["input"] & { column: Column<any, string> }) => {
+    const { column, className, ...otherprops } = props
+    return (
+        <input
+            type="text"
+            value={column.getFilterValue() as string ?? ""}
+            onChange={(e) => column.setFilterValue(e.target.value)}
+            className={twMerge(
+                "w-full border dark:border-gray-400 rounded-sm px-2 pt-2 dark:bg-gray-800 dark:text-white h-8",
+                className ?? "",
+            )}
+            {...otherprops}
+        />
+    )
+}
+
+export function TableFilterString(
+    props: TableFilterString
+): JSX.Element {
+    const { column, name, placeholder, ...otherprops } = props
+    const { className, ...otherdivprops } = otherprops
+
+    const [windowSize, setWindowSize] = useState([
+        1920, 1080
+    ]);
+
+    useEffect(() => {
+        setWindowSize([window.innerWidth, window.innerHeight])
+
+        const handleWindowResize = () => {
+            setWindowSize([window.innerWidth, window.innerHeight]);
+        };
+
+        window.addEventListener('resize', handleWindowResize);
+
+        return () => {
+            window.removeEventListener('resize', handleWindowResize);
+        };
+    }, []);
+
+    const [smallScreenNameFiltering, setSmallScreenNameFiltering] = useState(false)
+    useEffect(() => {
+        if (windowSize[0] > 640) {
+            setSmallScreenNameFiltering(false)
+        }
+    }, [windowSize])
+
+    /*
+    `smallScreenNameFiltering` is a boolean that controls whether the filter is
+    shown on small screens.
+    It is set to false on large screens, and can be toggled on small screens.
+    */
+
+    if (!smallScreenNameFiltering) {
+        return (
+            <div
+                className={twMerge(
+                    "flex flex-row justify-between items-baseline space-x-8",
+                    "pr-2",
+                    className ?? "",
+                )}
+            >
+                <span className="shrink-0">
+                    <H3>{name}</H3>
+                </span>
+                <Filter
+                    column={column}
+                    placeholder={placeholder ?? `Filter ${name}`}
+                    className="hidden sm:block"
+                />
+
+                <button
+                    onClick={(e) => { setSmallScreenNameFiltering(!smallScreenNameFiltering) }}
+                    className="sm:hidden pr-4"
+                >
+                    <HiSearch className="text-xl text-gray-500 dark:text-gray-200" />
+                </button>
+            </div>
+        )
+    } else {
+        return (
+            <div
+                className={twMerge(
+                    "flex",
+                    "bg-white",
+                    "absolute inset-0",
+                    "p-2 flex-row justify-between space-x-2 items-center"
+                )}
+            >
+                <Filter column={column} placeholder={placeholder ?? `Filter ${name}`} />
+                <button
+                    onClick={(e) => { setSmallScreenNameFiltering(!smallScreenNameFiltering) }}
+                >
+                    <HiCheck className="text-xl text-gray-500 dark:text-gray-200" />
+                </button>
+            </div>
+        )
+    }
+}

--- a/src/component-library/components/Tabs/Tabs.tsx
+++ b/src/component-library/components/Tabs/Tabs.tsx
@@ -1,56 +1,117 @@
 import { useEffect, useState } from "react"
 import { twMerge } from "tailwind-merge"
 
-export const Tabs = (
-    props: {
-        tabs: string[],
-        active: number,
-        handleClick: (event: any) => void,
-        dataTestid?: string,
+export const Tabs: React.FC<JSX.IntrinsicElements["ul"] & {
+    tabs: string[],
+    _ariaControls?: string[],
+    active: number,
+    updateActive: (active: number) => void,
+}> = (
+    {
+        tabs,
+        active,
+        updateActive,
+        ...props
     }
 ) => {
-    const [activestate, setActivestate] = useState<string>(props.active.toString())
-    useEffect(() => {
-        setActivestate(props.active.toString())
-    }, [props.active])
-    var onClick = (event: any) => {
-        setActivestate(event.target.dataset.id)
-        props.handleClick(event)
+        const { className, ...otherprops } = props
+
+        /*
+        ARIA for tabs:
+          - `Tab` places focus on *active* tab. Tabbing again will move focus
+          into the tabpanel. It is *not* possible to cycle through the tabs with
+          the tab key.
+          - `left arrow` and `right arrow` keys move focus between tabs.
+          - we use buttons with role="tab" in a div with role="tablist" to implement this.
+        Refer to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role#example
+        */
+        const [activestate, setActivestate] = useState<number>(active) // handle state internally
+        useEffect(() => {
+            setActivestate(active)
+        }, [active]) // update internal state when external factors (props) change
+        useEffect(() => {
+            document.getElementById(`tab-${activestate.toString()}`)?.focus()
+        }, [activestate]) // focus on tab when internal state changes
+        const changeFunc = (id: number) => {
+            var newId = id
+            if (id < 0) {
+                newId = tabs.length - 1
+            }
+            if (id >= tabs.length) {
+                newId = 0
+            }
+            setActivestate(newId)
+            updateActive(newId)
+        } // update internal state and external state when tab is clicked
+        const changeFuncEvent = (event: any) => {
+            changeFunc(Number(event.target.dataset.id))
+        } // wrap for event handler
+        return (
+            <div
+                className="flex flex-col sm:flex-row list-none font-bold"
+                role="tablist"
+            >
+                {tabs.map((element, index) => {
+                    return index === Number(activestate) ? (
+                        <button
+                            onClick={changeFuncEvent}
+                            data-id={index.toString()}
+                            className={twMerge(
+                                "flex-1 p-4 hover:cursor-pointer",
+                                "border-b-4 border-blue-500",
+                                "text-blue-500 hover:bg-gray-100 dark:hover:bg-transparent"
+                            )}
+                            key={index.toString()} // required by react
+                            role="tab"
+                            aria-selected="true"
+                            tabIndex={0}
+                            aria-controls={props._ariaControls ? props._ariaControls[index] : ""}
+                            id={`tab-${index.toString()}`} // indexed as tab-0, tab-1, etc. Refer to this in the tabpanels.
+                            onKeyDown={(event) => {
+                                if (event.key === "ArrowLeft") {
+                                    changeFunc(index - 1)
+                                }
+                                if (event.key === "ArrowRight") {
+                                    changeFunc(index + 1)
+                                }
+                            }}
+
+                        >
+                            <span
+                            >
+                                {element}
+                            </span>
+                        </button>
+                    ) : (
+                        <button
+                            onClick={changeFuncEvent}
+                            data-id={index.toString()}
+                            className={twMerge(
+                                "flex-1 p-4 hover:cursor-pointer",
+                                "border-b-4 border-gray-300 dark:border-gray-100",
+                                "text-gray-600 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-transparent"
+                            )}
+                            key={index.toString()}
+                            role="tab"
+                            aria-selected="false"
+                            tabIndex={-1}
+                            aria-controls={props._ariaControls ? props._ariaControls[index] : ""}
+                            onKeyDown={(event) => {
+                                if (event.key === "ArrowLeft") {
+                                    changeFunc(index - 1)
+                                }
+                                if (event.key === "ArrowRight") {
+                                    changeFunc(index + 1)
+                                }
+                            }}
+                        >
+                            <span
+                            >
+                                {element}
+                            </span>
+                        </button>
+                    )
+                })}
+            </div>
+        )
     }
-    return (
-        <ul
-            className="flex flex-col sm:flex-row list-none font-bold"
-            data-testid={props.dataTestid ?? "tabs"}
-        >
-            {props.tabs.map((element, index) => {
-                return index === Number(activestate) ? (
-                    <li
-                        onClick={onClick}
-                        className="flex-1 text-center"
-                        key={index.toString()}
-                    >
-                        <a
-                            data-id={index.toString()}
-                            className="block border-b-4 text-blue-500 border-blue-500 p-4 hover:bg-gray-100 dark:hover:bg-transparent hover:cursor-pointer"
-                        >
-                            {element}
-                        </a>
-                    </li>
-                ) : (
-                    <li
-                        onClick={onClick}
-                        className="flex-1 text-center"
-                        key={index.toString()}
-                    >
-                        <a
-                            data-id={index.toString()}
-                            className="block border-b-4 text-gray-600 dark:text-gray-100 border-gray-300 dark:border-gray-100 p-4 hover:bg-gray-100 dark:hover:bg-transparent hover:cursor-pointer"
-                        >
-                            {element}
-                        </a>
-                    </li>
-                )
-            })}
-        </ul>
-    )
-}

--- a/src/component-library/components/Tabs/Tabs.tsx
+++ b/src/component-library/components/Tabs/Tabs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react"
+import { twMerge } from "tailwind-merge"
 
 export const Tabs = (
     props: {

--- a/src/component-library/components/Tags/LockStateTag.stories.tsx
+++ b/src/component-library/components/Tags/LockStateTag.stories.tsx
@@ -1,0 +1,16 @@
+import { LockState } from "@/lib/core/entity/rucio";
+import { StoryFn, Meta } from "@storybook/react";
+import { LockStateTag as L } from "./LockStateTag";
+
+export default {
+    title: 'Components/Tags',
+    component: L,
+} as Meta<typeof L>;
+
+const Template: StoryFn<typeof L> = (args) => <L {...args} />;
+
+export const LockStateTag = Template.bind({});
+LockStateTag.args = {
+    lockState: LockState.OK,
+    tiny: false,
+};

--- a/src/component-library/components/Tags/LockStateTag.tsx
+++ b/src/component-library/components/Tags/LockStateTag.tsx
@@ -1,0 +1,40 @@
+import { LockState } from "@/lib/core/entity/rucio";
+import { twMerge } from "tailwind-merge";
+
+export const LockStateTag: (
+    React.FC<JSX.IntrinsicElements["span"] & { lockState: LockState; tiny?: boolean }>
+) = (
+    {
+        lockState = "OK",
+        tiny = false,
+        ...props
+
+    }
+) => {
+        const { className, ...otherprops } = props
+        const stateString: Record<string, string> = {
+            "R": "Replicating",
+            "O": "OK",
+            "S": "Stuck",
+        }
+
+        return (
+            <span
+                className={twMerge(
+                    lockState === LockState.OK ? "bg-green-300 border-green-700 dark:bg-green-700 dark:border-green-200" : (
+                        lockState === LockState.Stuck ? "bg-amber-300 border-amber-700 dark:bg-amber-700 dark:border-amber-200" : (
+                            lockState === LockState.Replicating ? "bg-red-400 border-red-700 dark:bg-red-700 dark:border-red-200" : 
+                                ""
+                        )
+                    ),
+                    "text-black dark:text-white font-sans",
+                    !tiny ? "w-28 rounded border text-center" : "w-6 h-6 rounded-full border text-center select-none shrink-0",
+                    "flex justify-center items-center",
+                    className ?? "",
+                )}
+                {...otherprops}
+            >
+                {!tiny ? stateString[lockState] : lockState}
+            </span>
+        );
+    };

--- a/src/component-library/components/Tags/RuleNotificationTag.stories.tsx
+++ b/src/component-library/components/Tags/RuleNotificationTag.stories.tsx
@@ -1,0 +1,16 @@
+import { RuleNotification } from "@/lib/core/entity/rucio";
+import { StoryFn, Meta } from "@storybook/react";
+import { RuleNotificationTag as R } from "./RuleNotificationTag";
+
+export default {
+    title: 'Components/Tags',
+    component: R,
+} as Meta<typeof R>;
+
+const Template: StoryFn<typeof R> = (args) => <R {...args} />;
+
+export const RuleNotificationTag = Template.bind({});
+RuleNotificationTag.args = {
+    notificationState: RuleNotification.Yes,
+    tiny: false,
+};

--- a/src/component-library/components/Tags/RuleNotificationTag.tsx
+++ b/src/component-library/components/Tags/RuleNotificationTag.tsx
@@ -1,6 +1,6 @@
 import { RuleNotification } from "@/lib/core/entity/rucio";
 import { twMerge } from "tailwind-merge";
-import { HiBell } from "react-icons/hi";
+import { HiBellAlert, HiBellSlash, HiBell } from "react-icons/hi2"; // hi does not have the bell decorations
 
 export const RuleNotificationTag: (
     React.FC<JSX.IntrinsicElements["span"] & { notificationState: RuleNotification; tiny?: boolean }>
@@ -21,9 +21,9 @@ export const RuleNotificationTag: (
         return (
             <span
                 className={twMerge(
-                    notificationState === RuleNotification.No? "bg-gray-300 text-gray-800 dark:bg-gray-700 dark:text-gray-200" : (
-                        notificationState === RuleNotification.Close? "bg-gray-300 text-gray-800 dark:bg-gray-700 dark:text-gray-200" : (
-                            notificationState === RuleNotification.Yes? "bg-green-300 text-green-800 dark:bg-green-700 dark:text-green-200" : (
+                    notificationState === RuleNotification.No ? "bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-gray-200" : (
+                        notificationState === RuleNotification.Close ? "bg-gray-300 text-gray-800 dark:bg-gray-600 dark:text-gray-200" : (
+                            notificationState === RuleNotification.Yes ? "bg-green-300 text-green-800 dark:bg-green-700 dark:text-green-200" : (
                                 notificationState === RuleNotification.Progress ? "bg-blue-300 text-blue-800 dark:bg-blue-700 dark:text-blue-200" :
                                     ""
                             )
@@ -36,7 +36,13 @@ export const RuleNotificationTag: (
                 )}
                 {...otherprops}
             >
-                <HiBell className={tiny ? "hidden" : "mr-1"}/>
+                {
+                    notificationState === RuleNotification.No ? <HiBellSlash className={tiny ? "hidden" : "mr-1"} /> : (
+                        notificationState === RuleNotification.Progress ? <HiBellAlert className={tiny ? "hidden" : "mr-1"} /> : (
+                            <HiBell className={tiny ? "hidden" : "mr-1"} />
+                        )
+                    )
+                }
                 {!tiny ? stateString[notificationState] : notificationState}
             </span>
         );

--- a/src/component-library/components/Tags/RuleNotificationTag.tsx
+++ b/src/component-library/components/Tags/RuleNotificationTag.tsx
@@ -1,0 +1,43 @@
+import { RuleNotification } from "@/lib/core/entity/rucio";
+import { twMerge } from "tailwind-merge";
+import { HiBell } from "react-icons/hi";
+
+export const RuleNotificationTag: (
+    React.FC<JSX.IntrinsicElements["span"] & { notificationState: RuleNotification; tiny?: boolean }>
+) = (
+    {
+        notificationState = RuleNotification.Yes,
+        tiny = false,
+        ...props
+    }
+) => {
+        const { className, ...otherprops } = props
+        const stateString: Record<string, string> = {
+            "Y": "Yes",
+            "N": "No",
+            "C": "Close",
+            "P": "Progress",
+        }
+        return (
+            <span
+                className={twMerge(
+                    notificationState === RuleNotification.No? "bg-gray-300 text-gray-800 dark:bg-gray-700 dark:text-gray-200" : (
+                        notificationState === RuleNotification.Close? "bg-gray-300 text-gray-800 dark:bg-gray-700 dark:text-gray-200" : (
+                            notificationState === RuleNotification.Yes? "bg-green-300 text-green-800 dark:bg-green-700 dark:text-green-200" : (
+                                notificationState === RuleNotification.Progress ? "bg-blue-300 text-blue-800 dark:bg-blue-700 dark:text-blue-200" :
+                                    ""
+                            )
+                        )
+                    ),
+                    "font-sans",
+                    !tiny ? "w-28 rounded" : "w-6 h-6 rounded-full text-center select-none shrink-0",
+                    "flex flex-row justify-center items-center",
+                    className ?? "",
+                )}
+                {...otherprops}
+            >
+                <HiBell className={tiny ? "hidden" : "mr-1"}/>
+                {!tiny ? stateString[notificationState] : notificationState}
+            </span>
+        );
+    };

--- a/src/component-library/components/Text/Content/P.tsx
+++ b/src/component-library/components/Text/Content/P.tsx
@@ -1,21 +1,22 @@
 import {twMerge} from 'tailwind-merge'
 
-export const P = (
-    props: {
-        children: any,
-        mono?: boolean,
-        className?: string
+export const P: React.FC<JSX.IntrinsicElements["p"] & {mono?: boolean}> = (
+    {
+        mono = false,
+        ...props
     }
 ) => {
-
-    const classes = twMerge(`
-        dark:text-white
-        ${props.mono ? "font-mono" : ""}
-        ${props.className ?? ""}
-    `)
+    const {className, ...otherprops} = props
 
     return (
-        <p className={classes}>
+        <p
+            className={twMerge(
+                "dark:text-white",
+                mono ? "font-mono" : "",
+                className ?? "",
+            )}
+            {...otherprops}
+        >
             {props.children}
         </p>
     )

--- a/src/component-library/components/Text/Headings/H3.tsx
+++ b/src/component-library/components/Text/Headings/H3.tsx
@@ -1,11 +1,17 @@
-export const H3 = (
-    props: {
-        children: any,
-    }
-) => {
+import { twMerge } from "tailwind-merge"
 
+export const H3: React.FC<JSX.IntrinsicElements["h3"]> = (
+    {...props}
+) => {
+    const { className, ...otherprops } = props
     return (
-        <h3 className="text-xl leading-none dark:text-white">
+        <h3
+            className={twMerge(
+                "text-xl leading-none dark:text-white",
+                className ?? "",
+            )}
+            {...otherprops}
+        >
             {props.children}
         </h3>
     )

--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -1258,11 +1258,6 @@ video {
   border-top-right-radius: 0.25rem;
 }
 
-.rounded-t-md {
-  border-top-left-radius: 0.375rem;
-  border-top-right-radius: 0.375rem;
-}
-
 .border {
   border-width: 1px;
 }
@@ -2484,6 +2479,11 @@ video {
     color: rgb(252 211 77 / var(--tw-text-opacity));
   }
 
+  .dark\:text-blue-200 {
+    --tw-text-opacity: 1;
+    color: rgb(191 219 254 / var(--tw-text-opacity));
+  }
+
   .dark\:text-blue-300 {
     --tw-text-opacity: 1;
     color: rgb(147 197 253 / var(--tw-text-opacity));
@@ -2512,6 +2512,11 @@ video {
   .dark\:text-gray-400 {
     --tw-text-opacity: 1;
     color: rgb(156 163 175 / var(--tw-text-opacity));
+  }
+
+  .dark\:text-green-200 {
+    --tw-text-opacity: 1;
+    color: rgb(187 247 208 / var(--tw-text-opacity));
   }
 
   .dark\:text-green-300 {

--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -1258,6 +1258,11 @@ video {
   border-top-right-radius: 0.25rem;
 }
 
+.rounded-t-md {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+}
+
 .border {
   border-width: 1px;
 }

--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -626,6 +626,10 @@ video {
   top: 2.5rem;
 }
 
+.top-12 {
+  top: 3rem;
+}
+
 .top-16 {
   top: 4rem;
 }
@@ -991,10 +995,6 @@ video {
 
 .grow-0 {
   flex-grow: 0;
-}
-
-.table-auto {
-  table-layout: auto;
 }
 
 .table-fixed {
@@ -2797,6 +2797,10 @@ video {
     padding-left: 0.5rem;
   }
 
+  .sm\:pr-1 {
+    padding-right: 0.25rem;
+  }
+
   .sm\:ring-8 {
     --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
     --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(8px + var(--tw-ring-offset-width)) var(--tw-ring-color);
@@ -2855,6 +2859,10 @@ video {
 
   .md\:w-28 {
     width: 7rem;
+  }
+
+  .md\:w-32 {
+    width: 8rem;
   }
 
   .md\:w-40 {

--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -993,6 +993,10 @@ video {
   flex-grow: 0;
 }
 
+.table-auto {
+  table-layout: auto;
+}
+
 .table-fixed {
   table-layout: fixed;
 }

--- a/src/lib/core/entity/rucio.ts
+++ b/src/lib/core/entity/rucio.ts
@@ -53,12 +53,12 @@ export type DIDMeta = {
 // copied from deployed rucio UI
 export type RuleMeta = {
     account: string
-    activity: string // ?
+    activity: string // VO-specific enums, just show string here.
     copies: number
     created_at: Date
     did_type: DIDType
     expires_at: Date
-    grouping: DIDType // ? but is it extended
+    grouping: DIDType
     id: string
     ignore_account_limit: boolean
     ignore_availability: boolean
@@ -67,13 +67,13 @@ export type RuleMeta = {
     locks_replicating_cnt: number
     locks_stuck_cnt: number
     name: string
-    notification: string // ? or bool
+    notification: RuleNotification
     priority: number
     purge_replicas: boolean
     rse_expression: string
     scope: string
     split_container: boolean
-    state: RuleState // ?
+    state: RuleState
     updated_at: Date
 }
 
@@ -82,6 +82,14 @@ export enum LockState {
     Replicating = "R",
     OK = "O",
     Stuck = "S",
+}
+
+// rucio.db.sqla.constants::RuleNotification
+export enum RuleNotification {
+    Yes = "Y", // notify when the rules state becomes OK
+    No = "N", // no notification
+    Close = "C", // notify when the rules state becomes OK *and* the DID is closed -> least verbose except for "no"
+    Progress = "P", // notify for each chang
 }
 
 export type DIDType = "Dataset" | "Container" | "Collection" | "File";

--- a/src/lib/core/entity/rucio.ts
+++ b/src/lib/core/entity/rucio.ts
@@ -50,6 +50,40 @@ export type DIDMeta = {
     filesize: number | null
 }
 
+// copied from deployed rucio UI
+export type RuleMeta = {
+    account: string
+    activity: string // ?
+    copies: number
+    created_at: Date
+    did_type: DIDType
+    expires_at: Date
+    grouping: DIDType // ? but is it extended
+    id: string
+    ignore_account_limit: boolean
+    ignore_availability: boolean
+    locked: boolean
+    locks_ok_cnt: number
+    locks_replicating_cnt: number
+    locks_stuck_cnt: number
+    name: string
+    notification: string // ? or bool
+    priority: number
+    purge_replicas: boolean
+    rse_expression: string
+    scope: string
+    split_container: boolean
+    state: RuleState // ?
+    updated_at: Date
+}
+
+// rucio.db.sqla.constants::LockState
+export enum LockState {
+    Replicating = "R",
+    OK = "O",
+    Stuck = "S",
+}
+
 export type DIDType = "Dataset" | "Container" | "Collection" | "File";
 
 export type RSE = {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,17 +1,19 @@
 module.exports = {
-    content: ["./src/**/*.{html,js,tsx,ts}"],
+    content: {
+        files: ["./src/**/*.{html,js,tsx,ts}"],
+    },
     theme: {
         extend: {
             keyframes: {
                 floatout: {
                     "0%": { opacity: "1", left: "0px", },
-                    "80%": { opacity: "1", left: "0px",},
+                    "80%": { opacity: "1", left: "0px", },
                     "100%": { opacity: "0", left: "100px", }
                 },
                 fadeout: {
-                    "0%": { opacity: "1"},
-                    "80%": { opacity: "1"},
-                    "100%": { opacity: "0"}
+                    "0%": { opacity: "1" },
+                    "80%": { opacity: "1" },
+                    "100%": { opacity: "0" }
                 },
             },
             animation: {

--- a/test/component/ListDID.test.tsx
+++ b/test/component/ListDID.test.tsx
@@ -51,6 +51,14 @@ describe("ListDID Story Test", () => {
         expect(lastPageButton).toBeDisabled()
     })
     it("Checks render with data and user input", async () => {
+        /*
+            PROBLEM:
+            we make use of `aria-label` to identify the table rows, but the
+            `aria-label` is only for *interactive* elements so we can't use it
+            on the table rows, which are not interactive
+            SOLUTION:
+            remove `aria-label` from the table rows, grab table rows differently.
+        */
         const mockDIDMeta = {
             "name": "dataset-YSytZjXJMdiCsSiiUwXx",
             "scope": "Lawrence.Myers",

--- a/test/component/PageRule.test.tsx
+++ b/test/component/PageRule.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, act, screen, cleanup, fireEvent, getByRole } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PageRule as PageRuleStory } from "@/component-library/components/Pages/PageRule/PageRule";
+import { createRuleMeta } from "test/fixtures/table-fixtures";
+var format = require("date-format")
+
+const ruleMeta = createRuleMeta()
+
+describe("PageRule Story Test", () => {
+    it("Check Subpage Movement", async () => {
+        await act(async () => render(
+            <PageRuleStory
+                ruleMeta={ruleMeta}
+                ruleLocks={{
+                    data: [],
+                    fetchStatus: "idle",
+                    pageSize: 10,
+                }}
+            />
+        ))
+        const user = userEvent.setup()
+        const selectedTabExpect = () => expect(screen.getByRole("tab", { selected: true }))
+        // check if the metadata tab is active
+        selectedTabExpect().toHaveTextContent("Metadata")
+        // assert metadata is visible
+        expect(screen.queryByRole("tabpanel", { name: "Metadata" })).toBeVisible()
+        // click on locks tab
+        await user.click(screen.getByRole("tab", { name: "Locks"}))
+        selectedTabExpect().toHaveTextContent("Locks")
+        expect(screen.queryByRole("tabpanel", { name: "Locks" })).toBeVisible()
+
+        // assert header is properly done
+        expect(
+            screen.getByRole("heading", { name: /Rule Page for/})
+        ).toHaveTextContent(
+            `${ruleMeta.scope}:${ruleMeta.name}`
+        )
+        // click on header
+        await user.click(screen.getByRole("heading", { name: /Rule Page for/}))
+        selectedTabExpect().not.toHaveFocus()
+        // tab to focus the `locks` tab
+        await user.tab()
+        selectedTabExpect().toHaveFocus()
+        // arrow right to focus the `metadata` tab (test cycling!)
+        await user.keyboard("{arrowright}")
+        selectedTabExpect().toHaveTextContent("Metadata")
+        // arrow right to focus `locks`
+        await user.keyboard("{arrowright}")
+        selectedTabExpect().toHaveTextContent("Locks")
+        // tab again to focus `filter DID` input
+        await user.tab()
+        expect(screen.getByPlaceholderText(/Filter DID/)).toHaveFocus()
+        // NB: we cant test further tabbing, because the testing library doesnt
+        // support responsive design: this means that the next tab will lead to
+        // the `Magnifying Glass` button which would be hidden otherwise.
+
+        // back to `locks` tab
+        await user.tab({shift: true})
+        // arrow left to focus the `metadata` tab
+        await user.keyboard("{arrowleft}")
+        selectedTabExpect().toHaveTextContent("Metadata")
+    })
+})

--- a/test/fixtures/table-fixtures.ts
+++ b/test/fixtures/table-fixtures.ts
@@ -1,0 +1,37 @@
+import { faker } from '@faker-js/faker'
+import { DIDContents } from '@/lib/infrastructure/data/view-model/page-did'
+import { RulePageLockEntry } from '@/component-library/components/Pages/PageRule/PageRule'
+import { LockState } from '@/lib/core/entity/rucio'
+
+function createRandomScope(): string {
+    return `user.${faker.person.firstName()}${faker.person.lastName()}`
+}
+
+function createRandomRSE(): string {
+    return (
+        "RSE-" +
+        faker.location.country().toUpperCase().replace(/\s/g, "-").replace(/[^a-zA-Z\d\s]/g, "") +
+        "-" +
+        faker.number.int({ max: 100 })
+    )
+}
+
+export function createRandomDIDContents(): DIDContents {
+    const did_type = faker.helpers.arrayElement(['container', 'dataset', 'file'])
+    return {
+        scope: createRandomScope(),
+        name: `${did_type}-${faker.string.alphanumeric(10)}`,
+        did_type: did_type.replace(/^\w/, (c) => c.toUpperCase()),
+    }
+}
+
+export function createRandomRulePageLockEntry(): RulePageLockEntry {
+    return {
+        scope: createRandomScope(),
+        name: faker.string.alphanumeric(10),
+        rse: createRandomRSE(),
+        state: faker.helpers.arrayElement(['R', 'O', 'S']) as LockState,
+        ddm_link: faker.internet.url(),
+        fts_link: faker.internet.url(),
+    }
+}

--- a/test/fixtures/table-fixtures.ts
+++ b/test/fixtures/table-fixtures.ts
@@ -1,10 +1,15 @@
 import { faker } from '@faker-js/faker'
 import { DIDContents } from '@/lib/infrastructure/data/view-model/page-did'
 import { RulePageLockEntry } from '@/component-library/components/Pages/PageRule/PageRule'
-import { LockState } from '@/lib/core/entity/rucio'
+import { LockState, RuleMeta, RuleNotification, RuleState } from '@/lib/core/entity/rucio'
+import { DIDType } from '@/lib/core/data/rucio-dto'
 
 function createRandomScope(): string {
     return `user.${faker.person.firstName()}${faker.person.lastName()}`
+}
+
+function randomEnum<T>(e: any): T {
+    return faker.helpers.arrayElement(Object.values(e)) as T
 }
 
 function createRandomRSE(): string {
@@ -33,5 +38,33 @@ export function createRandomRulePageLockEntry(): RulePageLockEntry {
         state: faker.helpers.arrayElement(['R', 'O', 'S']) as LockState,
         ddm_link: faker.internet.url(),
         fts_link: faker.internet.url(),
+    }
+}
+
+export function createRuleMeta(): RuleMeta {
+    return {
+        account: faker.internet.userName(),
+        activity: faker.company.buzzPhrase(),
+        copies: faker.number.int({ min: 1, max: 10 }),
+        created_at: faker.date.past(),
+        did_type: faker.helpers.arrayElement<DIDType>(['Dataset', 'Container', 'File']),
+        expires_at: faker.date.future(),
+        grouping: faker.helpers.arrayElement<DIDType>(['Dataset', 'Container', 'File']),
+        id: faker.string.uuid(),
+        ignore_account_limit: faker.datatype.boolean(),
+        ignore_availability: faker.datatype.boolean(),
+        locked: faker.datatype.boolean(),
+        locks_ok_cnt: faker.number.int({ min: 0, max: 10 }),
+        locks_replicating_cnt: faker.number.int({ min: 0, max: 10 }),
+        locks_stuck_cnt: faker.number.int({ min: 0, max: 10 }),
+        name: faker.lorem.words(3).replace(/\s/g, "."),
+        notification: randomEnum<RuleNotification>(RuleNotification),
+        priority: faker.number.int({ min: 0, max: 3 }),
+        purge_replicas: faker.datatype.boolean(),
+        rse_expression: createRandomRSE(),
+        scope: createRandomScope(),
+        split_container: faker.datatype.boolean(),
+        state: randomEnum<RuleState>(RuleState),
+        updated_at: faker.date.recent(),
     }
 }

--- a/tools/create-component-story
+++ b/tools/create-component-story
@@ -6,7 +6,7 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 path=$1
-component_path=$(echo $path | sed 's/.*components\///' | sed 's/.$//')
+component_path=$(echo $path | sed 's/.*components\///' | sed 's/\/$//')
 component_name=$(echo $2 | sed 's/\b\(.\)/\u\1/g')
 first_letter=$(echo $component_name | cut -c1)
 


### PR DESCRIPTION
Created the individual rule page with two subpages (metadata and locks table). Added a simple test.

The locks table runs on the new **Generic `StreamedTable`** component:
* Pass in tableData and an array of columnDefs (which I have not
  successfully managed to type yet) and it will render a table.
* Also has `tableStyling`, which currently only supports the
  `columnVisibility`.
* Filtering by discrete values is possible.
* Filtering by string values is possible (also for small screens, copied
  behaviour from small screens: textbox collapses into a magnifying
  glass button).
* Pagination via the `PaginationDiv` component. This div is placed
  within the `tfoot` component of the table, this means that all
  components of the table are contained in one `table` tag (instead of
  having an overall parent `div` tag).
* Has `FetchStatusIndicator`
* Component for `TableExternalLink` (based on the `a` tag but styled
  like buttons).
* Possible to choose column width in the `meta.style` object of the
  column definition. This is still pretty buggy, since tailwind does not
  recognise any classes defined only here and will not compile them. The
  styles will only be applied if the styles were defined elsewhere as
  well. #TODO!
* Begun work on adding table fixtures.

Also added ARIA to the `Tab` component.

*Added `faker-js` package as a dev-requirement*