### PR TITLE
Enhancement: Fix diplay issues for tables #414

### DIFF
--- a/src/component-library/Pages/Dashboard/Widgets/WidgetOngoingrules.tsx
+++ b/src/component-library/Pages/Dashboard/Widgets/WidgetOngoingrules.tsx
@@ -19,6 +19,7 @@ import {
 } from "@tanstack/react-table";
 import { useEffect, useState } from "react";
 import { TableSortUpDown } from "@/component-library/StreamedTables/TableSortUpDown.stories";
+import tailwind from "@/tailwind"
 
 ChartJS.register(
     CategoryScale,
@@ -83,6 +84,14 @@ export const WidgetOngoingrules: React.FC<JSX.IntrinsicElements["div"] & {
             labels: [],
             datasets: []
         })
+        const isDarkMode = () =>
+            window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+        window.matchMedia('(prefers-color-scheme: dark)')
+            .addEventListener('change',() => {
+                location.reload();
+            })
+
         const options = {
             indexAxis: "y" as const,
             responsive: true,
@@ -92,13 +101,21 @@ export const WidgetOngoingrules: React.FC<JSX.IntrinsicElements["div"] & {
                     title: {
                         display: true,
                         text: "Percentage [%]",
+                        color: isDarkMode() ? tailwind.theme.extend.colors.text[200] : tailwind.theme.extend.colors.text[900],
                     },
                     stacked: true,
                     min: 0,
                     max: 100,
+                    ticks: {
+                        color: isDarkMode() ? tailwind.theme.extend.colors.text[200] : tailwind.theme.extend.colors.text[900],
+                    }
                 },
                 y: {
                     stacked: true,
+                    ticks: {
+                        autoSkip: false,
+                        color: isDarkMode() ? tailwind.theme.extend.colors.text[200] : tailwind.theme.extend.colors.text[900],
+                      }
                 }
             },
             plugins: {
@@ -156,17 +173,17 @@ export const WidgetOngoingrules: React.FC<JSX.IntrinsicElements["div"] & {
                     {
                         label: "OK",
                         data: rows.map(row => percentify(row.getValue("ok"), row)),
-                        backgroundColor: "#bef264"
+                        backgroundColor: tailwind.theme.extend.colors.base.success[300],
                     },
                     {
                         label: "Replicating",
                         data: rows.map(row => percentify(row.getValue("replicating"), row)),
-                        backgroundColor: "#fcd34d",
+                        backgroundColor: tailwind.theme.extend.colors.base.warning[300],
                     },
                     {
                         label: "Stuck",
                         data: rows.map(row => percentify(row.getValue("stuck"), row)),
-                        backgroundColor: "#f87171"
+                        backgroundColor: tailwind.theme.extend.colors.base.error[400],
                     }
                 ]
             } as ChartData<ChartDataNumeric>

--- a/src/component-library/Pages/Dashboard/Widgets/WidgetUsedquota.tsx
+++ b/src/component-library/Pages/Dashboard/Widgets/WidgetUsedquota.tsx
@@ -6,8 +6,7 @@ import { Pie } from 'react-chartjs-2';
 import { BoolTag } from "@/component-library/Tags/BoolTag";
 import { Number } from "@/component-library/Text/Content/Number";
 import { Contenttd, Generaltable, Titleth } from "@/component-library/Helpers/Metatable";
-import { useEffect, useState } from "react";
-
+import tailwind from "@/tailwind"
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 const RSEPie: React.FC<JSX.IntrinsicElements["div"] & {
@@ -20,13 +19,20 @@ const RSEPie: React.FC<JSX.IntrinsicElements["div"] & {
         labels: ["Used", "Free"],
         datasets: [{
             data: [input.used, input.quota - input.used],
-            backgroundColor: ["#f87171", "#86efac"]
+            backgroundColor: [tailwind.theme.extend.colors.brand[400],tailwind.theme.extend.colors.extra.emerald[400]]
         }]
     }
+
+    const isDarkMode = () =>
+        window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
     const options = {
         plugins: {
             legend: {
-                display: small
+                display: true,
+                labels:{
+                    color: isDarkMode() ? tailwind.theme.extend.colors.text[200] : tailwind.theme.extend.colors.text[900],
+                }
             },
         }
     }
@@ -34,7 +40,7 @@ const RSEPie: React.FC<JSX.IntrinsicElements["div"] & {
     return (
         <div
             className={twMerge(
-                "w-52 md:w-96 h-auto",
+                "h-auto",
                 "flex flex-col justify-start items-center",
                 hideWhenSmall ? "hidden md:flex" : "",
                 className ?? "",
@@ -44,13 +50,13 @@ const RSEPie: React.FC<JSX.IntrinsicElements["div"] & {
         >
             <label
                 className={twMerge(
-                    "break-all",
+                    "w-max",
                 )}
                 htmlFor={customid}
             >
                 {input.rse}
             </label>
-            <div className="relative w-24 md:w-72">
+            <div className="relative flex w-full">
                 <Pie
                     data={data}
                     options={options}
@@ -87,25 +93,6 @@ export const WidgetUsedquota: React.FC<JSX.IntrinsicElements["div"] & {
     }
 ) => {
         const { className, ...otherprops } = props
-        const [windowSize, setWindowSize] = useState([
-            1920, 1080
-        ]);
-
-        useEffect(() => {
-            setWindowSize([window.innerWidth, window.innerHeight])
-
-            const handleWindowResize = () => {
-                setWindowSize([window.innerWidth, window.innerHeight]);
-            };
-
-            window.addEventListener('resize', handleWindowResize);
-
-            return () => {
-                window.removeEventListener('resize', handleWindowResize);
-            };
-        }, []);
-
-        const isSm = () => windowSize[0] > 640  // 640px is the breakpoint for sm => is minimum sm sized
 
         return (
             <div
@@ -116,7 +103,7 @@ export const WidgetUsedquota: React.FC<JSX.IntrinsicElements["div"] & {
                 {...otherprops}
             >
                 <div>
-                    <H4 className="font-bold">Top Used RSEs</H4>
+                    <H4 className="font-bold dark:text-text-0 text-text-1000">Top Used RSEs</H4>
                 </div>
                 <div
                     className={twMerge(
@@ -124,12 +111,12 @@ export const WidgetUsedquota: React.FC<JSX.IntrinsicElements["div"] & {
                         "dark:text-text-0 text-text-1000"
                     )}
                 >
-                    <RSEPie input={input[0]} small={isSm()} />
-                    <RSEPie input={input[1]} small={isSm()} />
-                    <RSEPie input={input[2]} small={isSm()} />
-                    <RSEPie input={input[3]} small={isSm()} hideWhenSmall />
-                    <RSEPie input={input[4]} small={isSm()} hideWhenSmall />
-                    <RSEPie input={input[5]} small={isSm()} hideWhenSmall />
+                    <RSEPie input={input[0]} />
+                    <RSEPie input={input[1]} />
+                    <RSEPie input={input[2]} />
+                    <RSEPie input={input[3]} hideWhenSmall/>
+                    <RSEPie input={input[4]} hideWhenSmall />
+                    <RSEPie input={input[5]} hideWhenSmall />
                 </div>
             </div>
         );

--- a/src/component-library/Pages/Rule/ListRule.tsx
+++ b/src/component-library/Pages/Rule/ListRule.tsx
@@ -101,7 +101,7 @@ export const ListRule = (
                 )
             },
             meta: {
-                style: "w-36"
+                style: ""
             }
         }),
         columnHelper.accessor("remaining_lifetime", {
@@ -118,7 +118,7 @@ export const ListRule = (
                 )
             },
             meta: {
-                style: "w-32"
+                style: ""
             }
         }),
         columnHelper.accessor("state", {
@@ -136,12 +136,12 @@ export const ListRule = (
                 )
             },
             meta: {
-                style: "w-44"
+                style: "md:w-44 w-28"
             }
         }),
         columnHelper.accessor("locks_ok_cnt", {
             id: "locks_ok_cnt",
-            cell: info => <P className="text-right dark:text-text-0 text-text-1000">{info.getValue()}</P>,
+            cell: info => <P className="text-right dark:text-text-0  text-text-1000">{info.getValue()}</P>,
             header: info => {
                 return (
                     <TableSortUpDown

--- a/src/component-library/StreamedTables/TableFilterString.tsx
+++ b/src/component-library/StreamedTables/TableFilterString.tsx
@@ -68,14 +68,14 @@ export function TableFilterString(
         return (
             <form
                 className={twMerge(
-                    "flex flex-row justify-between items-baseline space-x-8",
+                    "flex flex-row flex-wrap justify-between items-baseline ",
                     "pr-2",
                     className ?? "",
                 )}
                 role="search"
                 aria-label={`Filter ${name} Column`}
             >
-                <span className="shrink-0">
+                <span className="">
                     <H3>{name}</H3>
                 </span>
                 <Filter

--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -909,10 +909,6 @@ html {
   width: 1.25rem;
 }
 
-.w-52 {
-  width: 13rem;
-}
-
 .w-56 {
   width: 14rem;
 }
@@ -948,6 +944,10 @@ html {
 
 .min-w-0 {
   min-width: 0px;
+}
+
+.min-w-full {
+  min-width: 100%;
 }
 
 .max-w-sm {
@@ -1998,6 +1998,11 @@ html {
   color: rgb(241 245 249 / var(--tw-text-opacity));
 }
 
+.text-text-1000 {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 0 / var(--tw-text-opacity));
+}
+
 .text-text-200 {
   --tw-text-opacity: 1;
   color: rgb(226 232 240 / var(--tw-text-opacity));
@@ -2036,11 +2041,6 @@ html {
 .text-zinc-500 {
   --tw-text-opacity: 1;
   color: rgb(113 113 122 / var(--tw-text-opacity));
-}
-
-.text-text-1000 {
-  --tw-text-opacity: 1;
-  color: rgb(0 0 0 / var(--tw-text-opacity));
 }
 
 .underline {
@@ -3053,14 +3053,6 @@ html {
 
   .md\:w-60 {
     width: 15rem;
-  }
-
-  .md\:w-72 {
-    width: 18rem;
-  }
-
-  .md\:w-96 {
-    width: 24rem;
   }
 
   .md\:w-\[400px\] {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     "paths": {
       "@/*": [
         "./src/*"
-      ]
+      ],
+      "@/tailwind": ["./tailwind.config.js"]
     }
   },
   "include": [


### PR DESCRIPTION
This commit contains : 

-  Adaptation of the colours in the dashboard chart, they are now linked to the tailwind palette that was made.
- The colours of the charts adapt to the user's system preference (Dark/Light)
- The charts do not overflow in the dashboard, the table in the list rules page is now fixed for normal-sized screens

Added information : 

-  The charts do not reload when the user changes the system preference while on the site. An event listener will reload the page if it detects a change in the system preference. This part could be ameliorated if there is a way to only reload the charts.
- The list rules page does not adapt correctly for screens smaller than 850px
