### PR TITLE
Bug 426. Make all RSEs shown when no expression is specified.

### DIFF
--- a/src/component-library/Pages/RSE/ListRSE.tsx
+++ b/src/component-library/Pages/RSE/ListRSE.tsx
@@ -18,6 +18,8 @@ import { TextInput } from "@/component-library/Input/TextInput";
 import { useState } from "react";
 import { Button } from "@/component-library/Button/Button";
 
+const defaultRSEQuery = "*";
+
 export const ListRSE = (
     props: {
         comdom: UseComDOM<RSEViewModel>
@@ -25,7 +27,10 @@ export const ListRSE = (
     }
 ) => {
 
-    const [rseSearchQuery, setRSESearchQuery] = useState<string>("")
+    const [rseSearchQuery, setRSESearchQuery] = useState<string>(defaultRSEQuery)
+    const setInputAsQuery = (searchPattern: string) => {
+        setRSESearchQuery(searchPattern !== '' ? searchPattern : defaultRSEQuery)
+    }
 
     const columnHelper = createColumnHelper<RSEViewModel>()
     const tablecolumns = [
@@ -144,21 +149,22 @@ export const ListRSE = (
                         RSE Search Pattern
                     </label>
                     <TextInput
-                        onBlur={(event: any) => { setRSESearchQuery(event.target.value) }}
-                        onEnterkey={async (e: any) => {
+                        onBlur={(event: any) => { setInputAsQuery(event.target.value) }}
+                        onEnterkey={(e) => {
                             e.preventDefault()
-                            await props.setRSEQuery(e.target.value)
-                            setRSESearchQuery(e.target.value)
+                            setInputAsQuery(e.target.value)
+                            props.setRSEQuery(rseSearchQuery)
                             props.comdom.start()
                         }}
                         id="rse-search-pattern"
+                        placeholder={defaultRSEQuery}
                     />
                     <Button
                         type="button"
                         label="Search"
-                        onClick={async (e: any) => {
+                        onClick={(e: any) => {
                             e.preventDefault()
-                            await props.setRSEQuery(rseSearchQuery)
+                            props.setRSEQuery(rseSearchQuery)
                             props.comdom.start()
                         }}
                         className={twMerge(


### PR DESCRIPTION
Fix #426 

When the search bar is empty, show a * placeholder so that the user can see the equivalence of displaying all RSEs and inputting * as an expression.

![image](https://github.com/user-attachments/assets/ec4fcdb4-bdb7-41d4-aee8-b227b56a39d0)

Fix using await for a function that returns void.