### PR TITLE
Bug 313. Unhandled response status codes in BaseEndpoint

### DIFF
--- a/src/lib/sdk/gateway-endpoints.ts
+++ b/src/lib/sdk/gateway-endpoints.ts
@@ -272,43 +272,30 @@ async function handleCommonGatewayEndpointErrors<TDTO extends BaseDTO>(statusCod
         case 400:
             dto.errorName = BaseHttpErrorTypes.BAD_REQUEST.errorName;
             dto.errorMessage = `The request had invalid syntax.`
-            try {
-                const message = await response.json();
-                dto.errorMessage += ` Error Details: ${message}`; 
-            } catch(error) {}
             break;
         case 401:
             dto.errorName = BaseHttpErrorTypes.INVALID_AUTH_TOKEN.errorName;
             dto.errorMessage = `The provided authentication token is invalid or has expired.`;
-            try {
-                const message = await response.json();
-                dto.errorMessage += ` Error Details: ${message}`; 
-            } catch(error) {}
             break;
         case 404:
             dto.errorName = BaseHttpErrorTypes.NOT_FOUND.errorName;
             dto.errorMessage = `The requested resource was not found at ${response.url}.`
-            try {
-                const message = await response.json();
-                dto.errorMessage += ` Error Details: ${message}`;
-            } catch(error) {}
             break;
         case 406:
             dto.errorName = BaseHttpErrorTypes.NOT_ACCEPTABLE.errorName;
             dto.errorMessage = `Not Acceptable.`;
-            try {
-                const message = await response.json();
-            } catch(error) {}
             break;
         default:
             dto.errorName = BaseHttpErrorTypes.UNKNOWN_ERROR.errorName;
             dto.errorMessage = `An unknown server side error occurred while fetching ${response.url}.`;
-            try {
-                const message = await response.json();
-                dto.errorMessage += ` Error Details: ${message}`;
-            } catch(error) {}
             break;
     }
+
+    try {
+        const message = JSON.stringify(await response.json());
+        dto.errorMessage += ` Error Details: ${message}`;
+    } catch(error) {}
+
     return dto;
 }
 

--- a/src/lib/sdk/gateway-endpoints.ts
+++ b/src/lib/sdk/gateway-endpoints.ts
@@ -300,7 +300,7 @@ async function handleCommonGatewayEndpointErrors<TDTO extends BaseDTO>(statusCod
                 const message = await response.json();
             } catch(error) {}
             break;
-        case 500:
+        default:
             dto.errorName = BaseHttpErrorTypes.UNKNOWN_ERROR.errorName;
             dto.errorMessage = `An unknown server side error occurred while fetching ${response.url}.`;
             try {
@@ -308,8 +308,6 @@ async function handleCommonGatewayEndpointErrors<TDTO extends BaseDTO>(statusCod
                 dto.errorMessage += ` Error Details: ${message}`;
             } catch(error) {}
             break;
-        default:
-            return undefined;
     }
     return dto;
 }

--- a/src/lib/sdk/gateway-endpoints.ts
+++ b/src/lib/sdk/gateway-endpoints.ts
@@ -268,11 +268,10 @@ async function handleCommonGatewayEndpointErrors<TDTO extends BaseDTO>(statusCod
         errorMessage: `An error occurred while fetching ${response.url}`,
     } as TDTO;
 
-    
     switch(statusCode) {
         case 400:
-            dto.errorName = BaseHttpErrorTypes.NOT_FOUND.errorName;
-            dto.errorMessage = `The requested resource was not found at ${response.url}.`
+            dto.errorName = BaseHttpErrorTypes.BAD_REQUEST.errorName;
+            dto.errorMessage = `The request had invalid syntax.`
             try {
                 const message = await response.json();
                 dto.errorMessage += ` Error Details: ${message}`; 
@@ -284,6 +283,14 @@ async function handleCommonGatewayEndpointErrors<TDTO extends BaseDTO>(statusCod
             try {
                 const message = await response.json();
                 dto.errorMessage += ` Error Details: ${message}`; 
+            } catch(error) {}
+            break;
+        case 404:
+            dto.errorName = BaseHttpErrorTypes.NOT_FOUND.errorName;
+            dto.errorMessage = `The requested resource was not found at ${response.url}.`
+            try {
+                const message = await response.json();
+                dto.errorMessage += ` Error Details: ${message}`;
             } catch(error) {}
             break;
         case 406:


### PR DESCRIPTION
Fixes #313 

Moreover, it makes the message from the server be displayed correctly.

Before:
```{"status":"error","id":"","name":"","rse_type":"UNKNOWN","volatile":false,"deterministic":false,"staging_area":false,"message":"The requested resource was not found at https://127.0.0.1:8081/rses/?expression=MOCK1. Error Details: [object Object]"}```
![image](https://github.com/user-attachments/assets/6094a7f6-dc12-4af3-bcb7-7eff7089b33a)

After:
```{"status":"error","id":"","name":"","rse_type":"UNKNOWN","volatile":false,"deterministic":false,"staging_area":false,"message":"The request had invalid syntax. Error Details: {\"ExceptionClass\":\"InvalidRSEExpression\",\"ExceptionMessage\":\"RSE Expression resulted in an empty set.\"}"}```
![image](https://github.com/user-attachments/assets/582cc2de-137b-463d-a862-8a4c1b9153da)

P. S. I changed the BAD_REQUEST error message, but I undestand that it may sometimes signify that a resource wasn't found. Please let me know if that's okay