### PR TITLE
Bug 439. Remove mock data from the RSE page

### DIFF
--- a/src/app/(rucio)/rse/page/[name]/page.tsx
+++ b/src/app/(rucio)/rse/page/[name]/page.tsx
@@ -4,8 +4,6 @@ import { PageRSE as PageRSEStory } from "@/component-library/Pages/RSE/PageRSE";
 import { RSEBlockState } from "@/lib/core/entity/rucio";
 import { RSEAttributeViewModel, RSEProtocolViewModel, RSEViewModel } from "@/lib/infrastructure/data/view-model/rse";
 import { useEffect, useState } from "react";
-import { fixtureRSEViewModel, mockUseComDOM } from "test/fixtures/table-fixtures";
-import { fixtureRSEProtocolViewModel, fixtureRSEAttributeViewModel } from "test/fixtures/table-fixtures";
 import { getAttributes, getProtocols, getRSE } from "../../queries";
 
 export default function Page({ params }: { params: { name: string } }) {
@@ -14,19 +12,19 @@ export default function Page({ params }: { params: { name: string } }) {
     const [attributes, setAttributes] = useState<RSEAttributeViewModel>({status: "pending"} as RSEAttributeViewModel)
     useEffect(() => {
         getRSE(params.name).then(setRSE)
-    }, [])
+    }, [params.name])
     useEffect(() => {
         getProtocols(params.name).then(setProtocols)
-    }, [])
+    }, [params.name])
     useEffect(() => {
         getAttributes(params.name).then(setAttributes)
-    }, [])
+    }, [params.name])
     if (rse.status === "pending" || protocols.status === "pending" || attributes.status === "pending") {
         return <Loading title="View RSE" subtitle={`For RSE ${params.name}`}/>
     }
     return (
         <PageRSEStory
-            rse={{ ...fixtureRSEViewModel(), name: params.name }}
+            rse={rse}
             rseblockstate={0 as RSEBlockState}
             protocols={protocols}
             attributes={attributes}


### PR DESCRIPTION
Fix #439 

Depends on the PR #438 to fix the loading of the RSE page