### PR TITLE
Deploy to GitHub Pages Script Updated

### DIFF
--- a/tools/deploy-to-gh-pages
+++ b/tools/deploy-to-gh-pages
@@ -25,7 +25,7 @@ git reset --hard origin/master
 # delete everything on the directory
 # ignore the docs folder
 
-find * -maxdepth 0 -name 'docs' -prune -o -exec rm -rf '{}' ';'
+find * -maxdepth 0 -not -name 'storybook-static' -exec rm -rf '{}' ';'
 
 # remove some folders additionally
 
@@ -34,7 +34,7 @@ rm -rf .husky .storybook
 # move the docs folder content
 # explode in the repository root
 
-mv ./docs/* .
+mv ./storybook-static/* .
 
 # deletes the git cache
 # push the new content to gh-pages


### PR DESCRIPTION
`npm run build-storybook` will build into the top-level `storybook-static`. The new `deploy-to-gh-pages` script reflects this.

I also changed the `find` command in order for it to be easier to read and understand. The effect has not changed.