### PR TITLE
devops: remove NodeJS 16, add NodeJS 20 in CI #238

### DIFF
--- a/.github/workflows/api-and-component.yml
+++ b/.github/workflows/api-and-component.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test API and Components
     strategy:
       matrix:
-        node-version: [16.14.0, 18.5.0]
+        node-version: [18.16.1, 20.4.0]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -11,7 +11,7 @@ jobs:
     name: Gateway Tests
     strategy:
       matrix:
-        node-version: [16.14.0, 18.5.0]
+        node-version: [18.16.1, 20.4.0]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fix #238
 
- NodeJS 16 support removed from CI
- NodeJS 18 -> 18.16.1 (LTS)
- NodeJS 20 -> 20.4.0