### PR TITLE
Components: Fixed "Received ... for non-boolean attribute `stacked`"

### DIFF
--- a/src/component-library/components/StreamedTables/TableFooter.tsx
+++ b/src/component-library/components/StreamedTables/TableFooter.tsx
@@ -23,7 +23,7 @@ type TableFooterProps<T> = JSX.IntrinsicElements["tfoot"] & {
 }
 
 export function TableFooter<T>(props: TableFooterProps<T>) {
-    const { className, ...otherprops } = props
+    const { stacked, className, ...otherprops } = props
 
     return (
         <tfoot


### PR DESCRIPTION
The reason for this bug was that the props of `TableFooter` were unpacked by
```
const { className, ...otherprops } = props
```
which usually does not pose a problem when passing these "otherprops" into the HTML DOM component using
```
<tfoot
	{...otherprops}
>
```
because attributes such as `table: Table<T>` and `comdom: UseComDOM<T>` were not used as DOM attributes. The attribute `stacked?: boolean` on the other hand was passed into `tfoot`, causing errors that showed up in the console.

By explicitly unpacking `stacked` as in
```
const { stacked, className, ...otherprops } = props
```
the attribute `stacked` is no longer a part of `otherprops` and is no longer directly passed to the `tfoot` component, solving the issue.