### PR TITLE
Housekeeping: Move types from viewmodel to entities

### DIFF
--- a/src/component-library/Pages/DID/PageDIDMetadata.tsx
+++ b/src/component-library/Pages/DID/PageDIDMetadata.tsx
@@ -3,7 +3,7 @@ import { H3 } from "../../Text/Headings/H3";
 import { BoolTag } from "../../Tags/BoolTag";
 import { AvailabilityTag } from "../../Tags/AvailabilityTag";
 import { DIDTypeTag } from "../../Tags/DIDTypeTag";
-import { DIDType } from "@/lib/core/entity/rucio";
+import { DIDType, DIDKeyValuePair } from "@/lib/core/entity/rucio";
 import { NullTag } from "../../Tags/NullTag";
 
 // misc packages, react
@@ -14,7 +14,6 @@ import { twMerge } from "tailwind-merge"
 import { DIDAvailability } from "@/lib/core/entity/rucio"
 import { TableFilterString } from "../../StreamedTables/TableFilterString";
 import { DIDKeyValuePairsDataViewModel } from "@/lib/infrastructure/data/view-model/did";
-import { DIDKeyValuePair } from "@/lib/infrastructure/data/view-model/page-did";
 import { NormalTable } from "@/component-library/StreamedTables/NormalTable";
 
 export const PageDIDMetadata = (

--- a/src/component-library/Pages/Dashboard/Dashboard.tsx
+++ b/src/component-library/Pages/Dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@ import { Checkbox } from "../../Button/Checkbox";
 import { WidgetOngoingrules } from "./Widgets/WidgetOngoingrules";
 import { RoleTag } from "../../Tags/RoleTag";
 import { Role } from "@/lib/core/entity/account";
-import { Ongoingrules, Usedquota } from "@/lib/infrastructure/data/view-model/widgets";
+import { Ongoingrules, Usedquota } from "@/lib/core/entity/widgets";
 import { WidgetUsedquota } from "./Widgets/WidgetUsedquota";
 import { useState, useEffect } from "react";
 import { Heading } from "../Helpers/Heading";

--- a/src/component-library/Pages/Dashboard/Widgets/WidgetOngoingrules.tsx
+++ b/src/component-library/Pages/Dashboard/Widgets/WidgetOngoingrules.tsx
@@ -11,7 +11,8 @@ import {
     Tooltip,
     Legend,
 } from 'chart.js';
-import { ChartData, Ongoingrules } from "@/lib/infrastructure/data/view-model/widgets";
+import { ChartData } from "../types";
+import { Ongoingrules } from "@/lib/core/entity/widgets";
 import {
     createColumnHelper, getCoreRowModel, getPaginationRowModel, useReactTable,
     Row, Column, getSortedRowModel

--- a/src/component-library/Pages/Dashboard/Widgets/WidgetUsedquota.tsx
+++ b/src/component-library/Pages/Dashboard/Widgets/WidgetUsedquota.tsx
@@ -1,5 +1,5 @@
 import { H4 } from "@/component-library/Text/Headings/H4";
-import { Usedquota } from "@/lib/infrastructure/data/view-model/widgets";
+import { Usedquota } from "@/lib/core/entity/widgets";
 import { twMerge } from "tailwind-merge";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import { Pie } from 'react-chartjs-2';

--- a/src/component-library/Pages/Dashboard/types.d.ts
+++ b/src/component-library/Pages/Dashboard/types.d.ts
@@ -1,0 +1,16 @@
+
+/*
+* Widget Generics
+* These types are used to type a generic widget -> think of them as table column defs.
+*/
+export type ChartBasicDataset = {
+    label: string,
+    data: any[],
+    backgroundColor?: string, // Hex
+}
+
+export type ChartData<T extends ChartBasicDataset> = {
+    labels: string[],
+    datasets: T[],
+}
+

--- a/src/component-library/StreamedTables/NormalTable.stories.tsx
+++ b/src/component-library/StreamedTables/NormalTable.stories.tsx
@@ -2,7 +2,7 @@ import { StoryFn, Meta } from "@storybook/react";
 import { createColumnHelper } from "@tanstack/react-table";
 import { fixtureDIDKeyValuePair } from "test/fixtures/table-fixtures";
 import { NormalTable as N } from "./NormalTable";
-import { DIDKeyValuePair } from "@/lib/infrastructure/data/view-model/page-did";
+import { DIDKeyValuePair } from "@/lib/core/entity/rucio";
 import { TableFilterString } from "./TableFilterString";
 import { DIDAvailability, DIDType } from "@/lib/core/entity/rucio";
 import { twMerge } from "tailwind-merge";

--- a/src/lib/core/dto/did-dto.ts
+++ b/src/lib/core/dto/did-dto.ts
@@ -1,6 +1,5 @@
 import { BaseDTO, BaseStreamableDTO } from '@/lib/sdk/dto'
-import { DID, DIDMeta } from '@/lib/core/entity/rucio'
-import { DIDKeyValuePair, DIDRules } from '@/lib/infrastructure/data/view-model/page-did'
+import { DID, DIDKeyValuePair, DIDMeta, DIDRules } from '@/lib/core/entity/rucio'
 
 /**
  * Data Transfer Object for ListDIDsEndpoint

--- a/src/lib/core/dto/replica-dto.ts
+++ b/src/lib/core/dto/replica-dto.ts
@@ -1,4 +1,4 @@
-import { DIDDatasetReplicas, FilereplicaState } from "../entity/rucio";
+import { DIDDatasetReplicas, FileReplicaState } from "../entity/rucio";
 import { BaseDTO, BaseStreamableDTO } from "@/lib/sdk/dto";
 
 /**
@@ -11,7 +11,7 @@ export interface ListReplicasDTO extends BaseStreamableDTO {}
 /**
  * Represents file replica state.
  */
-export interface FileReplicaStateDTO extends BaseDTO, FilereplicaState {}
+export interface FileReplicaStateDTO extends BaseDTO, FileReplicaState {}
 
 
 /**

--- a/src/lib/core/dto/replica-dto.ts
+++ b/src/lib/core/dto/replica-dto.ts
@@ -1,4 +1,4 @@
-import { DIDDatasetReplicas, FilereplicaState } from "@/lib/infrastructure/data/view-model/page-did"; // TODO: Move to entity, breaks clean architecture
+import { DIDDatasetReplicas, FilereplicaState } from "../entity/rucio";
 import { BaseDTO, BaseStreamableDTO } from "@/lib/sdk/dto";
 
 /**

--- a/src/lib/core/entity/rucio.ts
+++ b/src/lib/core/entity/rucio.ts
@@ -23,6 +23,21 @@ export enum DIDAvailability {
     UNKNOWN = "Unknown",
 }
 
+export type DIDDatasetReplicas = {
+    rse: string;
+    rseblocked: RSEBlockState;
+    availability: boolean;
+    available_files: number;
+    available_bytes: number;
+    creation_date: DateISO;
+    last_accessed: DateISO;
+}
+
+// these are general key-value pairs including the metadata
+export type DIDKeyValuePair = { key: string; value: string | number | boolean | null }
+export type DIDKeyValuePairsData = {
+    data: DIDKeyValuePair[]
+}
 
 // copied from deployed rucio UI
 export type DIDMeta = {
@@ -45,6 +60,36 @@ export type DIDMeta = {
     md5: string | null
     guid: string | null
     filesize: number | null
+}
+
+export type DIDRules = {
+    id: string;
+    name: string;
+    state: RuleState;
+    account: string;
+    subscription?: {name: string, account: string}; // name and account together are unique for a subscription
+    last_modified: DateISO;
+}
+
+// File replica states for file DIDs
+export type FilereplicaState = {
+    rse: string
+    state: ReplicaState
+}
+
+// File replica states for dataset DIDs
+// stores summary information on the file replica states of the files within
+// a dataset DID: how many files are in each state
+// currently not in use since we only display scopenames
+export type FilereplicaStateD = {
+    scope: string,
+    name: string,
+    available: number,
+    unavailable: number,
+    copying: number,
+    being_deleted: number,
+    bad: number,
+    temporary_unavailable: number,
 }
 
 // results of web::flaskapi:v1::rses::RSEAccountUsageLimit::get
@@ -153,6 +198,35 @@ export type RSE = {
     volatile: boolean;
     deterministic: boolean;
     staging_area: boolean;
+}
+
+export type RSEProtocol = {
+    rseid: string,
+    scheme: string,
+    hostname: string,
+    port: number,
+    prefix: string,
+    impl: string,
+    priorities_lan: {
+        read: number,
+        write: number,
+        delete: number
+    },
+    priorities_wan: {
+        read: number,
+        write: number,
+        delete: number,
+        tpc: number,
+        tpcwrite: number,
+        tpcread: number,
+    },
+    updated_at: DateISO,
+    created_at: DateISO,
+}
+
+export type RSEAttribute = {
+    key: string,
+    value: string| DateISO | number | boolean | null,
 }
 
 /*

--- a/src/lib/core/entity/rucio.ts
+++ b/src/lib/core/entity/rucio.ts
@@ -72,7 +72,7 @@ export type DIDRules = {
 }
 
 // File replica states for file DIDs
-export type FilereplicaState = {
+export type FileReplicaState = {
     rse: string
     state: ReplicaState
 }
@@ -81,7 +81,7 @@ export type FilereplicaState = {
 // stores summary information on the file replica states of the files within
 // a dataset DID: how many files are in each state
 // currently not in use since we only display scopenames
-export type FilereplicaStateD = {
+export type FileReplicaStateD = {
     scope: string,
     name: string,
     available: number,

--- a/src/lib/core/entity/widgets.ts
+++ b/src/lib/core/entity/widgets.ts
@@ -1,19 +1,4 @@
 /*
-* Widget Generics
-* These types are used to type a generic widget -> think of them as table column defs.
-*/
-export type ChartBasicDataset = {
-    label: string,
-    data: any[],
-    backgroundColor?: string, // Hex
-}
-
-export type ChartData<T extends ChartBasicDataset> = {
-    labels: string[],
-    datasets: T[],
-}
-
-/*
 * Widget Types
 * These types are used to type a specific widget -> they correspond to a table row
 */

--- a/src/lib/core/usecase-models/did-keyvaluepairs-usecase-models.ts
+++ b/src/lib/core/usecase-models/did-keyvaluepairs-usecase-models.ts
@@ -1,4 +1,4 @@
-import { DIDKeyValuePair, DIDKeyValuePairsData } from "@/lib/infrastructure/data/view-model/page-did";
+import { DIDKeyValuePair, DIDKeyValuePairsData } from "../entity/rucio";
 import { BaseErrorResponseModel, BaseResponseModel } from "@/lib/sdk/usecase-models";
 
 export interface DIDKeyValuePairsDataRequest {

--- a/src/lib/core/usecase-models/list-dataset-replicas-usecase-models.ts
+++ b/src/lib/core/usecase-models/list-dataset-replicas-usecase-models.ts
@@ -1,4 +1,4 @@
-import { DIDDatasetReplicas } from "@/lib/infrastructure/data/view-model/page-did";
+import { DIDDatasetReplicas } from "../entity/rucio";
 import { BaseErrorResponseModel, BaseResponseModel } from "@/lib/sdk/usecase-models"
 /**
  * @interface ListDatasetReplicasRequest represents the RequestModel for list_dataset_replicas usecase

--- a/src/lib/core/usecase-models/list-did-rules-usecase-models.ts
+++ b/src/lib/core/usecase-models/list-did-rules-usecase-models.ts
@@ -1,4 +1,4 @@
-import { DIDRules } from "@/lib/infrastructure/data/view-model/page-did";
+import { DIDRules } from "../entity/rucio";
 import { BaseErrorResponseModel, BaseResponseModel } from "@/lib/sdk/usecase-models";
 
 export interface ListDIDRulesRequest {

--- a/src/lib/core/usecase-models/list-file-replicas-usecase-models.ts
+++ b/src/lib/core/usecase-models/list-file-replicas-usecase-models.ts
@@ -1,4 +1,4 @@
-import { FilereplicaState } from "@/lib/infrastructure/data/view-model/page-did"
+import { FilereplicaState } from "../entity/rucio"
 import { BaseErrorResponseModel, BaseResponseModel } from "@/lib/sdk/usecase-models"
 /**
  * @interface ListFileReplicasRequest represents the RequestModel for list_file_replicas usecase

--- a/src/lib/core/usecase-models/list-file-replicas-usecase-models.ts
+++ b/src/lib/core/usecase-models/list-file-replicas-usecase-models.ts
@@ -1,4 +1,4 @@
-import { FilereplicaState } from "../entity/rucio"
+import { FileReplicaState } from "../entity/rucio"
 import { BaseErrorResponseModel, BaseResponseModel } from "@/lib/sdk/usecase-models"
 /**
  * @interface ListFileReplicasRequest represents the RequestModel for list_file_replicas usecase
@@ -11,7 +11,7 @@ export interface ListFileReplicasRequest {
 /** 
  * @interface ListFileReplicasResponse represents the ResponseModel for list_file_replicas usecase
 */
-export interface ListFileReplicasResponse extends FilereplicaState, BaseResponseModel {}
+export interface ListFileReplicasResponse extends FileReplicaState, BaseResponseModel {}
 
 
 /**

--- a/src/lib/infrastructure/data/view-model/did.ts
+++ b/src/lib/infrastructure/data/view-model/did.ts
@@ -1,6 +1,8 @@
-import { DID, DIDLong, DIDMeta, DIDType, ReplicaState, RuleState } from "@/lib/core/entity/rucio";
+import {
+    DID, DIDLong, DIDMeta, DIDType, ReplicaState, RuleState,   DIDRules, DIDKeyValuePairsData,
+    FilereplicaState, FilereplicaStateD, DIDDatasetReplicas
+} from "@/lib/core/entity/rucio";
 import { BaseViewModel } from "@/lib/sdk/view-models";
-import { DIDRules, DIDDatasetReplicas, FilereplicaState, FilereplicaStateD, DIDKeyValuePairsData } from "./page-did";
 
 export interface DIDViewModel extends DID, BaseViewModel {}
 export interface DIDLongViewModel extends DIDLong, BaseViewModel {}

--- a/src/lib/infrastructure/data/view-model/did.ts
+++ b/src/lib/infrastructure/data/view-model/did.ts
@@ -1,6 +1,6 @@
 import {
     DID, DIDLong, DIDMeta, DIDType, ReplicaState, RuleState,   DIDRules, DIDKeyValuePairsData,
-    FilereplicaState, FilereplicaStateD, DIDDatasetReplicas
+    FileReplicaState, FileReplicaStateD, DIDDatasetReplicas
 } from "@/lib/core/entity/rucio";
 import { BaseViewModel } from "@/lib/sdk/view-models";
 
@@ -11,8 +11,8 @@ export interface DIDMetaViewModel extends DIDMeta, BaseViewModel {}
 export interface DIDKeyValuePairsDataViewModel extends DIDKeyValuePairsData, BaseViewModel {}
 export interface DIDRulesViewModel extends DIDRules, BaseViewModel {}
 export interface DIDDatasetReplicasViewModel extends DIDDatasetReplicas, BaseViewModel {}
-export interface FilereplicaStateViewModel extends FilereplicaState, BaseViewModel {}
-export interface FilereplicaStateDViewModel extends FilereplicaStateD, BaseViewModel {}
+export interface FilereplicaStateViewModel extends FileReplicaState, BaseViewModel {}
+export interface FilereplicaStateDViewModel extends FileReplicaStateD, BaseViewModel {}
 
 export function generateEmptyDIDRulesViewModel(): DIDRulesViewModel {
     return {

--- a/src/lib/infrastructure/data/view-model/page-did.d.ts
+++ b/src/lib/infrastructure/data/view-model/page-did.d.ts
@@ -2,47 +2,5 @@ import { DateISO, ReplicaState, RSEBlockState } from "@/lib/core/entity/rucio"
 import { RuleState } from "@/lib/core/entity/rucio"
 import { ObjectFlags } from "typescript"
 
-// File replica states for file DIDs
-export type FilereplicaState = {
-    rse: string
-    state: ReplicaState
-}
 
-// File replica states for dataset DIDs
-// stores summary information on the file replica states of the files within
-// a dataset DID: how many files are in each state
-export type FilereplicaStateD = {
-    scope: string,
-    name: string,
-    available: number,
-    unavailable: number,
-    copying: number,
-    being_deleted: number,
-    bad: number,
-    temporary_unavailable: number,
-}
 
-export type DIDDatasetReplicas = {
-    rse: string;
-    rseblocked: RSEBlockState;
-    availability: boolean;
-    available_files: number;
-    available_bytes: number;
-    creation_date: DateISO;
-    last_accessed: DateISO;
-}
-
-// these are general key-value pairs including the metadata
-export type DIDKeyValuePair = { key: string; value: string | number | boolean | null }
-export type DIDKeyValuePairsData = {
-    data: DIDKeyValuePair[]
-}
-
-export type DIDRules = {
-    id: string;
-    name: string;
-    state: RuleState;
-    account: string;
-    subscription?: {name: string, account: string}; // name and account together are unique for a subscription
-    last_modified: DateISO;
-}

--- a/src/lib/infrastructure/data/view-model/rse.ts
+++ b/src/lib/infrastructure/data/view-model/rse.ts
@@ -1,35 +1,7 @@
 import { DateISO } from "@/lib/core/entity/rucio"
 import { BaseViewModel } from "@/lib/sdk/view-models"
-import { RSE, RSEAccountUsageLimit } from "@/lib/core/entity/rucio"
+import { RSE, RSEAttribute, RSEAccountUsageLimit, RSEProtocol } from "@/lib/core/entity/rucio"
 
-export type RSEProtocol = {
-    rseid: string,
-    scheme: string,
-    hostname: string,
-    port: number,
-    prefix: string,
-    impl: string,
-    priorities_lan: {
-        read: number,
-        write: number,
-        delete: number
-    },
-    priorities_wan: {
-        read: number,
-        write: number,
-        delete: number,
-        tpc: number,
-        tpcwrite: number,
-        tpcread: number,
-    },
-    updated_at: DateISO,
-    created_at: DateISO,
-}
-
-export type RSEAttribute = {
-    key: string,
-    value: string| DateISO | number | boolean | null,
-}
 
 export interface RSEViewModel extends RSE, BaseViewModel {}
 

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
@@ -1,5 +1,5 @@
 import { DIDKeyValuePairsDTO } from "@/lib/core/dto/did-dto";
-import { DIDKeyValuePair } from "@/lib/infrastructure/data/view-model/page-did";
+import { DIDKeyValuePair } from "@/lib/core/entity/rucio";
 import { BaseEndpoint } from "@/lib/sdk/gateway-endpoints";
 import { HTTPRequest } from "@/lib/sdk/http";
 import { Response } from "node-fetch";

--- a/test/fixtures/table-fixtures.ts
+++ b/test/fixtures/table-fixtures.ts
@@ -12,7 +12,7 @@ import { SubscriptionRuleStatesViewModel, SubscriptionViewModel } from '@/lib/in
 import { BaseViewModel } from '@/lib/sdk/view-models';
 import { DIDDatasetReplicasViewModel, DIDKeyValuePairsDataViewModel, DIDLongViewModel, DIDMetaViewModel, DIDRulesViewModel, DIDViewModel, FilereplicaStateDViewModel, FilereplicaStateViewModel } from '@/lib/infrastructure/data/view-model/did';
 import { RuleMetaViewModel, RulePageLockEntryViewModel, RuleViewModel } from '@/lib/infrastructure/data/view-model/rule';
-import { DIDKeyValuePair } from '@/lib/infrastructure/data/view-model/page-did';
+import { DIDKeyValuePair } from '@/lib/core/entity/rucio';
 
 export function mockUseComDOM<T extends BaseViewModel>(data: T[]): UseComDOM<T> {
     return {

--- a/test/fixtures/widget-fixtures.ts
+++ b/test/fixtures/widget-fixtures.ts
@@ -1,4 +1,4 @@
-import { Ongoingrules, Usedquota } from "@/lib/infrastructure/data/view-model/widgets";
+import { Ongoingrules, Usedquota } from "@/lib/core/entity/widgets";
 import { faker } from "@faker-js/faker";
 import { createRSEName } from "./table-fixtures";
 


### PR DESCRIPTION
Moved types that were previously, and incorrectly, in the viewmodels folder, into the entities folder.