### PR TITLE
Bug 449. Incorrect handling of data chunks in streaming

### DIFF
--- a/test/api/did/list-dids-stream-error.test.ts
+++ b/test/api/did/list-dids-stream-error.test.ts
@@ -8,7 +8,7 @@ import { Readable } from 'stream'
 import { MockHttpStreamableResponseFactory } from 'test/fixtures/http-fixtures'
 import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server'
 
-describe('DID API Tests', () => {
+describe('DID API Tests #2', () => {
     beforeEach(() => {
         fetchMock.doMock()
         const listDIDsEndpoint: MockEndpoint = {
@@ -22,10 +22,11 @@ describe('DID API Tests', () => {
                 },
                 body: Readable.from(
                     [
-                        '"dataset1"',
-                        '"dataset2"',
-                        '"dataset3"',
-                        " "
+                        '"dataset1"\n',
+                        '"dataset2"\n',
+                        '"dataset3"\n',
+                        " ",
+                        " ",
                     ].join('\n'),
                 ),
             },
@@ -170,16 +171,6 @@ describe('DID API Tests', () => {
                 "bytes": 456,
                 "length": 789,
                 "open": true,
-            },
-            {
-                "status": "error",
-                "name": "Gateway Error: Undefined DID in stream",
-                "message": "Gateway recieved an invalid (undefined) DID for the query",
-                "scope": "",
-                "did_type": "Unknown",
-                "bytes": 0,
-                "length": 0,
-                "open": false,
             }
         ])
     })

--- a/test/api/did/list-dids.test.ts
+++ b/test/api/did/list-dids.test.ts
@@ -22,9 +22,9 @@ describe('DID API Tests', () => {
                 },
                 body: Readable.from(
                     [
-                        '"dataset1"',
-                        '"dataset2"',
-                        '"dataset3"',
+                        '"dataset1"\n',
+                        '"dataset2"\n',
+                        '"dataset3"\n',
                     ].join('\n'),
                 ),
             },

--- a/test/gateway/account/list-account-rse-usage.test.ts
+++ b/test/gateway/account/list-account-rse-usage.test.ts
@@ -15,7 +15,7 @@ describe('Account Gateway : List RSE Usage for an account', () => {
             JSON.stringify({"rse_id": "5883a989c9c047d99d2fc1c074e40f58", "rse": "XRD4", "bytes": 300, "files": 6, "bytes_limit": 700, "bytes_remaining": 400}),
             JSON.stringify({"rse_id": "2bb03a45a1b64b459cdc445d9844d936", "rse": "XRD3", "bytes": 400, "files": 7, "bytes_limit": 600, "bytes_remaining": 200}),
             JSON.stringify({"rse_id": "72fb4137ba3c460090bbd3fd8d490f8b", "rse": "XRD1", "bytes": 500, "files": 8, "bytes_limit": Infinity, "bytes_remaining": Infinity}),
-        ].join('\n'))
+        ].join('\n') + '\n');
 
         const listAccountRSEUsageEndpoint: MockEndpoint = {
             url: `${MockRucioServerFactory.RUCIO_HOST}/accounts/root/usage`,

--- a/test/gateway/rule/rule-gateway-list-rule-replica-lock-states.test.ts
+++ b/test/gateway/rule/rule-gateway-list-rule-replica-lock-states.test.ts
@@ -18,7 +18,7 @@ describe("RuleGateway", () => {
                 "rse": "XRD3",
                 "state": "REPLICATING",
                 "rule_id": "0dcdc93fab714f8b84bad116c409483b"
-            }),
+            }) + '\n',
             JSON.stringify({
                 "scope": "test",
                 "name": "file2",
@@ -26,7 +26,7 @@ describe("RuleGateway", () => {
                 "rse": "XRD3",
                 "state": "REPLICATING",
                 "rule_id": "0dcdc93fab714f8b84bad116c409483b"
-            }),
+            }) + '\n',
             JSON.stringify({
                 "scope": "test",
                 "name": "file3",
@@ -34,7 +34,7 @@ describe("RuleGateway", () => {
                 "rse": "XRD3",
                 "state": "REPLICATING",
                 "rule_id": "0dcdc93fab714f8b84bad116c409483b"
-            }),
+            }) + '\n',
             JSON.stringify({
                 "scope": "test",
                 "name": "file4",
@@ -42,7 +42,7 @@ describe("RuleGateway", () => {
                 "rse": "XRD3",
                 "state": "REPLICATING",
                 "rule_id": "0dcdc93fab714f8b84bad116c409483b"
-            })
+            }) + '\n'
         ])
 
         const listRuleReplicaLockStatesEndpoint: MockEndpoint = {

--- a/test/sdk/streaming-transformers.test.ts
+++ b/test/sdk/streaming-transformers.test.ts
@@ -117,6 +117,19 @@ describe("NewlineDelimittedDataParser - a transform stream that parses newline-d
         ])
     })
 
+    it("Handles a single NDJSON passed in multiple chunks", () => {
+        source.write('{"hel')
+        source.write('lo": "')
+        source.write('wor')
+        source.write('ld"}')
+        source.write('\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'}
+        ])
+    })
+
     it("Handles multiple NDJSON passed partially", () => {
         source.write('{"hello": "wor')
         source.write('ld"}\n{"test": "json"}\n{"variable"')

--- a/test/sdk/streaming-transformers.test.ts
+++ b/test/sdk/streaming-transformers.test.ts
@@ -1,0 +1,173 @@
+import appContainer from "@/lib/infrastructure/ioc/container-config"
+import {NewlineDelimittedDataParser} from "@/lib/sdk/stream-transformers"
+import {Transform} from "stream"
+
+
+class TestPipelineSink extends Transform {
+
+    _transform(chunk: any, encoding: string, callback: Function) {
+        const data = chunk.toString()
+        this.push(data)
+        callback()
+    }
+
+}
+
+class TestPipelineSource extends Transform {
+
+    _transform(chunk: any, encoding: string, callback: Function) {
+        const data = chunk.toString()
+        this.push(data)
+        callback()
+    }
+
+}
+
+// Is double parsing a desired behaviour?
+const parseChunk = (chunk: string) => JSON.parse(JSON.parse(chunk))
+
+describe("NewlineDelimittedDataParser - a transform stream that parses newline-delimited JSON data", () => {
+    let source: Transform;
+    let sink: Transform;
+    let outputChunks: string[];
+
+    beforeEach(() => {
+        source = new TestPipelineSource()
+        sink = new TestPipelineSink()
+        outputChunks = []
+
+        sink.on('data', (chunk) => {
+            outputChunks.push(chunk.toString())
+        })
+
+        source.pipe(new NewlineDelimittedDataParser()).pipe(sink)
+    })
+
+    it("Handles a single full NDJSON object in one chunk", () => {
+        source.write('{"hello": "world"}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'}
+        ])
+    })
+
+    it("Handles two full NDJSON objects in one chunk", () => {
+        source.write('{"hello": "world"}\n{"test": "json"}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'},
+            {'test': 'json'},
+        ])
+    })
+
+    it("Handles multiple full NDJSON objects in one chunk", () => {
+        source.write('{"hello": "world"}\n{"test": "json"}\n{"variable": 0, "test": "json"}\n{"variable": 0}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'},
+            {'test': 'json'},
+            {'test': 'json', 'variable': 0},
+            {'variable': 0}
+        ])
+    })
+
+    it("Handles multiple full NDJSON objects in two chunks", () => {
+        source.write('{"hello": "world"}\n{"test": "json"}\n')
+        source.write('{"variable": 0, "test": "json"}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'},
+            {'test': 'json'},
+            {'test': 'json', 'variable': 0},
+        ])
+    })
+
+    it("Handles multiple full NDJSON objects in three chunks", () => {
+        source.write('{"hello": "world"}\n{"test": "json"}\n')
+        source.write('{"variable": 0, "test": "json"}\n')
+        source.write('{"variable": 0}\n{"hello": "world", "variable": 0}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'},
+            {'test': 'json'},
+            {'test': 'json', 'variable': 0},
+            {'variable': 0},
+            {'hello': 'world', 'variable': 0},
+        ])
+    })
+
+    it("Doesn't pass a partial NDJSON", () => {
+        source.write('{"hello": "world"')
+
+        expect(outputChunks.length).toEqual(0)
+    })
+
+    it("Handles a single NDJSON passed in two chunks", () => {
+        source.write('{"hello": "world"')
+        source.write('}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'}
+        ])
+    })
+
+    it("Handles multiple NDJSON passed partially", () => {
+        source.write('{"hello": "wor')
+        source.write('ld"}\n{"test": "json"}\n{"variable"')
+        source.write(': 0}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'},
+            {'test': 'json'},
+            {'variable': 0},
+        ])
+    })
+
+    it("Handles long chunks of full NDJSON objects", () => {
+        source.write('{"hello": "world"}\n{"test": "json"}\n{"hour": 1}\n')
+        source.write('{"variable": 0, "test": "json"}\n{"method": "GET"}\n')
+        source.write('{"variable": 0}\n{"hello": "world", "variable": 0}\n{"error": "unknown"}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'},
+            {'test': 'json'},
+            {'hour': 1},
+            {'test': 'json', 'variable': 0},
+            {'method': 'GET'},
+            {'variable': 0},
+            {'hello': 'world', 'variable': 0},
+            {'error': 'unknown'}
+        ])
+    })
+
+    it("Doesn't pass a chunk that doesn't end in a newline", () => {
+        source.write('{"hello": "world"}')
+
+        expect(outputChunks.length).toEqual(0)
+    })
+
+    it("Doesn't pass a chunk that isn't a valid NDJSON string", () => {
+        source.write('abc\n')
+
+        expect(outputChunks.length).toEqual(0)
+    })
+
+    it("Passes only valid NDJSON strings", () => {
+        source.write('{"hello": "wor')
+        source.write('ld"}\n{{"test": "json"}\n{"variable": 0}\n')
+
+        const parsedChunks = outputChunks.map(parseChunk)
+        expect(parsedChunks).toEqual([
+            {'hello': 'world'},
+            {'variable': 0},
+        ])
+    })
+})


### PR DESCRIPTION
Fixes #449 (after consideration of the following misunderstanding)

The CI will fail because of the DID API test. It expects a chunk with an invalid JSON string to be pushed into the stream, while per the discussion it should be stopped at the gateway. @maany please let me know what is the expected behavior.

Moreover, it seems like ```JSON.stringify()``` doesn't check the validity of the chunk. Is it desired to have the chunk stringified and double parsed then?