### PR TITLE
Feature 295 gateway didmetadata (KeyValuePairs)

### DIFF
--- a/src/lib/core/dto/did-dto.ts
+++ b/src/lib/core/dto/did-dto.ts
@@ -1,5 +1,6 @@
 import { BaseDTO, BaseStreamableDTO } from '@/lib/sdk/dto'
 import { DID, DIDMeta } from '@/lib/core/entity/rucio'
+import { DIDKeyValuePairs } from '@/lib/infrastructure/data/view-model/page-did'
 
 /**
  * Data Transfer Object for ListDIDsEndpoint
@@ -29,3 +30,10 @@ export interface DIDDTO extends DID, BaseDTO {
  * Data Transfer Object for DIDMeta Endpoint
  */
 export interface DIDMetaDTO extends BaseDTO, DIDMeta {}
+
+/**
+ * Data Transfer Object for DIDKeyValuePairs Endpoint
+ */
+export interface DIDKeyValuePairsDTO extends BaseDTO {
+    data: DIDKeyValuePairs[]
+}

--- a/src/lib/core/port/secondary/did-gateway-output-port.ts
+++ b/src/lib/core/port/secondary/did-gateway-output-port.ts
@@ -1,4 +1,4 @@
-import { ListDIDDTO, DIDDTO, DIDMetaDTO } from "../../dto/did-dto";
+import { ListDIDDTO, DIDDTO, DIDMetaDTO, DIDKeyValuePairsDTO } from "../../dto/did-dto";
 import { DIDType } from "../../entity/rucio";
 
 
@@ -12,13 +12,21 @@ export default interface DIDGatewayOutputPort {
     getDID(rucioAuthToken: string, scope: string, name: string): Promise<DIDDTO>
     
     /**
-     * 
+     * Returns a selection of metadata in an object
      * @param rucioAuthToken A valid rucio auth token
      * @param scope The scope of the DID
      * @param name The name of the DID
      */
     getDIDMeta(rucioAuthToken: string, scope: string, name: string): Promise<DIDMetaDTO>
     
+    /**
+     * Returns the key value pairs for the DID as a list (sourced from rucio meta)
+     * @param rucioAuthToken A valid rucio auth token
+     * @param scope The scope of the DID
+     * @param name The name of the DID
+     */
+    getDIDKeyValuePairs(rucioAuthToken: string, scope: string, name: string): Promise<DIDKeyValuePairsDTO>
+
     /**
      * Searches Rucio Server for expressions that match the scope:name pattern provided.
      * @param rucioAuthToken A valid rucio auth token

--- a/src/lib/infrastructure/gateway/did-gateway/did-gateway.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/did-gateway.ts
@@ -1,10 +1,11 @@
-import { DIDDTO, DIDMetaDTO, ListDIDDTO } from '@/lib/core/dto/did-dto'
+import { DIDDTO, DIDKeyValuePairsDTO, DIDMetaDTO, ListDIDDTO } from '@/lib/core/dto/did-dto'
 import { DIDAvailability, DIDType } from '@/lib/core/entity/rucio'
 import DIDGatewayOutputPort from '@/lib/core/port/secondary/did-gateway-output-port'
 import { injectable } from 'inversify'
 import GetDIDEndpoint from './endpoints/get-did-endpoint'
 import GetDIDMetaEndpoint from './endpoints/get-did-meta-endpoint'
 import ListDIDsEndpoint from './endpoints/list-dids-endpoint'
+import GetDIDKeyValuePairsEndpoint from './endpoints/get-did-keyvaluepairs-endpoint'
 
 
 @injectable()
@@ -52,6 +53,24 @@ export default class RucioDIDGateway implements DIDGatewayOutputPort {
                 guid: '',
                 filesize: 0
 
+            }
+            return Promise.resolve(errorDTO)
+        }
+    }
+
+    async getDIDKeyValuePairs(rucioAuthToken: string, scope: string, name: string): Promise<DIDKeyValuePairsDTO> {
+        try {
+            const endpoint = new GetDIDKeyValuePairsEndpoint(rucioAuthToken, scope, name)
+            const dto: DIDKeyValuePairsDTO = await endpoint.fetch()
+            return Promise.resolve(dto)
+        } catch (error) {
+            const errorDTO: DIDKeyValuePairsDTO = {
+                status: 'error',
+                errorName: 'Unknown Error',
+                errorType: 'gateway_endpoint_error',
+                errorCode: 500,
+                errorMessage: error?.toString(),
+                data: []
             }
             return Promise.resolve(errorDTO)
         }

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
@@ -1,0 +1,53 @@
+import { DIDKeyValuePairsDTO } from "@/lib/core/dto/did-dto";
+import { DIDKeyValuePairs } from "@/lib/infrastructure/data/view-model/page-did";
+import { BaseEndpoint } from "@/lib/sdk/gateway-endpoints";
+import { HTTPRequest } from "@/lib/sdk/http";
+import { Response } from "node-fetch";
+
+export default class GetDIDKeyValuePairsEndpoint extends BaseEndpoint<DIDKeyValuePairsDTO> {
+    constructor(
+        private rucioAuthToken: string,
+        private scope: string,
+        private name: string,
+    ) {
+        super()
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize()
+        this.url = `${this.rucioHost}/dids/${this.scope}/${this.name}/meta`
+        const request: HTTPRequest = {
+            method: 'GET',
+            url: this.url,
+            headers: {
+                'X-Rucio-Auth-Token': this.rucioAuthToken,
+                'Content-Type': 'application/json',
+            },
+            body: null,
+            params: undefined
+        }
+        this.request = request
+        this.initialized = true
+    }
+
+    reportErrors(statusCode: number, response: Response): Promise<DIDKeyValuePairsDTO | undefined> {
+        if (statusCode === 200) {
+            return Promise.resolve(undefined);
+        }
+        return Promise.resolve({ status: 'error', data: [] } as DIDKeyValuePairsDTO) // TODO: add error message
+    }
+
+    createDTO(response : Buffer): DIDKeyValuePairsDTO {
+        const jsondata = JSON.parse(JSON.parse(response.toString()))
+        const dto: DIDKeyValuePairsDTO = {
+            status: 'success',
+            data: Object.entries(jsondata).map(
+                ([key, value]) => {
+                    return { key: key, value: value } as DIDKeyValuePairs
+                }
+            )
+        }
+        return dto
+    }
+
+}

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
@@ -37,11 +37,10 @@ export default class GetDIDKeyValuePairsEndpoint extends BaseEndpoint<DIDKeyValu
         return Promise.resolve({ status: 'error', data: [] } as DIDKeyValuePairsDTO) // TODO: add error message
     }
 
-    createDTO(response : Buffer): DIDKeyValuePairsDTO {
-        const jsondata = JSON.parse(JSON.parse(response.toString()))
+    createDTO(response: Object): DIDKeyValuePairsDTO {
         const dto: DIDKeyValuePairsDTO = {
             status: 'success',
-            data: Object.entries(jsondata).map(
+            data: Object.entries(response).map(
                 ([key, value]) => {
                     return { key: key, value: value } as DIDKeyValuePairs
                 }

--- a/test/gateway/did/did-gateway-keyvaluepairs.test.ts
+++ b/test/gateway/did/did-gateway-keyvaluepairs.test.ts
@@ -1,0 +1,37 @@
+import { DIDKeyValuePairsDTO } from "@/lib/core/dto/did-dto";
+import DIDGatewayOutputPort from "@/lib/core/port/secondary/did-gateway-output-port";
+import appContainer from "@/lib/infrastructure/ioc/container-config";
+import GATEWAYS from "@/lib/infrastructure/ioc/ioc-symbols-gateway";
+import MockRucioServerFactory, { MockEndpoint } from "test/fixtures/rucio-server";
+
+describe("DID Gateway KeyValuePairs Endpoint Tests", () => {
+    beforeEach(() => {
+        fetchMock.doMock();
+        const didKVMockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/dids/test/dataset1/meta`,
+            method: "GET",
+            includes: "test/dataset1/meta",
+            response: {
+                status: 200,
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({
+                    "scope": "test",
+                    "name": "dataset1",
+                    "extra_key": "extra_value",
+                })
+            }
+        }
+        MockRucioServerFactory.createMockRucioServer(true, [didKVMockEndpoint]);
+    });
+    afterEach(() => {
+        fetchMock.dontMock();
+    });
+    it("should return a DIDKeyValuePairsDTO", async () => {
+        const didGateway: DIDGatewayOutputPort = appContainer.get(GATEWAYS.DID)
+        const dto: DIDKeyValuePairsDTO = await didGateway.getDIDKeyValuePairs(MockRucioServerFactory.VALID_RUCIO_TOKEN, "test", "dataset1")
+        expect(dto.status).toEqual("success")
+        expect(dto.data).toContainEqual({key: "extra_key", value: "extra_value"})
+    });
+})

--- a/test/gateway/did/did-gateway-keyvaluepairs.test.ts
+++ b/test/gateway/did/did-gateway-keyvaluepairs.test.ts
@@ -33,5 +33,6 @@ describe("DID Gateway KeyValuePairs Endpoint Tests", () => {
         const dto: DIDKeyValuePairsDTO = await didGateway.getDIDKeyValuePairs(MockRucioServerFactory.VALID_RUCIO_TOKEN, "test", "dataset1")
         expect(dto.status).toEqual("success")
         expect(dto.data).toContainEqual({key: "extra_key", value: "extra_value"})
+        expect(dto.data).toContainEqual({key: "scope", value: "test"})
     });
 })


### PR DESCRIPTION
Metadata (Keyvaluepairs) static fetch endpoint, creation of gateway and test.

KeyValuePairs differs from the normal metadata endpoint because the normal endpoint places a subset of the queried metadata into an object with fixed keys. The KeyValuePairs DTO has a field `data: DIDKeyValuePairs[]` in which the pairs of keys and values are stored as objects in an array. It is then fed into a streamedtable (even though it is not technically a stream)