### PR TITLE
Set font settings (force monospace, rem=16px)

### DIFF
--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -43,7 +43,7 @@ html {
   -o-tab-size: 4;
      tab-size: 4;
   /* 3 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: monospace;
   /* 4 */
   font-feature-settings: normal;
   /* 5 */
@@ -126,7 +126,7 @@ code,
 kbd,
 samp,
 pre {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: monospace;
   /* 1 */
   font-size: 1em;
   /* 2 */
@@ -417,6 +417,11 @@ video {
 
 [hidden] {
   display: none;
+}
+
+html {
+  font-size: 16px;
+  /* font-family: monospace; */
 }
 
 *, ::before, ::after {
@@ -1702,11 +1707,11 @@ video {
 }
 
 .font-mono {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family: monospace;
 }
 
 .font-sans {
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  font-family: monospace;
 }
 
 .text-2xl {

--- a/src/component-library/tailwind.css
+++ b/src/component-library/tailwind.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    html {
+        font-size: 16px;
+        /* font-family: monospace; */
+    }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,13 @@ module.exports = {
     },
     theme: {
         extend: {
+            fontFamily: {
+                sans: ["monospace"],
+                mono: ["monospace"],
+                serif: ["monospace"],
+                forcesans: ["sans-serif"],
+                forceserif: ["serif"],
+            },
             keyframes: {
                 floatout: {
                     "0%": { opacity: "1", left: "0px", },


### PR DESCRIPTION
This commit sets values for the font settings, instead of leaving it to the default values which appeared to change from device to device.

The default setting is that all text is of font `monospace`, i.e. the system monospace font, which *may* differ between devices. To be clear: the `sans` and `serif` font-styles have also been overridden in `tailwind.config.js` and set to `monospace`.

Tailwind uses `rem` as the basis of all sizing, including the font sizing. In order to fix the root element size, the `tailwind.css` file has been extended by a style definition for the `html` element, setting `font-size: 16px;`. The remaining website dimensions will be calculated based on the size of this root element.

Should the developer wish to use serif or sans fonts in the project, the `fontFamily` has been extended by the elements `forcesans` and `forceserif`, which are mapped to the tailwind classes `font-forcesans` and `font-forceserif`, respectively.

Justification of changes made:
* Using a monospace font everywhere is a design choice that has been discussed with @mlassnig. It can be rolled back anytime (although I must say that I quite like it this way, and it makes the process of designing the website a lot easier, since text widths are trivially easy to predict). For the time being, it fixes the issue of differing designs on different machines.
* A choice had to be made between shipping a font to the user, i.e. using `next/font` to pass a specific font to all users, leading to a uniform cross-platform appearance, and simply setting the font to the system `monospace` font (which may differ between devices). In order to reduce complexity and because ultimately, the font choice does not matter (as long as the fonts are metrically compatible, which they should be) this small amount of un-uniformity can be tolerated. We went with the system monospace font. (and system sans and serif fonts too)