### PR TITLE
Feature: DID Listing with optional name parameter

### DIFF
--- a/src/component-library/features/search/DIDSearchPanel.tsx
+++ b/src/component-library/features/search/DIDSearchPanel.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/component-library/atoms/form/input';
 import { SearchButton } from '@/component-library/features/search/SearchButton';
 
 const SCOPE_DELIMITER = ':';
-const emptyToastMessage = 'Please specify both scope and name before the search.';
+const emptyToastMessage = 'Please specify scope before the search.';
 const delimiterToastMessage = 'Neither scope nor name should contain ":".';
 
 interface SearchPanelProps {
@@ -73,19 +73,16 @@ export const DIDSearchPanel = (props: SearchPanelProps) => {
         return validateField(scope, 'scope', scopeInputRef);
     };
 
-    const validateName = (): boolean => {
-        return validateField(name, 'name', nameInputRef);
-    };
-
     const onSearch = (event: any) => {
         event.preventDefault();
 
-        if (!validateScope() || !validateName()) return;
+        if (!validateScope()) return;
 
-        const params = new URLSearchParams({
-            query: `${scope}${SCOPE_DELIMITER}${name}`,
-            type: type,
-        });
+        const queryValue = (name?.trim() ? `${scope}${SCOPE_DELIMITER}${name.trim()}` : scope) ?? '';
+
+        const params = new URLSearchParams();
+        params.set('query', queryValue);
+        params.set('type', type);
 
         const url = '/api/feature/list-dids?' + params;
         props.startStreaming(url);

--- a/src/lib/common/did-utils.ts
+++ b/src/lib/common/did-utils.ts
@@ -5,8 +5,11 @@
  * @returns The scope and name components of the DID string as a tuple
  * @throws An error if the DID string is invalid.
  */
-export function parseDIDString(didString: string, allowWildcardNames: boolean = true): { scope: string; name: string } {
+export function parseDIDString(didString: string, allowWildcardNames: boolean = true): { scope: string; name?: string } {
     const didParts = didString.trim().split(':');
+        if (didParts.length === 1) {
+        return { scope: didParts[0] };
+    }
     if (didParts.length !== 2) throw new Error('Invalid DID string');
     if (!allowWildcardNames && didParts[1].includes('*')) throw new Error('Invalid DID string, wildcard names not allowed');
     return {

--- a/src/lib/core/port/secondary/did-gateway-output-port.ts
+++ b/src/lib/core/port/secondary/did-gateway-output-port.ts
@@ -105,7 +105,7 @@ export default interface DIDGatewayOutputPort {
      * @param type The {@link DIDType} of the DID.
      * @returns A Promise that resolves to a {@link ListDIDDTO} object.
      */
-    listDIDs(rucioAuthToken: string, scope: string, name: string, type: DIDType): Promise<ListDIDDTO>;
+    listDIDs(rucioAuthToken: string, scope: string, name: string | undefined, type: DIDType): Promise<ListDIDDTO>;
 
     /**
      * Retrieves a list of replication rules for a given DID.

--- a/src/lib/core/use-case/list-dids/list-dids-usecase.ts
+++ b/src/lib/core/use-case/list-dids/list-dids-usecase.ts
@@ -30,7 +30,7 @@ class ListDIDsUseCase
 
     validateRequestModel(requestModel: AuthenticatedRequestModel<ListDIDsRequest>): ListDIDsError | undefined {
         let scope: string;
-        let name: string;
+        let name: string | undefined;
         try {
             let didComponents = parseDIDString(requestModel.query);
             scope = didComponents.scope;

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/list-dids-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/list-dids-endpoint.ts
@@ -34,7 +34,7 @@ export default class ListDIDsEndpoint extends BaseStreamableEndpoint<ListDIDDTO,
             },
             body: null,
             params: {
-                name: this.name,
+                ...(this.name ? { name: this.name } : {}),
                 type: this.type.toLocaleLowerCase(),
             },
         };


### PR DESCRIPTION
[GSoC 2025 Qualification Task]

Fixes: #520 

## Summary  
This PR modifies the `ListDID` feature in the Rucio WebUI to allow searching for DIDs **without requiring a `name` parameter**. Instead of making multiple API calls for each DID, the WebUI now fetches a list of all DIDs under a given scope first. Detailed information is retrieved **only when a DID is clicked**, improving performance.  

## Changes Implemented  

### **1. Made `name` Optional in Search DIDs**  
- Updated the search logic to allow requests with only `scope`, making `name` optional.  

### **2. Updated Frontend Behavior**  
- The UI now lists all DIDs under a scope first.  
- Clicking on a DID triggers a separate request to fetch its full details.  
- This approach prevents excessive API calls and improves responsiveness.  

## Testing and Validation  

- Verified that searching with both `scope` and `name` works as before.  
- Ensured that searching with only `scope` correctly lists all DIDs under it.