### PR TITLE
Bug 435. Login redirects and running under different hostnames

### DIFF
--- a/src/app/(rucio)/did/list/page.tsx
+++ b/src/app/(rucio)/did/list/page.tsx
@@ -15,7 +15,7 @@ export default function Page() {
     }
     const didQuery = async (query: string, type: DIDType) => {
         const request: any = {
-            url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-dids`),
+            url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-dids`),
             method: 'GET',
             headers: new Headers({
                 'Content-Type': 'application/json',

--- a/src/app/(rucio)/did/page/[scope]/[name]/page.tsx
+++ b/src/app/(rucio)/did/page/[scope]/[name]/page.tsx
@@ -30,7 +30,7 @@ export default function Page({ params }: { params: { scope: string, name: string
     )
     const didFileReplicasDOnChange = (scope: string, name: string) => {
         didFileReplicasComDOM.setRequest({
-            url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-file-replicas`),
+            url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-file-replicas`),
             method: 'GET',
             params: {
                 scope: scope,
@@ -52,7 +52,7 @@ export default function Page({ params }: { params: { scope: string, name: string
     useEffect(() => {
         const setRequests = async () => {
             await didContentsComDOM.setRequest({
-                url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-did-contents`),
+                url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-did-contents`),
                 method: 'GET',
                 params: {
                     scope: params.scope,
@@ -64,7 +64,7 @@ export default function Page({ params }: { params: { scope: string, name: string
                 body: null,
             } as HTTPRequest)
             await didParentsComDOM.setRequest({
-                url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-did-parents`),
+                url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-did-parents`),
                 method: 'GET',
                 params: {
                     scope: params.scope,
@@ -76,7 +76,7 @@ export default function Page({ params }: { params: { scope: string, name: string
                 body: null,
             } as HTTPRequest)
             await didFileReplicasComDOM.setRequest({
-                url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-file-replicas`),
+                url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-file-replicas`),
                 method: 'GET',
                 params: {
                     scope: params.scope,
@@ -88,7 +88,7 @@ export default function Page({ params }: { params: { scope: string, name: string
                 body: null,
             } as HTTPRequest)
             await didRulesComDOM.setRequest({
-                url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-did-rules`),
+                url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-did-rules`),
                 method: 'GET',
                 params: {
                     scope: params.scope,
@@ -100,7 +100,7 @@ export default function Page({ params }: { params: { scope: string, name: string
                 body: null,
             } as HTTPRequest)
             await didDatasetReplicasComDOM.setRequest({
-                url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-dataset-replicas`),
+                url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-dataset-replicas`),
                 method: 'GET',
                 params: {
                     scope: params.scope,

--- a/src/app/(rucio)/did/queries.ts
+++ b/src/app/(rucio)/did/queries.ts
@@ -1,13 +1,13 @@
 import { DIDKeyValuePairsDataViewModel, DIDMetaViewModel } from "@/lib/infrastructure/data/view-model/did";
 
 export async function didMetaQueryBase(scope: string, name: string): Promise<DIDMetaViewModel> {
-    const url = `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-did-meta?` + new URLSearchParams({scope, name})
+    const url = '/api/feature/get-did-meta?' + new URLSearchParams({scope, name})
     const res = await fetch(url)
     return await res.json()
 }
 
 export async function didKeyValuePairsDataQuery(scope: string, name: string): Promise<DIDKeyValuePairsDataViewModel> {
-    const url = `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-did-keyvaluepairs?` + new URLSearchParams({scope, name})
+    const url = '/api/feature/get-did-keyvaluepairs?' + new URLSearchParams({scope, name})
     const res = await fetch(url)
     return await res.json()
 }

--- a/src/app/(rucio)/queries.ts
+++ b/src/app/(rucio)/queries.ts
@@ -1,23 +1,6 @@
 import { SiteHeaderViewModel } from '@/lib/infrastructure/data/view-model/site-header'
 
 export async function getSiteHeader(): Promise<SiteHeaderViewModel> {
-    const req: any = {
-        method: 'GET',
-        url: new URL(
-            `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-site-header`,
-        ),
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        params: {},
-    }
-
-    const res = await fetch(req.url, {
-        method: 'GET',
-        headers: new Headers({
-            'Content-Type': 'application/json',
-        } as HeadersInit),
-    })
-
+    const res = await fetch('/api/feature/get-site-header')
     return await res.json()
 }

--- a/src/app/(rucio)/rse/list/page.tsx
+++ b/src/app/(rucio)/rse/list/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
 
     const setRSEQuery = async (rseExpression: string) => {
         await RSESearchComDOM.setRequest({
-            url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-rses`),
+            url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-rses`),
             method: 'GET',
             headers: new Headers({
                 'Content-Type': 'application/json',

--- a/src/app/(rucio)/rse/page/[name]/page.tsx
+++ b/src/app/(rucio)/rse/page/[name]/page.tsx
@@ -6,19 +6,19 @@ import { RSEAttributeViewModel, RSEProtocolViewModel, RSEViewModel } from "@/lib
 import { useEffect, useState } from "react";
 
 async function getRSE(rseName: string): Promise<RSEViewModel> {
-    const url = `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-rse?` + new URLSearchParams({rseName})
+    const url = '/api/feature/get-rse?' + new URLSearchParams({rseName})
     const res = await fetch(url)
     return await res.json()
 }
 
 async function getProtocols(rseName: string): Promise<RSEProtocolViewModel> {
-    const url = `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-rse-protocols?` + new URLSearchParams({rseName})
+    const url = '/api/feature/get-rse-protocols?' + new URLSearchParams({rseName})
     const res = await fetch(url)
     return await res.json()
 }
 
 async function getAttributes(rseName:string): Promise<RSEAttributeViewModel> {
-    const url = `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-rse-attributes?` + new URLSearchParams({rseName})
+    const url = '/api/feature/get-rse-attributes?' + new URLSearchParams({rseName})
     const res = await fetch(url)
     return await res.json()
 }

--- a/src/app/(rucio)/rucio-app-layout.tsx
+++ b/src/app/(rucio)/rucio-app-layout.tsx
@@ -14,7 +14,7 @@ export const RucioAppLayout = (props: QueryContextLayoutProps) => {
         homeUrl: ""
     })
     const fetchAccounts = async () => {
-        await fetch(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-site-header`)
+        await fetch('/api/feature/get-site-header')
         .then(res => {
             if (res.ok) {
                 return res.json()

--- a/src/app/(rucio)/rule/create/page.tsx
+++ b/src/app/(rucio)/rule/create/page.tsx
@@ -22,7 +22,7 @@ export default function CreateRule() {
         viewModel.status = 'pending'
         
         try {
-            const response = await fetch(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/create-rule`, {
+            const response = await fetch(`/api/feature/create-rule`, {
                 method: "POST",
                 headers: new Headers({
                     'Content-Type': 'application/json'
@@ -100,7 +100,7 @@ export default function CreateRule() {
 
     const [accountInfo, setAccountInfo] = useState<AccountInfo>(generateEmptyAccountInfoViewModel())
     useEffect(() => {
-        fetch(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/account-info`)
+        fetch(`${window.location.protocol}//${window.location.host}/api/feature/account-info`)
         .then((response) => {
             if(response.ok) {
                 return response.json()

--- a/src/app/(rucio)/rule/page/[id]/page.tsx
+++ b/src/app/(rucio)/rule/page/[id]/page.tsx
@@ -27,7 +27,7 @@ export default function PageRule({ params }: { params: { id: string } }) {
     
     useEffect(() => {
         // TODO get from mock endpoint
-        fetch(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/mock-get-rule-meta`)
+        fetch('/api/feature/mock-get-rule-meta')
         .then(res => {
             if (res.ok) {
                 return res.json()
@@ -46,7 +46,7 @@ export default function PageRule({ params }: { params: { id: string } }) {
     useEffect(() => {
         const runQuery = async () => {
             const request: HTTPRequest = {
-                url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/mock-list-rule-page-lock`),
+                url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/mock-list-rule-page-lock`),
                 method: "GET",
                 headers: new Headers({
                     'Content-Type': 'application/json'

--- a/src/app/(rucio)/subscription/list/page.tsx
+++ b/src/app/(rucio)/subscription/list/page.tsx
@@ -28,7 +28,7 @@ export default function ListSubscription({ params }: { params: { account: string
     useEffect(() => {
         const runQuery = async () => {
             await ComDOM.start({
-                url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-subscription-rule-states`),
+                url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-subscription-rule-states`),
                 method: "GET",
                 headers: new Headers({
                     'Content-Type': 'application/json'

--- a/src/app/(rucio)/subscription/page/[account]/[name]/page.tsx
+++ b/src/app/(rucio)/subscription/page/[account]/[name]/page.tsx
@@ -12,7 +12,7 @@ async function updateSubscription(
 ) {
     const req: any = {
         method: "PUT",
-        url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/mock-update-subscription`),
+        url: new URL(`/api/feature/mock-update-subscription`),
         headers: {
             'Content-Type': 'application/json',
         },
@@ -43,7 +43,7 @@ export default function PageSubscription({ params }: { params: { account: string
     async function subscriptionQuery(account: string, name: string): Promise<SubscriptionViewModel> {
         const req: any = {
             method: "GET",
-            url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/get-subscription`),
+            url: new URL(`/api/feature/get-subscription`),
             params: {
                 "account": account,
                 "name": name

--- a/src/app/moncomdom/page.tsx
+++ b/src/app/moncomdom/page.tsx
@@ -79,7 +79,7 @@ export default function RSETable() {
             <ErrorList errors={errors} resolve={resolveError} resolveAllErrors={resolveAllErrors} />
             <button className="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800" onClick={async () => {
                 const request: HTTPRequest = {
-                    url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/stream`),
+                    url: new URL(`${window.location.protocol}//${window.location.host}/api/stream`),
                     method: 'GET',
                     headers: {
                         'Content-Type': 'application/json'

--- a/src/component-library/Pages/Rule/1_DIDs/CreateRuleDIDsPage.tsx
+++ b/src/component-library/Pages/Rule/1_DIDs/CreateRuleDIDsPage.tsx
@@ -71,7 +71,7 @@ export const CreateRuleDIDsPage = (props: {
         // build request for comdom
         const request: HTTPRequest = {
             url: new URL(
-                `${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-dids`,
+                `${window.location.protocol}//${window.location.host}/api/feature/list-dids`,
             ),
             method: 'GET',
             headers: new Headers({

--- a/src/component-library/Pages/Rule/2_RSEs/CreateRuleRSEsPage.tsx
+++ b/src/component-library/Pages/Rule/2_RSEs/CreateRuleRSEsPage.tsx
@@ -71,7 +71,7 @@ export const CreateRuleRSEsPage = (props: {
         var RSEExpression = explicitRSEExpression ? explicitRSEExpression : PageRSEsState.RSEExpression
         // build request for comdom
         const request: HTTPRequest = {
-            url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-account-rse-quotas`),
+            url: new URL(`${window.location.protocol}//${window.location.host}/api/feature/list-account-rse-quotas`),
             method: "POST",
             headers: new Headers({
                 'Content-Type': 'application/json'

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,12 +30,12 @@ export const config = {
 }
 
 async function reLogin(request: NextRequest) {
-    const logoutPage = new URL(`/api/auth/logout?callbackUrl=${request.url}`, request.url)
+    const logoutPage = new URL(`/api/auth/logout?callbackUrl=${request.nextUrl.pathname}`, request.url)
     return NextResponse.redirect(logoutPage)
 }
 
 async function initiateLogin(request: NextRequest){
-    const loginPage = new URL(`/api/auth/login?callbackUrl=${request.url}`, request.url)
+    const loginPage = new URL(`/api/auth/login?callbackUrl=${request.nextUrl.pathname}`, request.url)
     return NextResponse.redirect(loginPage)
 }
 


### PR DESCRIPTION
Seemingly fix #435

I tested the changes by using a different hostname for referring to the local deployment. I managed to turn
![image](https://github.com/user-attachments/assets/6de1be73-7046-4939-8204-f4072d514898)
into
![image](https://github.com/user-attachments/assets/6ba32172-abf5-450f-9921-581f35eb619f)

It works for all the use cases of middleware redirects. I believe that might be the fix for the issue.