### PR TITLE
Feature 276 page did meta

### DIFF
--- a/src/app/did/list/page.tsx
+++ b/src/app/did/list/page.tsx
@@ -6,33 +6,13 @@ import { DIDMetaViewModel, DIDViewModel } from "@/lib/infrastructure/data/view-m
 import useComDOM from "@/lib/infrastructure/hooks/useComDOM";
 import { HTTPRequest, prepareRequestArgs } from "@/lib/sdk/http";
 import { useEffect, useState } from "react";
-import { fixtureDIDMetaViewModel } from "test/fixtures/table-fixtures";
+import { didMetaQueryBase } from "../queries";
 
 export default function Page() {
     const [didMetaQueryResponse, setDIDMetaQueryResponse] = useState<DIDMetaViewModel>({} as DIDMetaViewModel)
-    const didMetaQuery = async (scope: string, name: string) => {
-        const req: HTTPRequest = {
-            method: "GET",
-            url: new URL('http://localhost:3000/api/didmeta'),
-            params: {
-                "scope": scope,
-                "name": name
-            },
-            headers: new Headers({
-                'Content-Type': 'application/json',
-            } as HeadersInit)
-        }
-        const { url, requestArgs } = prepareRequestArgs(req)
-        console.log(url)
-        const res = await fetch(url, {
-            method: "GET",
-            headers: new Headers({
-                'Content-Type': 'application/json',
-            } as HeadersInit)
-        })
-        // console.log(await res.json())
 
-        setDIDMetaQueryResponse({ status: 'success', ... await res.json() })
+    const didMetaQuery = async (scope: string, name: string) => {
+        setDIDMetaQueryResponse(await didMetaQueryBase(scope, name))
     }
 
     const didQuery = async (query: string, type: DIDType) => {
@@ -58,9 +38,6 @@ export default function Page() {
         200,
         true
     )
-    useEffect(() => {
-        setDIDMetaQueryResponse(fixtureDIDMetaViewModel())
-    }, [])
     useEffect(() => {
         const setRequest = async () => {
             const request: HTTPRequest = {

--- a/src/app/did/page/[scope]/[name]/page.tsx
+++ b/src/app/did/page/[scope]/[name]/page.tsx
@@ -5,12 +5,13 @@ import { useEffect, useState } from "react";
 import { fixtureDIDDatasetReplicasViewModel, fixtureDIDMetaViewModel, fixtureDIDRulesViewModel, mockUseComDOM, fixtureDIDKeyValuePairsViewModel } from 'test/fixtures/table-fixtures';
 import { HTTPRequest } from "@/lib/sdk/http";
 import { DIDMetaViewModel, DIDViewModel, FilereplicaStateDViewModel, FilereplicaStateViewModel } from '@/lib/infrastructure/data/view-model/did';
+import { didMetaQueryBase } from '@/app/did/queries';
 
 export default function Page({ params }: { params: { scope: string, name: string } }) {
     const [didMeta, setDIDMeta] = useState<DIDMetaViewModel>({} as DIDMetaViewModel)
     const [fromDidList, setFromDidList] = useState<string>("yosearch")
     useEffect(() => {
-        setDIDMeta(fixtureDIDMetaViewModel())
+        didMetaQueryBase(params.scope, params.name).then(setDIDMeta)
     }, [])
 
     const didParentsComDOM = useComDOM<DIDViewModel>(

--- a/src/app/did/queries.ts
+++ b/src/app/did/queries.ts
@@ -1,0 +1,26 @@
+import { DIDMetaViewModel } from "@/lib/infrastructure/data/view-model/did";
+import { HTTPRequest, prepareRequestArgs } from "@/lib/sdk/http";
+
+export async function didMetaQueryBase(scope: string, name: string): Promise<DIDMetaViewModel> {
+    const req: HTTPRequest = {
+        method: "GET",
+        url: new URL('http://localhost:3000/api/didmeta'),
+        params: {
+            "scope": scope,
+            "name": name
+        },
+        headers: new Headers({
+            'Content-Type': 'application/json',
+        } as HeadersInit)
+    }
+
+    const { url, requestArgs } = prepareRequestArgs(req)
+    const res = await fetch(url, {
+        method: "GET",
+        headers: new Headers({
+            'Content-Type': 'application/json',
+        } as HeadersInit)
+    })
+
+    return await res.json()
+}

--- a/src/component-library/Pages/DID/ListDID.tsx
+++ b/src/component-library/Pages/DID/ListDID.tsx
@@ -10,6 +10,7 @@ import { Heading } from "../Helpers/Heading"
 import { Body } from "../Helpers/Body"
 import { DIDType } from "@/lib/core/entity/rucio"
 import { Checkbox } from "../../Button/Checkbox"
+import Link from "next/link"
 
 var format = require("date-format")
 
@@ -153,7 +154,7 @@ export const ListDID = (
                         "flex flex-col space-y-2",
                     )}
                 >
-                    <DIDMetaView data={props.didMetaQueryResponse} show={selectedDID ? true : false} />
+                    <DIDMetaView data={meta} show={selectedDID ? true : false} />
                     <div
                         className={twMerge(
                             "text-gray-800",
@@ -165,11 +166,20 @@ export const ListDID = (
                     </div>
                     <div
                         className={twMerge(
-                            selectedDID ? "block" : "hidden",
+                            selectedDID ? "" : "hidden",
                         )}
                         aria-label="Go To DID Page"
                     >
-                        <Button label="Go To DID Page" aria-label="Go To DID Page" />
+                        <Link
+                            className={twMerge(
+                                "py-1 px-3 rounded w-full block",
+                                "bg-blue-500 hover:bg-blue-600 text-white",
+                                "cursor-pointer",
+                                "text-center font-bold",
+                            )}
+                            href={`/did/page/${meta.scope}/${meta.name}`}>
+                            Go To DID Page
+                        </Link>
                     </div>
                 </div>
             </Body>

--- a/src/component-library/Pages/DID/ListDID.tsx
+++ b/src/component-library/Pages/DID/ListDID.tsx
@@ -70,7 +70,12 @@ export const ListDID = (
                     <div className='grow'>
                         <TextInput
                             onBlur={(event: any) => { setDidSearchQuery(event.target.value) }}
-                            onEnterkey={(event: any) => { setDidSearchQuery(event.target.value) }}
+                            onEnterkey={async (e: any) => {
+                                e.preventDefault()
+                                await props.didQuery(e.target.value, didTypeAllowed)
+                                setDidSearchQuery(e.target.value)
+                                props.comdom.start()
+                            }}
                             id="did-search-pattern"
                         />
                     </div>

--- a/test/component/ListDID.test.tsx
+++ b/test/component/ListDID.test.tsx
@@ -30,8 +30,8 @@ describe("ListDID Story Test", () => {
         // Check that `No DID selected` is shown instead of the DIDMetaView, etc
         const noDIDSelectedDiv = screen.getByText("No DID selected").closest("div")
         expect(noDIDSelectedDiv).toHaveClass("block")
-        const goDIDViewButton = screen.getByText("Go To DID Page").closest("button")
-        expect(goDIDViewButton?.parentElement).toHaveClass("hidden")
+        const goDIDViewLink = screen.getByText("Go To DID Page")
+        expect(goDIDViewLink?.parentElement).toHaveClass("hidden")
         // Check that the DID Table Search is empty
         const didFilterInputs = screen.getAllByPlaceholderText("Filter DID")
         didFilterInputs.map((didFilterInput) => { expect(didFilterInput).toHaveValue("") })
@@ -65,6 +65,7 @@ describe("ListDID Story Test", () => {
         await act(async () => render(
             <ListDIDStory
                 comdom={mockUseComDOM(Array.from({length: 100}, () => fixtureDIDViewModel()))}
+                didQuery={jest.fn(x => console.log(x))}
                 didMetaQuery={jest.fn(x => console.log(x))}
                 didMetaQueryResponse={mockDIDMeta}
             />
@@ -78,8 +79,8 @@ describe("ListDID Story Test", () => {
         expect(noDIDSelectedDiv).not.toHaveClass("block")
         const metaDataDiv = screen.getByRole("generic", { name: "DID Metadata Quick Summary" })
         expect(metaDataDiv).toHaveClass("flex")
-        const goDIDViewButton = screen.getByRole("generic", { name: "Go To DID Page" })
-        expect(goDIDViewButton).toHaveClass("block")
+        const goDIDViewButton = screen.getByRole("link", { name: "Go To DID Page" })
+        expect(goDIDViewButton).not.toHaveClass("hidden")
         const didCreationRow = screen.getByRole("row", { name: "Date of DID Creation" })
         expect(didCreationRow).toHaveTextContent(format("yyyy-MM-dd", new Date(mockDIDMeta.created_at)))
         const didObsoleteRow = screen.getByRole("row", { name: "DID Obsolete" })


### PR DESCRIPTION
Main change:
* connected the DID Metadata to the frontend

Extra housekeeping:
* extracted the common fetch method
* linked from `ListDID` to `PageDID` using the NextJS `Link` component
* Suppressed page reload on enter key in `ListDID`

note: has a typo, was called feature 278 on my local machine, but should really refer to #276 