### PR TITLE
Bug 485. URL encode DID names.

### DIFF
--- a/src/app/(rucio)/did/page/[scope]/[name]/page.tsx
+++ b/src/app/(rucio)/did/page/[scope]/[name]/page.tsx
@@ -2,13 +2,6 @@
 import { PageDID as PageDIDStory } from '@/component-library/pages/legacy/DID/PageDID';
 import useComDOM from '@/lib/infrastructure/hooks/useComDOM';
 import { useEffect, useState } from 'react';
-import {
-    fixtureDIDDatasetReplicasViewModel,
-    fixtureDIDKeyValuePairsDataViewModel,
-    fixtureDIDMetaViewModel,
-    fixtureDIDRulesViewModel,
-    mockUseComDOM,
-} from 'test/fixtures/table-fixtures';
 import { HTTPRequest } from '@/lib/sdk/http';
 import {
     DIDDatasetReplicasViewModel,
@@ -16,21 +9,23 @@ import {
     DIDMetaViewModel,
     DIDRulesViewModel,
     DIDViewModel,
-    FilereplicaStateDViewModel,
     FileReplicaStateViewModel,
 } from '@/lib/infrastructure/data/view-model/did';
 import { didKeyValuePairsDataQuery, didMetaQueryBase } from '@/app/(rucio)/did/queries';
 import { Loading } from '@/component-library/pages/legacy/Helpers/Loading';
 
 export default function Page({ params }: { params: { scope: string; name: string } }) {
+    const decodedScope = decodeURIComponent(params.scope);
+    const decodedName = decodeURIComponent(params.name);
+
     const [didMeta, setDIDMeta] = useState<DIDMetaViewModel>({ status: 'pending' } as DIDMetaViewModel);
     const [didKeyValuePairsData, setDIDKeyValuePairsData] = useState({ status: 'pending' } as DIDKeyValuePairsDataViewModel);
     const [fromDidList, setFromDidList] = useState<string>('yosearch');
     useEffect(() => {
-        didMetaQueryBase(params.scope, params.name).then(setDIDMeta);
+        didMetaQueryBase(decodedScope, decodedName).then(setDIDMeta);
     }, []);
     useEffect(() => {
-        didKeyValuePairsDataQuery(params.scope, params.name).then(setDIDKeyValuePairsData);
+        didKeyValuePairsDataQuery(decodedScope, decodedName).then(setDIDKeyValuePairsData);
     }, []);
 
     const didParentsComDOM = useComDOM<DIDViewModel>('page-did-parents-query', [], false, Infinity, 200, true);
@@ -59,8 +54,8 @@ export default function Page({ params }: { params: { scope: string; name: string
                 url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-did-contents`),
                 method: 'GET',
                 params: {
-                    scope: params.scope,
-                    name: params.name,
+                    scope: decodedScope,
+                    name: decodedName,
                 },
                 headers: new Headers({
                     'Content-Type': 'application/json',
@@ -71,8 +66,8 @@ export default function Page({ params }: { params: { scope: string; name: string
                 url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-did-parents`),
                 method: 'GET',
                 params: {
-                    scope: params.scope,
-                    name: params.name,
+                    scope: decodedScope,
+                    name: decodedName,
                 },
                 headers: new Headers({
                     'Content-Type': 'application/json',
@@ -83,8 +78,8 @@ export default function Page({ params }: { params: { scope: string; name: string
                 url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-file-replicas`),
                 method: 'GET',
                 params: {
-                    scope: params.scope,
-                    name: params.name,
+                    scope: decodedScope,
+                    name: decodedName,
                 },
                 headers: new Headers({
                     'Content-Type': 'application/json',
@@ -95,8 +90,8 @@ export default function Page({ params }: { params: { scope: string; name: string
                 url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-did-rules`),
                 method: 'GET',
                 params: {
-                    scope: params.scope,
-                    name: params.name,
+                    scope: decodedScope,
+                    name: decodedName,
                 },
                 headers: new Headers({
                     'Content-Type': 'application/json',
@@ -107,8 +102,8 @@ export default function Page({ params }: { params: { scope: string; name: string
                 url: new URL(`${process.env.NEXT_PUBLIC_WEBUI_HOST}/api/feature/list-dataset-replicas`),
                 method: 'GET',
                 params: {
-                    scope: params.scope,
-                    name: params.name,
+                    scope: decodedScope,
+                    name: decodedName,
                 },
                 headers: new Headers({
                     'Content-Type': 'application/json',
@@ -119,7 +114,7 @@ export default function Page({ params }: { params: { scope: string; name: string
         setRequests();
     }, []);
     if (didMeta.status === 'pending') {
-        return <Loading title="View DID" subtitle={`For DID ${params.scope}:${params.name}`} />;
+        return <Loading title="View DID" subtitle={`For DID ${decodedScope}:${decodedName}`} />;
     }
     return (
         <PageDIDStory

--- a/src/component-library/pages/DID/list/ListDID.tsx
+++ b/src/component-library/pages/DID/list/ListDID.tsx
@@ -40,7 +40,7 @@ export const ListDID = (props: ListDIDProps) => {
 
     const queryMeta = async () => {
         if (selectedItem !== null) {
-            const params = new URLSearchParams({ scope: selectedItem.scope, name: selectedItem.name });
+            const params = new URLSearchParams({ scope: encodeURIComponent(selectedItem.scope), name: encodeURIComponent(selectedItem.name) });
             const url = '/api/feature/get-did-meta?' + params;
 
             const res = await fetch(url);

--- a/src/component-library/pages/DID/list/meta/ListDIDMeta.tsx
+++ b/src/component-library/pages/DID/list/meta/ListDIDMeta.tsx
@@ -15,7 +15,7 @@ import { KeyValueWrapper } from '@/component-library/features/key-value/KeyValue
 
 const MetaHeader = ({ scope, name }: { scope: string; name: string }) => {
     return (
-        <KeyValueLinkHeader href={`/did/page/${scope}/${name}`}>
+        <KeyValueLinkHeader href={`/did/page/${encodeURIComponent(scope)}/${encodeURIComponent(name)}`}>
             <span>
                 {scope}:{name}
             </span>

--- a/src/lib/sdk/http.ts
+++ b/src/lib/sdk/http.ts
@@ -25,7 +25,10 @@ export function prepareRequestArgs(request: HTTPRequest): {
 } {
     if (request.params) {
         const url = new URL(request.url);
-        Object.keys(request.params).forEach(key => url.searchParams.append(key, request.params![key]));
+        Object.keys(request.params).forEach(key => {
+            const encodedValue = encodeURIComponent(request.params![key]);
+            url.searchParams.append(key, encodedValue);
+        });
         request.url = url.toString();
     }
     const requestArgs: RequestInit = {

--- a/src/pages/api/feature/get-did-meta.ts
+++ b/src/pages/api/feature/get-did-meta.ts
@@ -25,8 +25,8 @@ async function getDIDMeta(req: NextApiRequest, res: NextApiResponse, rucioAuthTo
     const controller = appContainer.get<BaseController<DIDMetaControllerParameters, void>>(CONTROLLERS.DID_META);
     const controllerParameters: DIDMetaControllerParameters = {
         response: res,
-        scope: scope,
-        name: name,
+        scope: decodeURIComponent(scope),
+        name: decodeURIComponent(name),
         rucioAuthToken: rucioAuthToken,
     };
 


### PR DESCRIPTION
Fix #485 

With this fix, the detailed view of the DIDs should become functional when slashes are present in the name.