### PR TITLE
Bug 427. DIDs redirects lead to an unexpected route

### DIFF
--- a/src/app/(rucio)/did/list/page.tsx
+++ b/src/app/(rucio)/did/list/page.tsx
@@ -26,7 +26,6 @@ export default function Page() {
             },
 
         }
-        console.log(request)
         await DIDSearchComDOM.setRequest(request)
     }
 

--- a/src/app/(rucio)/did/queries.ts
+++ b/src/app/(rucio)/did/queries.ts
@@ -1,47 +1,13 @@
 import { DIDKeyValuePairsDataViewModel, DIDMetaViewModel } from "@/lib/infrastructure/data/view-model/did";
 
 export async function didMetaQueryBase(scope: string, name: string): Promise<DIDMetaViewModel> {
-    const req: any = {
-        method: "GET",
-        url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-did-meta`),
-        params: {
-            "scope": scope,
-            "name": name
-        },
-        headers: new Headers({
-            'Content-Type': 'application/json',
-        } as HeadersInit)
-    }
-
-    const res = await fetch(req.url, {
-        method: "GET",
-        headers: new Headers({
-            'Content-Type': 'application/json',
-        } as HeadersInit)
-    })
-
+    const url = `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-did-meta?` + new URLSearchParams({scope, name})
+    const res = await fetch(url)
     return await res.json()
 }
 
 export async function didKeyValuePairsDataQuery(scope: string, name: string): Promise<DIDKeyValuePairsDataViewModel> {
-    const req: any = {
-        method: "GET",
-        url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-did-keyvaluepairs`),
-        params: {
-            "scope": scope,
-            "name": name
-        },
-        headers: new Headers({
-            'Content-Type': 'application/json',
-        } as HeadersInit)
-    }
-
-    const res = await fetch(req.url, {
-        method: "GET",
-        headers: new Headers({
-            'Content-Type': 'application/json',
-        } as HeadersInit)
-    })
-
+    const url = `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-did-keyvaluepairs?` + new URLSearchParams({scope, name})
+    const res = await fetch(url)
     return await res.json()
 }


### PR DESCRIPTION
Fix #427 

The bug was caused by improper request handling. Seemingly, parsing works just fine. The screenshot shows a DID with a complex name have correct information listed and point to the correct page.

![image](https://github.com/user-attachments/assets/256e42c7-0b09-4f07-adcb-34307e804e84)

![image](https://github.com/user-attachments/assets/7e5d1659-a1ba-4708-aeb2-70344569b361)
