### PR TITLE
Improve the site header

### DIFF
--- a/src/app/(rucio)/layout.tsx
+++ b/src/app/(rucio)/layout.tsx
@@ -1,12 +1,9 @@
-'use client';
+'use client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import "@/component-library/outputtailwind.css";
-import "reflect-metadata";
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { Layout as LayoutStory } from '@/component-library/Pages/Layout/Layout';
-
-
-const queryClient = new QueryClient();
+import '@/component-library/outputtailwind.css'
+import 'reflect-metadata'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { RucioAppLayout } from './rucio-app-layout'
 
 
 export default function RootLayout({
@@ -14,19 +11,10 @@ export default function RootLayout({
 }: {
     children: React.ReactNode
 }) {
-
     return (
-        <LayoutStory
-            LVM={{
-                accountActive: "test",
-                accountsPossible: ["test", "test2"],
-                rucioProjectLink: "rucio.cern.ch",
-                experimentProjectLink: "atlas.cern",
-            }}
-        >
-            <QueryClientProvider client={queryClient}>
-                {children}
-            </QueryClientProvider>
-        </LayoutStory>
+        <QueryClientProvider client={new QueryClient()}>
+            <RucioAppLayout>{children}</RucioAppLayout>
+            <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
     )
 }

--- a/src/app/(rucio)/rucio-app-layout.tsx
+++ b/src/app/(rucio)/rucio-app-layout.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from "react"
+import { Layout } from '@/component-library/Pages/Layout/Layout';
+import { useQuery } from "@tanstack/react-query";
+import { SiteHeaderViewModel } from "@/lib/infrastructure/data/view-model/site-header";
+import { User } from "@/lib/core/entity/auth-models";
+
+export interface QueryContextLayoutProps {
+    children: React.ReactNode;
+
+}
+export const RucioAppLayout = (props: QueryContextLayoutProps) => {
+    const [siteHeaderViewModel, setSiteHeaderViewModel] = useState<SiteHeaderViewModel>({
+        status: "error",
+        homeUrl: ""
+    })
+    const fetchAccounts = async () => {
+        await fetch(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-site-header`)
+        .then(res => {
+            if (res.ok) {
+                return res.json()
+            }
+            throw new Error(res.statusText)
+        })
+        .then(viewModel => {
+            setSiteHeaderViewModel(viewModel as SiteHeaderViewModel)
+        })
+        .catch(error => {
+            // do sth with error
+            console.error("Error fetching data:", error);
+        })
+    }
+    
+    const fetchAccountKey = ['fetchAccounts']
+    useQuery(fetchAccountKey,fetchAccounts)
+    return (
+            <Layout
+            LVM={{
+                accountActive: siteHeaderViewModel.activeAccount?.rucioAccount ?? "",
+                accountsPossible: siteHeaderViewModel.availableAccounts?.map((user: User) => { return user.rucioAccount}) ?? [],
+                rucioProjectLink: "rucio.cern.ch",
+                experimentProjectLink: "atlas.cern",
+            }}
+            >
+                {props.children}
+            </Layout>
+    )
+}

--- a/src/component-library/Pages/Layout/AccountDropdown.tsx
+++ b/src/component-library/Pages/Layout/AccountDropdown.tsx
@@ -1,5 +1,5 @@
 import { twMerge } from "tailwind-merge"
-import { ForwardedRef, forwardRef } from "react"
+import { ForwardedRef, forwardRef, useState } from "react"
 import { HiCog, HiSwitchHorizontal, HiLogout } from "react-icons/hi"
 import Link from "next/link"
 
@@ -58,7 +58,7 @@ export const AccountDropdown = forwardRef(function AccountDropdown
                                     "text-right"
                                 )}
                                 key={index}
-                                href="/switchaccount"
+                                href="/api/account/switch"
                                 prefetch={false}
                             >
                                 <HiSwitchHorizontal className="text-2xl dark:text-gray-100 shrink-0" />

--- a/src/component-library/Pages/Layout/Layout.tsx
+++ b/src/component-library/Pages/Layout/Layout.tsx
@@ -28,15 +28,18 @@ export const Layout = (
     const [isHamburgerOpen, setIsHamburgerOpen] = useState(false)
     const [isProfileOpen, setIsProfileOpen] = useState(false)
 
-    const SearchDropdown = forwardRef(function SearchDropdown
-        (
-            props: {
+    /* Add contants with state for each section if it is clicked or not*/
+
+    const [isRulesDropDown, setIsRulesDropDown] = useState(false)
+    const [isMoreDropDown, setIsMoreDropDown] = useState(false)
+
+    const SearchDropdown = forwardRef(function SearchDropdown(
+        props: {
                 inputSelected: boolean,
                 searchstring: string,
             },
             ref: React.ForwardedRef<HTMLDivElement>
         ) {
-
         const [isMouseOver, setIsMouseOver] = useState(false)
         const LinkElem = (props: { href: string, children: React.ReactNode }) => {
             return (
@@ -125,7 +128,6 @@ export const Layout = (
         document.addEventListener("mousedown", handleClickOutside)
     }, [searchMenuRef])
 
-
     // images to be returned by static nextjs
     return (
         <div
@@ -162,7 +164,7 @@ export const Layout = (
                         </a>
                         <a className="bg-purple-500 w-12 h-12" href={props.LVM.experimentProjectLink} />
                     </span>
-                    <span className="hidden md:visible md:flex space-x-4 items-center">
+                    <span className="hidden md:visible md:flex space-x-12 items-center pl-2 pr-2">
                         <span className="relative">
                             <input
                                 className={twMerge(
@@ -172,22 +174,52 @@ export const Layout = (
                                 placeholder="Search"
                                 onFocus={() => setIsSearching(true)}
                                 // onBlur={() => setIsSearching(false)}
-                                onChange={(e) => setSearchString(e.target.value)}
+                                onChange={e => setSearchString(e.target.value)}
                                 ref={searchMenuInputRef}
                             />
-                            <SearchDropdown inputSelected={isSearching} searchstring={searchString} ref={searchMenuRef} />
+                            <SearchDropdown
+                                inputSelected={isSearching}
+                                searchstring={searchString}
+                                ref={searchMenuRef}
+                            />
                         </span>
-                        <HeaderLinks href="/rule/create" onFocus={() => setIsSearching(false)}>Create Rule</HeaderLinks>
-                        <HeaderLinks href="/did/list">List DIDs</HeaderLinks>
-                        <HeaderLinks href="/rule/list">List Rules</HeaderLinks>
-                    </span>
-                    <span className="flex space-x-2 items-end relative">
-                        <a
-                            className="hidden md:block text-gray-100"
-                            href="/notifications"
+                        <HeaderLinks
+                            href="/did/list"
+                            className="w-full pt-2 pb-2 text-gray-100 text-left"
+                            
                         >
-                            <HiBell className="text-4xl" />
-                        </a>
+                           DIDs
+                        </HeaderLinks>
+                        <HeaderLinks
+                            href="/rse/list"
+                            className="w-full pt-2  pb-2 text-gray-100 text-center"
+                        >
+                            RSEs
+                        </HeaderLinks>
+
+                        <button
+                            className="w-full pt-2 pb-2 text-gray-100 text-center"
+                            onClick={() => {
+                                setIsRulesDropDown(!isRulesDropDown)
+                                if (isMoreDropDown)
+                                {setIsMoreDropDown(!isMoreDropDown) }
+                            }}
+                        >
+                            Rules
+                        </button>
+                        <button
+                            className="w-full pt-2 pb-2 text-gray-100 text-center"
+                            onClick={() => {
+                                setIsMoreDropDown(!isMoreDropDown) 
+                                if(isRulesDropDown){
+                                setIsRulesDropDown(!isRulesDropDown)}
+                            }}
+                        >
+                            ...
+                        </button>
+                    </span>
+
+                    <span className="flex space-x-2 items-end relative pl-2 pr-2">
                         <button
                             className="text-gray-100 flex items-center"
                             onClick={() => setIsProfileOpen(!isProfileOpen)}
@@ -204,14 +236,95 @@ export const Layout = (
                         />
                     </span>
                 </nav>
+
+                <Collapsible showIf={isRulesDropDown} className="bg-gray-800">
+                    <nav className="w-full md:flex flex-col md:visible hidden items-start space-y-2 divide-y divide-gray-600 border-t border-gray-600">
+                        <HeaderLinks
+                            href="/rule/create"
+                            className="w-full pt-2 text-gray-100  text-center"
+                        >
+                            Create Rule
+                        </HeaderLinks>
+                        <HeaderLinks
+                            href="/rule/list"
+                            className="w-full pt-2 pb-2  text-gray-100 text-center"
+                        >
+                            List Rules
+                        </HeaderLinks>
+                    </nav>
+                </Collapsible>
+                <Collapsible showIf={isMoreDropDown} className="bg-gray-800 w-full">
+                    <nav className="w-full md:flex flex-col md:visible hidden items-start space-y-2 divide-y divide-gray-600 border-t border-gray-600">
+                        <HeaderLinks
+                            href="/subscription/list"
+                            className="w-full pt-2 pb-2  text-gray-100 text-center"
+                        >
+                            Subscription
+                        </HeaderLinks>
+                    </nav>
+                </Collapsible>
+
                 <Collapsible showIf={isHamburgerOpen}>
-                    <nav
-                        className="w-full flex flex-col md:hidden items-start space-y-2 divide-y divide-gray-600 border-t border-gray-600 "
-                    >
-                        <HeaderLinks href="/rule/create" className="w-full pt-2">Create Rule</HeaderLinks>
-                        <HeaderLinks href="/did/list" className="w-full pt-2">List DIDs</HeaderLinks>
-                        <HeaderLinks href="/rule/list" className="w-full pt-2">List Rules</HeaderLinks>
-                        <HeaderLinks href="/notifications" className="w-full pt-2"><span className="flex justify-between items-center">Notifications <HiBell /></span></HeaderLinks>
+                    <nav className="w-full flex flex-col md:hidden items-start space-y-2 divide-y divide-gray-600 border-t border-gray-600 ">
+                        <HeaderLinks
+                            href="/did/list"
+                            className="w-full pt-2  text-gray-100 text-left"
+                        >
+                            List DIDs
+                        </HeaderLinks>
+                        <HeaderLinks
+                            href="/rse/list"
+                            className="w-full pt-2  text-gray-100 text-left"
+                        >
+                            List RSEs
+                        </HeaderLinks>
+
+                        <button
+                            className="w-full pt-2 text-gray-100 text-left"
+                            onClick={() => {
+                                setIsRulesDropDown(!isRulesDropDown)
+                                if (isMoreDropDown)
+                                {setIsMoreDropDown(!isMoreDropDown) }
+                            }}
+                        >
+                            Rules
+                        </button>
+                        <Collapsible showIf={isRulesDropDown} className='w-full'>
+                            <nav className="w-full flex flex-col md:hidden items-start space-y-2 divide-y divide-gray-600 border-t border-gray-600 ">
+                                <HeaderLinks
+                                    href="/rule/create"
+                                    className="w-full pt-2 text-gray-100 text-left"
+                                >
+                                    Create Rule
+                                </HeaderLinks>
+                                <HeaderLinks
+                                    href="/rule/list"
+                                    className="w-full pt-2  text-gray-100 text-left"
+                                >
+                                    List Rules
+                                </HeaderLinks>
+                            </nav>
+                        </Collapsible>
+                        <button
+                            className="w-full pt-1 pb-1 text-gray-100 text-left"
+                            onClick={() => {
+                                setIsMoreDropDown(!isMoreDropDown) 
+                                if(isRulesDropDown){
+                                    setIsRulesDropDown(!isRulesDropDown)}
+                            }}
+                        >
+                            ...
+                        </button>
+                        <Collapsible showIf={isMoreDropDown} className="w-full">
+                    <nav className="w-full flex flex-col md:hidden items-start space-y-2 divide-y divide-gray-600 border-t border-gray-600 ">
+                        <HeaderLinks
+                            href="/subscription/list"
+                            className="w-full pt-2 pb-2  text-gray-100 text-left"
+                        >
+                            Subscription
+                        </HeaderLinks>
+                    </nav>
+                </Collapsible>
                     </nav>
                 </Collapsible>
             </header>

--- a/src/component-library/Pages/Login/Login.tsx
+++ b/src/component-library/Pages/Login/Login.tsx
@@ -116,12 +116,15 @@ export const Login = ({
                 } />
             </Collapsible>
             <div className="text-center dark:text-white">
-                <H1 className="mt-4 mb-2">Rucio Login</H1>
+                <H1 className="mt-4 mb-2">Rucio Login</H1> 
             </div>
 
-            <form
+            <div
                 className="flex flex-col space-y-2"
-                onSubmit={e => { e.preventDefault() }} // TODO handle proper submit!
+                onSubmit={ (e) => { 
+                        e.preventDefault()
+                    }
+                } // TODO handle proper submit!
             >
                 <Tabs
                     tabs={loginViewModel.voList.map((vo) => vo.name)}
@@ -171,7 +174,7 @@ export const Login = ({
                         setShowUserPassLoginForm(!showUserPassLoginForm)
                     }
                     } />
-
+                    <form>
                     <fieldset
                         className={twMerge(
                             "flex flex-col space-y-2",
@@ -183,6 +186,7 @@ export const Login = ({
                     >
                         <div
                             className={twMerge("flex flex-col space-y-1")}
+
                         >
                             <LabelledInput
                                 label="Username"
@@ -198,12 +202,13 @@ export const Login = ({
                             <LabelledInput
                                 label="Account"
                                 idinput="account-input"
-                                updateFunc={(data: string) => { setAccount(data) }}
+                                updateFunc={(data: string) => { setAccount(data) }}                               
                             />
                         </div>
                         <Button
                             label="Login"
                             type="submit"
+                            role="button"
                             onClick={async () => {
                                 await handleUserPassSubmit(
                                     username,
@@ -212,8 +217,9 @@ export const Login = ({
                                     account
                                 )
                             }}
-                        />
+                        />             
                     </fieldset>
+                    </form>
                     <fieldset
                         className={twMerge(
                             "mx-2 md:mx-10",
@@ -229,7 +235,7 @@ export const Login = ({
                         />
                     </fieldset>
                 </div>
-            </form >
+            </div >
         </div >
     )
 }

--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -1119,6 +1119,12 @@ html {
   margin-left: calc(0.25rem * calc(1 - var(--tw-space-x-reverse)));
 }
 
+.space-x-12 > :not([hidden]) ~ :not([hidden]) {
+  --tw-space-x-reverse: 0;
+  margin-right: calc(3rem * var(--tw-space-x-reverse));
+  margin-left: calc(3rem * calc(1 - var(--tw-space-x-reverse)));
+}
+
 .space-x-2 > :not([hidden]) ~ :not([hidden]) {
   --tw-space-x-reverse: 0;
   margin-right: calc(0.5rem * var(--tw-space-x-reverse));
@@ -1725,6 +1731,10 @@ html {
   padding-top: 0.5rem;
 }
 
+.pb-1 {
+  padding-bottom: 0.25rem;
+}
+
 .text-left {
   text-align: left;
 }
@@ -2206,6 +2216,11 @@ html {
   color: rgb(37 99 235 / var(--tw-text-opacity));
 }
 
+.hover\:text-blue-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(29 78 216 / var(--tw-text-opacity));
+}
+
 .hover\:text-gray-400:hover {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity));
@@ -2219,11 +2234,6 @@ html {
 .hover\:text-red-700:hover {
   --tw-text-opacity: 1;
   color: rgb(185 28 28 / var(--tw-text-opacity));
-}
-
-.hover\:text-blue-700:hover {
-  --tw-text-opacity: 1;
-  color: rgb(29 78 216 / var(--tw-text-opacity));
 }
 
 .hover\:underline:hover {
@@ -2560,6 +2570,11 @@ html {
     color: rgb(147 197 253 / var(--tw-text-opacity));
   }
 
+  .dark\:text-blue-400 {
+    --tw-text-opacity: 1;
+    color: rgb(96 165 250 / var(--tw-text-opacity));
+  }
+
   .dark\:text-emerald-300 {
     --tw-text-opacity: 1;
     color: rgb(110 231 183 / var(--tw-text-opacity));
@@ -2628,16 +2643,6 @@ html {
   .dark\:text-white {
     --tw-text-opacity: 1;
     color: rgb(255 255 255 / var(--tw-text-opacity));
-  }
-
-  .dark\:text-red-200 {
-    --tw-text-opacity: 1;
-    color: rgb(254 202 202 / var(--tw-text-opacity));
-  }
-
-  .dark\:text-blue-400 {
-    --tw-text-opacity: 1;
-    color: rgb(96 165 250 / var(--tw-text-opacity));
   }
 
   .dark\:ring-gray-900 {
@@ -2725,14 +2730,14 @@ html {
     background-color: rgb(17 24 39 / var(--tw-bg-opacity));
   }
 
-  .dark\:hover\:text-blue-400:hover {
-    --tw-text-opacity: 1;
-    color: rgb(96 165 250 / var(--tw-text-opacity));
-  }
-
   .dark\:hover\:text-blue-300:hover {
     --tw-text-opacity: 1;
     color: rgb(147 197 253 / var(--tw-text-opacity));
+  }
+
+  .dark\:hover\:text-blue-400:hover {
+    --tw-text-opacity: 1;
+    color: rgb(96 165 250 / var(--tw-text-opacity));
   }
 
   .dark\:focus\:ring-blue-800:focus {
@@ -3055,6 +3060,10 @@ html {
 
   .lg\:w-48 {
     width: 12rem;
+  }
+
+  .lg\:w-80 {
+    width: 20rem;
   }
 
   .lg\:w-96 {


### PR DESCRIPTION
This commit adds a few improvements to the site header :
- The menu items are reorganised and split into items and sub-items, the items are DIDs, RSEs, Rules and more symbolized by **...**
- The` switch-account` feature is connected to the list items in the active accounts section
- The `get-site-header` feature is connected to get the list of available accounts and the currently active account and show them in the account drop down
- The `logout` feature is connected to the logout button
- The default UserPass login is now a form and can be submitted using the Enter key

