### PR TITLE
Rewrite the userpass login functionality to extend from Base

### DIFF
--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -1998,6 +1998,11 @@ html {
   color: rgb(241 245 249 / var(--tw-text-opacity));
 }
 
+.text-text-1000 {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity));
+}
+
 .text-text-200 {
   --tw-text-opacity: 1;
   color: rgb(226 232 240 / var(--tw-text-opacity));
@@ -2036,11 +2041,6 @@ html {
 .text-zinc-500 {
   --tw-text-opacity: 1;
   color: rgb(113 113 122 / var(--tw-text-opacity));
-}
-
-.text-text-1000 {
-  --tw-text-opacity: 1;
-  color: rgb(0 0 0 / var(--tw-text-opacity));
 }
 
 .underline {

--- a/src/lib/core/dto/account-dto.ts
+++ b/src/lib/core/dto/account-dto.ts
@@ -11,10 +11,9 @@ export type TAccountAttributes = TAccountAttribute[]
 /**
  * Account Attributes DTO to store the response from /accounts/<account>/attr/ endpoint
  */
-export type AccountAttributesDTO = {
+export type AccountAttributesDTO = BaseDTO & {
     account: string,
     attributes: TAccountAttributes,
-    status: 'OK' | 'ERROR'
     error?: AccountAttributeErrorTypesDTO
     message?: string 
 }

--- a/src/lib/core/dto/userpassLoginV2-dto.ts
+++ b/src/lib/core/dto/userpassLoginV2-dto.ts
@@ -1,6 +1,5 @@
-import { BaseDTO } from "@/lib/sdk/dto"
-
-export interface UserPassLoginAuthServerDTO extends BaseDTO {
+export type UserPassLoginV2AuthServerDTO = {
+    status: 'success' | 'error'
     statusCode: number
     message: string
     authToken: string

--- a/src/lib/core/port/primary/userpass-login-V2-ports.ts
+++ b/src/lib/core/port/primary/userpass-login-V2-ports.ts
@@ -1,0 +1,12 @@
+import { BaseAuthenticatedInputPort, BaseOutputPort } from "@/lib/sdk/primary-ports";
+import { UserpassLoginV2Error, UserpassLoginV2Request, UserpassLoginV2Response } from "@/lib/core/usecase-models/userpass-login-V2-usecase-models";
+
+/**
+ * @interface UserpassLoginV2InputPort representing the UserpassLoginV2 usecase.
+ */
+export interface UserpassLoginV2InputPort extends BaseAuthenticatedInputPort<UserpassLoginV2Request> { }
+
+/**
+ * @interface UserpassLoginV2OutputPort representing the UserpassLoginV2 presenter.
+ */
+export interface UserpassLoginV2OutputPort extends BaseOutputPort<UserpassLoginV2Response, UserpassLoginV2Error> { }

--- a/src/lib/core/port/secondary/userpass-login-V2-gateway-output-port.ts
+++ b/src/lib/core/port/secondary/userpass-login-V2-gateway-output-port.ts
@@ -1,0 +1,5 @@
+import { UserPassLoginV2AuthServerDTO } from "../../dto/userpassLoginV2-dto";
+
+export default interface AuthServerGatewayOutputPort {
+    getuserpassLoginV2(username: string, password: string, account: string, vo: string): Promise<UserPassLoginV2AuthServerDTO>
+}

--- a/src/lib/core/use-case/userpass-login-v2/pipeline-element-get-account-attribute.ts
+++ b/src/lib/core/use-case/userpass-login-v2/pipeline-element-get-account-attribute.ts
@@ -1,0 +1,69 @@
+import { BasePostProcessingPipelineElement } from "@/lib/sdk/postprocessing-pipeline-elements"
+import { AccountAttributesDTO } from "../../dto/account-dto";
+import { Role } from "../../entity/auth-models";
+import AccountGatewayOutputPort from "../../port/secondary/account-gateway-output-port";
+import { UserpassLoginV2Error, UserpassLoginV2Request, UserpassLoginV2Response } from "../../usecase-models/userpass-login-V2-usecase-models";
+
+/**
+ * Pipeline element of the UserpassLoginV2UseCase to get account attributes 
+ */
+export default class GetAccountAttributePipelineElement extends BasePostProcessingPipelineElement<UserpassLoginV2Request, UserpassLoginV2Response, UserpassLoginV2Error, AccountAttributesDTO> {
+    constructor(private gateway: AccountGatewayOutputPort) {
+        super();
+    }
+
+    async makeGatewayRequest(requestModel: UserpassLoginV2Request, responseModel: UserpassLoginV2Response): Promise<AccountAttributesDTO> {
+
+        try {
+            const { account } = requestModel;
+            const rucioAuthToken = responseModel.rucioAuthToken
+            const accountAttrs: AccountAttributesDTO = await this.gateway.listAccountAttributes(account, rucioAuthToken)
+            return accountAttrs
+        } catch (error: AccountAttributesDTO | any) {
+            const errorDTO: AccountAttributesDTO = { account: 'undefined', status: 'error', attributes: [] };
+            errorDTO.errorCode = 500;
+            errorDTO.errorName = 'Gateway Error';
+            errorDTO.errorMessage = (error as Error).message;
+            responseModel.role = undefined
+            return errorDTO;
+        }
+
+    }
+
+    handleGatewayError(error: AccountAttributesDTO): UserpassLoginV2Error {
+        const errorModel: UserpassLoginV2Error = {
+            status: 'error',
+            message: error.message ? error.message : 'no error message available',
+            code: 400,
+            name: 'Gateway error',
+            type: 'ACCOUNT_ATTRIBUTE_ERROR',
+
+        }
+        return errorModel;
+    }
+
+    transformResponseModel(responseModel: UserpassLoginV2Response, dto: AccountAttributesDTO): UserpassLoginV2Response | UserpassLoginV2Error {
+
+        dto.attributes.forEach((attr) => {
+            if (attr.key == 'admin' && attr.value == 'True') {
+                responseModel.role = Role.ADMIN;
+            }
+            else if (attr.key.startsWith('country-')) {
+                responseModel.country = attr.key.split('-')[1];
+                if (attr.value == 'admin') {
+                    responseModel.countryRole = Role.ADMIN;
+                } else if (attr.value == 'user') {
+                    responseModel.countryRole = Role.USER;
+                } else {
+                    responseModel.countryRole = undefined;
+                }
+            } else {
+                responseModel.role = Role.USER;
+            }
+        })
+
+        responseModel.status = 'success'
+
+        return responseModel
+    }
+}

--- a/src/lib/core/use-case/userpass-login-v2/userpass-login-V2-usecase.ts
+++ b/src/lib/core/use-case/userpass-login-v2/userpass-login-V2-usecase.ts
@@ -1,0 +1,118 @@
+import { injectable } from "inversify";
+import { BaseSingleEndpointPostProcessingPipelineUseCase} from "@/lib/sdk/usecase"
+import { AuthenticatedRequestModel } from "@/lib/sdk/usecase-models";
+import { UserpassLoginV2Error, UserpassLoginV2Request, UserpassLoginV2Response } from "@/lib/core/usecase-models/userpass-login-V2-usecase-models";
+import { UserpassLoginV2InputPort, type UserpassLoginV2OutputPort } from "@/lib/core/port/primary/userpass-login-V2-ports";
+import { UserPassLoginV2AuthServerDTO } from "@/lib/core/dto/userpassLoginV2-dto";
+import type AuthServerGatewayOutputPort from "@/lib/core/port/secondary/auth-server-gateway-output-port";
+import { UserPassLoginAuthServerDTO } from "../../dto/auth-server-dto";
+import GetAccountAttributePipelineElement from "./pipeline-element-get-account-attribute";
+import type AccountGatewayOutputPort from "../../port/secondary/account-gateway-output-port";
+
+/**
+ * UseCase for UserPassLoginV2 workflow.
+ */
+@injectable()
+export default class UserpassLoginV2UseCase extends BaseSingleEndpointPostProcessingPipelineUseCase<UserpassLoginV2Request, UserpassLoginV2Response, UserpassLoginV2Error, UserPassLoginAuthServerDTO> implements UserpassLoginV2InputPort {
+    validateFinalResponseModel(responseModel: UserpassLoginV2Response): { isValid: boolean; errorModel?: UserpassLoginV2Error | undefined; } {
+        return {
+            isValid: true,
+        }
+    }
+
+    private requestModel: UserpassLoginV2Request | undefined
+    constructor(
+        protected readonly presenter: UserpassLoginV2OutputPort,
+        private readonly gateway: AuthServerGatewayOutputPort,
+        readonly accountGateway: AccountGatewayOutputPort,
+    ) {
+        const pipelineElements = new GetAccountAttributePipelineElement(accountGateway);
+        super(presenter, [pipelineElements]);
+        this.gateway = gateway;
+        this.requestModel = undefined;
+    }
+
+    validateRequestModel(requestModel: AuthenticatedRequestModel<UserpassLoginV2Request>): UserpassLoginV2Error | undefined {
+        // set the request model here
+        this.requestModel = requestModel;
+        return undefined
+    }
+
+    async makeGatewayRequest(requestModel: AuthenticatedRequestModel<UserpassLoginV2Request>): Promise<UserPassLoginV2AuthServerDTO> {
+        const { username, password, account, vo } = requestModel;
+        const dto: UserPassLoginV2AuthServerDTO = await this.gateway.userpassLogin(username, password, account, vo);
+        return dto;
+
+    }
+    handleGatewayError(error: UserPassLoginV2AuthServerDTO): UserpassLoginV2Error {
+        let error_type: 'AUTH_SERVER_CONFIGURATION_ERROR' | 'AUTH_SERVER_SIDE_ERROR' | 'INVALID_CREDENTIALS' | 'UNKNOWN_ERROR' | 'ACCOUNT_ATTRIBUTE_ERROR' | 'UNDEFINED_REQUEST_MODEL'
+        switch (error.statusCode) {
+            case 500: error_type = 'AUTH_SERVER_SIDE_ERROR'; break;
+            case 502: error_type = 'AUTH_SERVER_SIDE_ERROR'; break;
+            case 503: error_type = 'AUTH_SERVER_CONFIGURATION_ERROR'; break;
+            case 401: error_type = 'INVALID_CREDENTIALS'; break;
+            default: error_type = 'UNKNOWN_ERROR'; break;
+        }
+        const errorModel: UserpassLoginV2Error = {
+            name: `Gateway Error`,
+            type: error_type,
+            message: error.message ? error.message : 'Gateway Error',
+            status: "error",
+            code: error.statusCode,
+
+        }
+
+        return errorModel
+
+
+    }
+
+    processDTO(dto: UserPassLoginV2AuthServerDTO): { data: UserpassLoginV2Response | UserpassLoginV2Error; status: "success" | "error"; } {
+
+        if (this.requestModel === undefined) {
+            return {
+                status: "error",
+                data: {
+                    name: 'Invalid Login',
+                    status: 'error',
+                    type: 'UNDEFINED_REQUEST_MODEL',
+                    message: 'The request model is undefined',
+                    code: 400,
+
+                } as UserpassLoginV2Error
+            }
+        }
+        if (dto.statusCode == 200) {
+            const responseModel: UserpassLoginV2Response = {
+                status: "success",
+                rucioIdentity: this.requestModel.username,
+                rucioAccount: dto.account,
+                rucioAuthToken: dto.authToken,
+                rucioAuthTokenExpires: dto.authTokenExpires,
+                vo: this.requestModel.vo,
+                role: undefined,
+                country: undefined,
+                countryRole: undefined
+            }
+            return {
+                status: 'success',
+                data: responseModel,
+            }
+
+        }
+
+        const errorModel: UserpassLoginV2Error = {
+            name: 'error',
+            type: 'UNKNOWN_ERROR',
+            message: dto.message,
+            status: "error",
+            code: dto.statusCode,
+
+        }
+
+        return {
+            status: 'error',
+            data: errorModel,
+        }
+    }
+}

--- a/src/lib/core/usecase-models/userpass-login-V2-usecase-models.ts
+++ b/src/lib/core/usecase-models/userpass-login-V2-usecase-models.ts
@@ -1,0 +1,51 @@
+import { BaseErrorResponseModel, BaseResponseModel } from "@/lib/sdk/usecase-models"
+import { Role } from "../entity/auth-models";
+
+
+/**
+* @interface UserpassLoginV2Request represents the RequestModel for userpass_login_V2 usecase
+*/
+export interface UserpassLoginV2Request {
+    username: string;
+    password: string;
+    account: string;
+    vo: string;
+    redirectTo: string;
+}
+
+
+
+/** 
+* @interface UserpassLoginV2Response represents the ResponseModel for userpass_login_V2 usecase
+*/
+
+export interface UserpassLoginV2Response extends BaseResponseModel {
+    rucioIdentity: string;
+    rucioAccount: string;
+    vo: string;
+    rucioAuthToken: string;
+    rucioAuthTokenExpires: string;
+    role: Role | undefined;
+    // ATLAS specific, used for country-{} account attribute in Rucio
+    country?: string;
+    countryRole?: Role;
+}
+
+/**
+* @interface UserpassLoginV2Error represents the ErrorModel for userpass_login_V2 usecase
+* add link to output port later
+* @property {string} type - Type of error: 
+* 'AUTH_SERVER_CONFIGURATION_ERROR':If webui's environment file is missing the configuration variable for rucio auth server
+* 'AUTH_SERVER_SIDE_ERROR': If rucio auth server returns an error
+* 'INVALID_CREDENTIALS': If the user entered invalid credentials
+* 'ACCOUNT_ATTRIBUTE_ERROR' : If the error occured during the fetch of the account attributes
+* 'UNDEFINED_REQUEST_MODEL' : If the error is caused by an undefined request model
+* 'UNKNOWN_ERROR': If the error is not one of the above
+* @property {string} message - Error message
+*/
+
+export interface UserpassLoginV2Error extends BaseErrorResponseModel {
+    type: 'AUTH_SERVER_CONFIGURATION_ERROR' | 'AUTH_SERVER_SIDE_ERROR' | 'INVALID_CREDENTIALS' | 'UNKNOWN_ERROR' | 'ACCOUNT_ATTRIBUTE_ERROR' | 'UNDEFINED_REQUEST_MODEL';
+    message: string;
+}
+

--- a/src/lib/infrastructure/auth/session-utils.ts
+++ b/src/lib/infrastructure/auth/session-utils.ts
@@ -211,7 +211,9 @@ export async function setActiveSessionUser(
 ) {
     await addOrUpdateSessionUser(session, sessionUser, false)
     session.user = sessionUser
-    saveSession ? await session.save() : null
+    if(saveSession) {
+        await session.save()
+    }
 }
 
 /**

--- a/src/lib/infrastructure/controller/userpass-login-V2-controller.ts
+++ b/src/lib/infrastructure/controller/userpass-login-V2-controller.ts
@@ -1,0 +1,37 @@
+import { injectable, inject } from "inversify";
+import { NextApiResponse } from "next";
+import { BaseController, TSimpleControllerParameters } from "@/lib/sdk/controller";
+import { UserpassLoginV2Request } from "@/lib/core/usecase-models/userpass-login-V2-usecase-models";
+import { UserpassLoginV2InputPort } from "@/lib/core/port/primary/userpass-login-V2-ports";
+import USECASE_FACTORY from "@/lib/infrastructure/ioc/ioc-symbols-usecase-factory";
+import { IronSession } from "iron-session";
+
+export type UserpassLoginV2ControllerParameters = TSimpleControllerParameters & {
+  username: string
+  password: string
+  vo: string
+  account?: string
+  redirectTo?: string
+}
+
+@injectable()
+class UserpassLoginV2Controller extends BaseController<UserpassLoginV2ControllerParameters, UserpassLoginV2Request> {
+  public constructor(
+    @inject(USECASE_FACTORY.USERPASS_LOGIN_V2) useCaseFactory: (response: NextApiResponse, session?: IronSession) => UserpassLoginV2InputPort,
+  ) {
+    super(useCaseFactory)
+  }
+  prepareRequestModel(parameters: UserpassLoginV2ControllerParameters): UserpassLoginV2Request {
+    return {
+      username: parameters.username,
+      password: parameters.password,
+      vo: parameters.vo,
+      account: parameters.account,
+      redirectTo: parameters.redirectTo,
+    } as UserpassLoginV2Request
+  }
+}
+
+export default UserpassLoginV2Controller;
+
+

--- a/src/lib/infrastructure/data/view-model/UserpassloginV2.ts
+++ b/src/lib/infrastructure/data/view-model/UserpassloginV2.ts
@@ -1,0 +1,54 @@
+import { AuthType, Role, SessionUser } from "@/lib/core/entity/auth-models";
+
+export interface UserpassLoginV2ViewModel {
+    status: 'success' | 'error' | 'multiple_accounts' | 'cannot_determine_account_role';
+    message?: string;
+    error_cause?: string;
+    redirectTo?: string;
+    rucioIdentity: string;
+    rucioAccount: string;
+    rucioMultiAccount?: string;
+    rucioAuthType: AuthType | '';
+    rucioAuthToken: string;
+    rucioAuthTokenExpires: string;
+    role: Role | undefined;
+    country?: string;
+    countryRole?: Role;
+    sessionUser?: SessionUser,
+}
+
+
+export interface x509AuthRequestHeadersV2 {
+    'X-Rucio-VO': string;
+    'X-Rucio-Allow-Return-Multiple-Accounts': boolean;
+    'X-Rucio-AppID': string
+    'X-Rucio-Account'?: string;
+
+}
+
+
+export const getEmptyUserpassLoginV2ViewModel = (): UserpassLoginV2ViewModel => {
+
+    return {
+        status: 'error',
+        rucioIdentity: '',
+        rucioAccount: '',
+        rucioAuthType: '',
+        rucioAuthToken: '',
+        rucioAuthTokenExpires: '',
+        role: undefined,
+
+    } as UserpassLoginV2ViewModel
+
+}
+
+
+export const getEmptyx509AuthRequestHeadersV2 = (): x509AuthRequestHeadersV2 => {
+
+    return {
+        'X-Rucio-VO': '',
+        'X-Rucio-Allow-Return-Multiple-Accounts': false,
+        'X-Rucio-AppID': 'rucio-webui',
+    } as x509AuthRequestHeadersV2
+
+}

--- a/src/lib/infrastructure/gateway/account-gateway/account-gateway.ts
+++ b/src/lib/infrastructure/gateway/account-gateway/account-gateway.ts
@@ -40,7 +40,7 @@ export default class RucioAccountGateway implements AccountGatewayOutputPort {
 
     generateErrorResponse(error: AccountAttributeErrorTypesDTO, account: string, message: string): AccountAttributesDTO {
         return {
-            status: 'ERROR',
+            status: 'error',
             error: error,
             account: account,
             attributes: {},
@@ -110,7 +110,7 @@ export default class RucioAccountGateway implements AccountGatewayOutputPort {
 
 
         const dto: AccountAttributesDTO = {
-            status: 'OK',
+            status: 'success',
             account: account,
             attributes: data,
         }

--- a/src/lib/infrastructure/gateway/rucio-auth-server.ts
+++ b/src/lib/infrastructure/gateway/rucio-auth-server.ts
@@ -50,6 +50,7 @@ class RucioAuthServer implements AuthServerGatewayOutputPort {
                 authHost === ''
             ) {
                 dto = {
+                    status: "error",
                     statusCode: 503,
                     message:
                         'Rucio Auth Server is not configured in the WebUI settings',
@@ -59,6 +60,7 @@ class RucioAuthServer implements AuthServerGatewayOutputPort {
                 }
             } else {
                 dto = {
+                    status: "error",
                     statusCode: 500,
                     message:
                         'Rucio Auth Server error: fetch failed. Reason: ' +
@@ -72,6 +74,7 @@ class RucioAuthServer implements AuthServerGatewayOutputPort {
         }
         if (!response) {
             dto = {
+                status: "error",
                 statusCode: 502,
                 message: 'Rucio Auth Server did not return a response',
                 account: '',
@@ -83,6 +86,7 @@ class RucioAuthServer implements AuthServerGatewayOutputPort {
 
         if (response.status === 401) {
             dto = {
+                status: "error",
                 statusCode: response.status,
                 message: 'Invalid credentials',
                 account: '',
@@ -94,6 +98,7 @@ class RucioAuthServer implements AuthServerGatewayOutputPort {
 
         if (response.status === 200) {
             let dto: UserPassLoginAuthServerDTO = {
+                status: "success",
                 statusCode: response.status,
                 message: '',
                 account: '',

--- a/src/lib/infrastructure/ioc/container-config.ts
+++ b/src/lib/infrastructure/ioc/container-config.ts
@@ -62,6 +62,7 @@ import RuleGatewayOutputPort from "@/lib/core/port/secondary/rule-gateway-output
 import RuleGateway from "../gateway/rule-gateway/rule-gateway";
 import ListAccountRSEQuotasFeature from "./features/list-account-rse-quotas-feature";
 import GetAccountInfoFeature from "./features/get-account-info-feature";
+import UserpassLoginV2Feature from "./features/userpass-login-V2-feature";
 
 
 /**
@@ -86,6 +87,7 @@ loadFeaturesSync(appContainer, [
 // Load Auth Features/Usecases
 loadFeaturesSync(appContainer, [
     new LoginConfigFeature(appContainer),
+    new UserpassLoginV2Feature(appContainer)
 ])
 
 // Load Features

--- a/src/lib/infrastructure/ioc/features/userpass-login-V2-feature.ts
+++ b/src/lib/infrastructure/ioc/features/userpass-login-V2-feature.ts
@@ -1,0 +1,45 @@
+import AccountGatewayOutputPort from "@/lib/core/port/secondary/userpass-login-V2-gateway-output-port"
+import { UserpassLoginV2Error, UserpassLoginV2Request, UserpassLoginV2Response } from "@/lib/core/usecase-models/userpass-login-V2-usecase-models"
+import { UserpassLoginV2ControllerParameters } from "@/lib/infrastructure/controller/userpass-login-V2-controller"
+import UserpassLoginV2Controller from "@/lib/infrastructure/controller/userpass-login-V2-controller"
+import { UserpassLoginV2ViewModel } from "@/lib/infrastructure/data/view-model/UserpassloginV2"
+import { BaseFeature, IOCSymbols } from "@/lib/sdk/ioc-helpers"
+import GATEWAYS from "@/lib/infrastructure/ioc/ioc-symbols-gateway"
+import CONTROLLERS from "@/lib/infrastructure/ioc/ioc-symbols-controllers"
+import INPUT_PORT from "@/lib/infrastructure/ioc/ioc-symbols-input-port"
+import USECASE_FACTORY from "@/lib/infrastructure/ioc/ioc-symbols-usecase-factory"
+import { Container } from 'inversify'
+import UserpassLoginV2UseCase from "@/lib/core/use-case/userpass-login-v2/userpass-login-V2-usecase"
+import UserpassLoginV2Presenter from "@/lib/infrastructure/presenter/userpass-login-V2-presenter"
+import AuthServerGatewayOutputPort from "@/lib/core/port/secondary/auth-server-gateway-output-port"
+
+export default class UserpassLoginV2Feature extends BaseFeature<
+    UserpassLoginV2ControllerParameters,
+    UserpassLoginV2Request,
+    UserpassLoginV2Response,
+    UserpassLoginV2Error,
+    UserpassLoginV2ViewModel
+> {
+    constructor(appContainer: Container) {
+        const userpassLoginV2Gateway = appContainer.get<AuthServerGatewayOutputPort>(GATEWAYS.AUTH_SERVER)
+        const accountGateway = appContainer.get<AccountGatewayOutputPort>(GATEWAYS.ACCOUNT)
+        const symbols: IOCSymbols = {
+            CONTROLLER: CONTROLLERS.USERPASS_LOGIN_V2,
+            USECASE_FACTORY: USECASE_FACTORY.USERPASS_LOGIN_V2,
+            INPUT_PORT: INPUT_PORT.USERPASS_LOGIN_V2,
+        }
+        const useCaseConstructorArgs = [
+            userpassLoginV2Gateway,
+            accountGateway
+        ]
+        super(
+            'UserpassLoginV2',
+            UserpassLoginV2Controller,
+            UserpassLoginV2UseCase,
+            useCaseConstructorArgs,
+            UserpassLoginV2Presenter,
+            true,
+            symbols
+        )
+    }
+}

--- a/src/lib/infrastructure/ioc/ioc-symbols-controllers.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-controllers.ts
@@ -29,6 +29,7 @@ const CONTROLLERS = {
     STREAM: Symbol.for("StreamController"),
     SWITCH_ACCOUNT: Symbol.for("SwitchAccountController"),
     USERPASS_LOGIN: Symbol.for("UserPassLoginController"),
+    USERPASS_LOGIN_V2: Symbol.for("UserpassLoginV2Controller"),
 }
 
 export default CONTROLLERS;

--- a/src/lib/infrastructure/ioc/ioc-symbols-input-port.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-input-port.ts
@@ -28,6 +28,7 @@ const INPUT_PORT = {
     SWITCH_ACCOUNT: Symbol.for("SwitchAccountInputPort"),
     TEST: Symbol.for("TestInputPort"),
     USERPASS_LOGIN: Symbol.for("UserPassLoginInputPort"),
+    USERPASS_LOGIN_V2: Symbol.for("UserpassLoginV2InputPort"),
 }
 
 export default INPUT_PORT;

--- a/src/lib/infrastructure/ioc/ioc-symbols-usecase-factory.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-usecase-factory.ts
@@ -29,6 +29,7 @@ const USECASE_FACTORY = {
     STREAM: Symbol.for("Factory<StreamUseCase>"),
     SWITCH_ACCOUNT: Symbol.for("Factory<SwitchAccountUseCase>"),
     USERPASS_LOGIN: Symbol.for("Factory<UserPassLoginUseCase>"),
+    USERPASS_LOGIN_V2: Symbol.for("Factory<UserPassLoginV2UseCase>"),
 
 }
 

--- a/src/lib/infrastructure/presenter/userpass-login-V2-presenter.ts
+++ b/src/lib/infrastructure/presenter/userpass-login-V2-presenter.ts
@@ -1,0 +1,136 @@
+import { BasePresenter } from '@/lib/sdk/presenter'
+import { UserpassLoginV2Error, UserpassLoginV2Response } from '@/lib/core/usecase-models/userpass-login-V2-usecase-models'
+import { getEmptyUserpassLoginV2ViewModel, UserpassLoginV2ViewModel } from '@/lib/infrastructure/data/view-model/UserpassloginV2'
+import { NextApiResponse } from 'next'
+import { UserpassLoginV2OutputPort } from '@/lib/core/port/primary/userpass-login-V2-ports'
+import { IronSession } from 'iron-session'
+import { AuthType, Role, SessionUser } from '@/lib/core/entity/auth-models'
+import { setActiveSessionUser } from '../auth/session-utils'
+
+/**
+ * Provides an implementation of the {@link UserpassLoginV2OutputPort} interface.
+ * This implementation is injected into the {@link UserpassLoginV2UseCase} via the IoC container.
+ */
+export default class UserpassLoginV2Presenter
+    extends BasePresenter<
+        UserpassLoginV2Response,
+        UserpassLoginV2Error,
+        UserpassLoginV2ViewModel
+    >
+    implements UserpassLoginV2OutputPort {
+
+    constructor(response: NextApiResponse, session?: IronSession | undefined) {
+        super(response, session)
+    }
+
+    async processSession(session: IronSession, viewModel: UserpassLoginV2ViewModel, status: number): Promise<void> {
+        if (session != undefined && viewModel.sessionUser != undefined) {
+            await setActiveSessionUser(session, viewModel.sessionUser)
+        }
+    }
+
+    convertResponseModelToViewModel(responseModel: UserpassLoginV2Response): {
+        viewModel: UserpassLoginV2ViewModel
+        status: number
+    } {
+        const viewModel: UserpassLoginV2ViewModel = {
+            rucioIdentity: responseModel.rucioIdentity,
+            rucioAccount: responseModel.rucioAccount,
+            rucioAuthType: AuthType.USERPASS,
+            rucioAuthToken: responseModel.rucioAuthToken,
+            status: 'success',
+            role: Role.USER,
+            rucioAuthTokenExpires: responseModel.rucioAuthTokenExpires,
+        }
+
+        const role = responseModel.role
+        if (role) {
+            viewModel.role = role
+        } else {
+            viewModel.role = Role.USER
+        }
+
+        const sessionUser: SessionUser = {
+            rucioIdentity: responseModel.rucioIdentity,
+            rucioAccount: responseModel.rucioAccount,
+            rucioAuthType: AuthType.USERPASS,
+            rucioAuthToken: responseModel.rucioAuthToken,
+            rucioOIDCProvider: null,
+            rucioVO: responseModel.vo,
+            role: viewModel.role || Role.USER,
+            isLoggedIn: true,
+            rucioAuthTokenExpires: responseModel.rucioAuthTokenExpires,
+        }
+
+        viewModel.sessionUser = sessionUser
+
+        if (responseModel.country) {
+            viewModel.country = responseModel.country
+            sessionUser.country = responseModel.country
+        }
+        if (responseModel.countryRole) {
+            viewModel.countryRole = responseModel.countryRole
+            sessionUser.countryRole = responseModel.countryRole
+        }
+
+        return { viewModel, status: 200 }
+    }
+
+    convertErrorModelToViewModel(errorModel: UserpassLoginV2Error): {
+        viewModel: UserpassLoginV2ViewModel
+        status: number
+    } {
+        const viewModel: UserpassLoginV2ViewModel =
+            getEmptyUserpassLoginV2ViewModel()
+
+        if (errorModel.type === 'AUTH_SERVER_CONFIGURATION_ERROR') {
+            viewModel.message = "There is a problem with the configuration of the authentication server, please contact support"
+            viewModel.error_cause = errorModel.type
+            return {
+                status: 503,
+                viewModel: viewModel,
+            }
+        }
+        else if (errorModel.type === 'AUTH_SERVER_SIDE_ERROR') {
+            viewModel.message = 'There is a problem with the authentication server, please contact support'
+            viewModel.error_cause = errorModel.type
+            return {
+                status: 502,
+                viewModel: viewModel,
+            }
+        }
+        else if (errorModel.type === 'INVALID_CREDENTIALS') {
+            viewModel.message = 'Invalid username, password or account, please check your credentials and try again'
+            viewModel.error_cause = errorModel.type
+            return {
+                status: 401,
+                viewModel: viewModel,
+            }
+        }
+        else if (errorModel.type === 'UNKNOWN_ERROR') {
+            viewModel.message = 'An unknown error occurred, please try again, if the error persists contact support.'
+            viewModel.error_cause = errorModel.type
+            return {
+                status: 400,
+                viewModel: viewModel,
+            }
+        }
+        else if (errorModel.type === 'UNDEFINED_REQUEST_MODEL') {
+            viewModel.message = 'The request model is undefined, please contact support'
+            viewModel.error_cause = errorModel.type
+            return {
+                status: 400,
+                viewModel: viewModel,
+            }
+        }
+
+        // gateway errors
+        const message = errorModel.message || errorModel.name
+        viewModel.message = message
+        const errorCode = errorModel.code || 500
+        return {
+            status: errorCode,
+            viewModel: viewModel,
+        }
+    }
+}

--- a/src/lib/sdk/presenter.ts
+++ b/src/lib/sdk/presenter.ts
@@ -44,12 +44,27 @@ export abstract class BasePresenter<TResponseModel, TErrorModel, TViewModel>
     }
 
     /**
+     * Process the session, set active current sessionUser
+     * @param session The current session to process
+     * @param viewModel The current viewmodel
+     * @param status The current status
+     * @returns A promise that resolves to the session
+     */
+    async processSession(session: IronSession, viewModel: TViewModel, status: number ) : Promise<void> {
+        return Promise.resolve()
+    }
+
+    /**
      * Presents a successful response model.
      * @param responseModel The response model to present.
      * @returns A promise that resolves to the view model.
      */
     async presentSuccess(responseModel: TResponseModel): Promise<void> {
-        const { viewModel, status } = this.convertResponseModelToViewModel(responseModel)
+        const { viewModel, status } =  this.convertResponseModelToViewModel(responseModel)
+        if(this.session) {
+            await this.processSession(this.session, viewModel, status)
+            await this.session.save()
+        }
         await this.response.status(status).json(viewModel)
         return Promise.resolve()
     }
@@ -60,7 +75,7 @@ export abstract class BasePresenter<TResponseModel, TErrorModel, TViewModel>
      * @returns A promise that resolves to the view model.
      */
     async presentError(errorModel: TErrorModel): Promise<void> {
-        const { status, viewModel } = this.convertErrorModelToViewModel(errorModel)
+        const { status, viewModel } = await this.convertErrorModelToViewModel(errorModel)
         await this.response.status(status).json(viewModel)
         return Promise.resolve()
     }

--- a/src/pages/api/auth/userpass-login-V2.ts
+++ b/src/pages/api/auth/userpass-login-V2.ts
@@ -1,0 +1,29 @@
+import { withSessionRoute } from "@/lib/infrastructure/auth/session-utils";
+import { UserpassLoginV2ControllerParameters } from "@/lib/infrastructure/controller/userpass-login-V2-controller";
+import appContainer from "@/lib/infrastructure/ioc/container-config";
+import { UserpassLoginV2Request } from "@/lib/core/usecase-models/userpass-login-V2-usecase-models";
+import CONTROLLERS from "@/lib/infrastructure/ioc/ioc-symbols-controllers";
+import { BaseController } from "@/lib/sdk/controller";
+import { NextApiRequest, NextApiResponse } from "next";
+
+
+async function userpassLoginV2(req: NextApiRequest, res: NextApiResponse){
+
+    const UserpassV2controller = appContainer.get<BaseController<UserpassLoginV2ControllerParameters, UserpassLoginV2Request>>(CONTROLLERS.USERPASS_LOGIN_V2)
+    const redirectTo = '/dashboard'
+    const { username, password, account, vo } = req.body
+    const controllerParameters: UserpassLoginV2ControllerParameters = {
+        response: res,
+        username: username,
+        password: password,
+        vo: vo,
+        account: account,
+        redirectTo: redirectTo,
+        session: req.session,
+    }
+    await UserpassV2controller.execute(controllerParameters);
+
+}
+
+export default withSessionRoute(userpassLoginV2)
+

--- a/test/api/auth/userpassV2/userpass-login-V2-2.test.ts
+++ b/test/api/auth/userpassV2/userpass-login-V2-2.test.ts
@@ -1,0 +1,118 @@
+import appContainer from "@/lib/infrastructure/ioc/container-config";
+import { UserpassLoginV2Request } from "@/lib/core/usecase-models/userpass-login-V2-usecase-models";
+import { UserpassLoginV2ControllerParameters } from "@/lib/infrastructure/controller/userpass-login-V2-controller"
+import CONTROLLERS from "@/lib/infrastructure/ioc/ioc-symbols-controllers"
+import { BaseController } from "@/lib/sdk/controller";
+import { UserpassLoginV2ViewModel } from "@/lib/infrastructure/data/view-model/UserpassloginV2";
+import { NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { getIronSession } from "iron-session";
+import { setEmptySession } from "@/lib/infrastructure/auth/session-utils";
+import MockRucioServerFactory, { MockEndpoint } from "test/fixtures/rucio-server"
+
+describe("Feature: UserpassLoginV2 API tests 2", () => {
+    beforeEach(() => {
+        process.env.RUCIO_AUTH_HOST = MockRucioServerFactory.RUCIO_HOST
+        fetchMock.doMock();
+
+        const getuserpassLoginV2MockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/auth/userpass`,
+            method: 'GET',
+            includes: 'userpass',
+            response: {
+                status: 401,
+                headers: {
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Allow-Headers": "None",
+                    "Access-Control-Allow-Methods": "*",
+                    "Access-Control-Allow-Origin": "None",
+                    "Access-Control-Expose-Headers": "X-Rucio-Auth-Token, X-Rucio-Auth-Token-Expires, X-Rucio-Auth-Account, X-Rucio-Auth-Accounts",
+                    "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate, post-check=0, pre-check=0",
+                    "Connection": "close",
+                    "Content-Length": "122",
+                    "Content-Type": "application/octet-stream",
+                    "Date": "Mon, 06 May 2024 08:19:28 GMT",
+                    "Exceptionclass": "CannotAuthenticate",
+                    "Exceptionmessage": "Cannot authenticate to account root with given credentials",
+                    "Pragma": "no-cache",
+                    "Server": " Werkzeug/3.0.2 Python/3.9.18",
+
+                },
+
+                body: JSON.stringify({
+                    "ExceptionClass": "CannotAuthenticate",
+                    "ExceptionMessage": "Cannot authenticate to account root with given credentials"
+                })
+            }
+        }
+
+        const getAccountAttributesMockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/accounts/root/attr`,
+            method: "GET",
+            includes: "attr",
+            response: {
+                status: 401,
+                headers: {},
+                body: JSON.stringify(
+                    {
+                        "ExceptionClass": "CannotAuthenticate",
+                        "ExceptionMessage": "Cannot authenticate with given credentials"
+                    }
+                )
+            }
+        }
+
+        MockRucioServerFactory.createMockRucioServer(false, [getuserpassLoginV2MockEndpoint, getAccountAttributesMockEndpoint]);
+    });
+
+    afterEach(() => {
+        process.env.RUCIO_AUTH_HOST = undefined
+        fetchMock.dontMock();
+    });
+
+    it("should return an error model for an invalid request to UserpassLoginV2 feature : invalid credentials", async () => {
+        const { req, res } = createMocks({
+            method: 'POST',
+            body: {
+                username: 'ddmlab',
+                password: 'secrt',
+            }
+        });
+        const session = await getIronSession(req, res, {
+            password: 'passwordpasswordpasswordpasswordpassword',
+            cookieName: 'test-request-session',
+            cookieOptions: {
+                secure: false,
+            },
+        })
+
+        await setEmptySession(session, true)
+
+        const controller = appContainer.get<BaseController<UserpassLoginV2ControllerParameters, UserpassLoginV2Request>>(CONTROLLERS.USERPASS_LOGIN_V2)
+        const controllerParameters: UserpassLoginV2ControllerParameters = {
+            response: res as unknown as NextApiResponse,
+            username: req.body.username,
+            password: req.body.password,
+            account: 'root',
+            vo: 'def',
+            session: session,
+            redirectTo: '/dashboard',
+
+        }
+
+        await controller.execute(controllerParameters)
+        expect(res._getStatusCode()).toBe(401)
+
+        // test if the view model is what we expect :
+
+        const data: UserpassLoginV2ViewModel = await res._getJSONData()
+
+        expect(data.status).toBe('error')
+        expect(data).toHaveProperty('error_cause')
+        expect(data.error_cause).toBe("INVALID_CREDENTIALS")
+        expect(data).toHaveProperty("message")
+        expect(data.message).toBe('Invalid username, password or account, please check your credentials and try again')
+
+    });
+
+});

--- a/test/api/auth/userpassV2/userpass-login-V2.test.ts
+++ b/test/api/auth/userpassV2/userpass-login-V2.test.ts
@@ -1,0 +1,153 @@
+import appContainer from "@/lib/infrastructure/ioc/container-config";
+import { UserpassLoginV2Request } from "@/lib/core/usecase-models/userpass-login-V2-usecase-models";
+import { UserpassLoginV2ControllerParameters } from "@/lib/infrastructure/controller/userpass-login-V2-controller"
+import CONTROLLERS from "@/lib/infrastructure/ioc/ioc-symbols-controllers"
+import { BaseController } from "@/lib/sdk/controller";
+import { UserpassLoginV2ViewModel } from "@/lib/infrastructure/data/view-model/UserpassloginV2";
+import { NextApiResponse } from "next";
+import { createMocks } from "node-mocks-http";
+import { getIronSession } from "iron-session";
+import { setEmptySession } from "@/lib/infrastructure/auth/session-utils";
+import MockRucioServerFactory, { MockEndpoint } from "test/fixtures/rucio-server"
+import { Role } from "@/lib/core/entity/auth-models";
+
+
+describe("Feature: UserpassLoginV2 API tests", () => {
+    beforeEach(() => {
+        process.env.RUCIO_AUTH_HOST = MockRucioServerFactory.RUCIO_HOST
+        fetchMock.doMock();
+
+        const getuserpassLoginV2MockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/auth/userpass`,
+            method: 'GET',
+            includes: 'userpass',
+            response: {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Credentials": "true",
+                    "Access-Control-Allow-Headers": "None",
+                    "Access-Control-Allow-Methods": "*",
+                    "Access-Control-Allow-Origin": "None",
+                    "Access-Control-Expose-Headers": "X-Rucio-Auth-Token, X-Rucio-Auth-Token-Expires, X-Rucio-Auth-Account, X-Rucio-Auth-Accounts",
+                    "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate, post-check=0, pre-check=0",
+                    "Connection": "close",
+                    "Content-Length": "0",
+                    "Content-Type": "application/octet-stream",
+                    "Date": "Thu, 02 May 2024 15:02:40 GMT",
+                    "Pragma": "no-cache",
+                    "Server": "Werkzeug/3.0.2 Python/3.9.18",
+                    "X-Rucio-Auth-Account": "root",
+                    "X-Rucio-Auth-Token": "root-ddmlab-unknown-998c33f798314f5e81c6a74fc15f8899",
+                    "X-Rucio-Auth-Token-Expires": "Thu, 02 May 2024 16:02:40 UTC",
+                },
+
+                body: JSON.stringify({
+                })
+            }
+        }
+
+        const getAccountAttributesMockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/accounts/root/attr`,
+            method: "GET",
+            includes: "attr",
+            response: {
+                status: 200,
+                headers: {},
+                body: JSON.stringify(
+                    [
+                        {
+                            "key": "admin",
+                            "value": "True"
+                        },
+                        {
+                            "key": "country-Jamaica",
+                            "value": "admin"
+                        }
+                    ]
+                )
+            }
+        }
+
+        MockRucioServerFactory.createMockRucioServer(false, [getuserpassLoginV2MockEndpoint, getAccountAttributesMockEndpoint]);
+    });
+
+    afterEach(() => {
+        process.env.RUCIO_AUTH_HOST = undefined
+        fetchMock.dontMock();
+    });
+
+    it("should return a view model for a valid request to UserpassLoginV2 feature", async () => {
+        const { req, res } = createMocks({
+            method: 'POST',
+            body: {
+                username: 'ddmlab',
+                password: 'secret',
+            }
+        });
+        const session = await getIronSession(req, res, {
+            password: 'passwordpasswordpasswordpasswordpassword',
+            cookieName: 'test-request-session',
+            cookieOptions: {
+                secure: false,
+            },
+        })
+
+        await setEmptySession(session, true)
+
+        const controller = appContainer.get<BaseController<UserpassLoginV2ControllerParameters, UserpassLoginV2Request>>(CONTROLLERS.USERPASS_LOGIN_V2)
+        const controllerParameters: UserpassLoginV2ControllerParameters = {
+            response: res as unknown as NextApiResponse,
+            username: req.body.username,
+            password: req.body.password,
+            account: 'root',
+            vo: 'def',
+            session: session,
+            redirectTo: '/dashboard',
+
+        }
+
+        await controller.execute(controllerParameters)
+        expect(res._getStatusCode()).toBe(200)
+
+        // test if the view model is what we expect :
+
+        const data: UserpassLoginV2ViewModel = await res._getJSONData()
+
+        expect(data.status).toBe('success')
+        expect(data).toHaveProperty('role')
+        expect(data.role).toBe(Role.ADMIN)
+        expect(data).toHaveProperty('countryRole')
+        expect(data.countryRole).toBe(Role.ADMIN)
+        expect(data).toHaveProperty('rucioAccount');
+        expect(data.rucioAccount).toBe('root')
+        expect(data).toHaveProperty('country')
+        expect(data.country).toBe('Jamaica')
+        expect(data).toHaveProperty('rucioIdentity');
+        expect(data.rucioIdentity).toBe('ddmlab')
+        expect(data).toHaveProperty('rucioAuthToken');
+        expect(data.rucioAuthToken).toBe('root-ddmlab-unknown-998c33f798314f5e81c6a74fc15f8899');
+        expect(data).toHaveProperty('rucioAuthTokenExpires');
+        expect(data.rucioAuthTokenExpires).toBe('Thu, 02 May 2024 16:02:40 UTC');
+
+        // test if the session is what we expect : 
+
+        expect(session.user).toHaveProperty('rucioIdentity');
+        expect(session.user?.rucioIdentity).toBe('ddmlab');
+        expect(session.user).toHaveProperty('rucioAuthToken');
+        expect(session.user?.rucioAuthToken).toBe('root-ddmlab-unknown-998c33f798314f5e81c6a74fc15f8899');
+        expect(session.user).toHaveProperty('rucioAccount');
+        expect(session.user?.rucioAccount).toBe('root');
+        expect(session.user).toHaveProperty('isLoggedIn');
+        expect(session.user?.isLoggedIn).toBe(true);
+        expect(session.user).toHaveProperty('rucioAuthTokenExpires');
+        expect(session.user?.rucioAuthTokenExpires).toBe('Thu, 02 May 2024 16:02:40 UTC');
+        expect(session.user).toHaveProperty('role')
+        expect(session.user?.role).toBe(Role.ADMIN)
+        expect(session.user).toHaveProperty('country')
+        expect(session.user?.country).toBe('Jamaica')
+        expect(session.user).toHaveProperty('countryRole')
+        expect(session.user?.countryRole).toBe(Role.ADMIN)
+
+    });
+
+});

--- a/test/gateway/account/account-gateway.test.ts
+++ b/test/gateway/account/account-gateway.test.ts
@@ -43,7 +43,7 @@ describe("Account Gateway Tests", () => {
         const rucioAccountGateway: AccountGatewayOutputPort = appContainer.get(GATEWAYS.ACCOUNT)
         const accoutAttrs: AccountAttributesDTO = await rucioAccountGateway.listAccountAttributes('ddmadmin', 'rucio-ddmlab-askdjljioj')
         expect(accoutAttrs).toEqual({
-            status: 'OK',
+            status: 'success',
             account: 'ddmadmin',
             attributes: [
                 {


### PR DESCRIPTION
This change is a rewrite of the userpass login functionality so that the different elements extend from a Base class, type or interface.

The templates for the different files were made by the [https://github.com/maany/meow-maker](https://github.com/maany/meow-maker)

The AccountAttributesDTO now uses the BaseDTO type, therefore the status is now 'success' or 'error' and not 'OK' or 'ERROR'.

For now the old userpass functionality is still used, this new userpass login functionality is simply written and ready for use.