### PR TITLE
Issue #542. Replace old dark mode logo with new inverted version

### DIFF
--- a/public/logo_dark.svg
+++ b/public/logo_dark.svg
@@ -1,291 +1,90 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   id="Black"
-   viewBox="0 110 89.999995 90"
-   version="1.1"
-   sodipodi:docname="logocropped.svg"
-   width="90"
-   height="90"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview942"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="true"
-     showgrid="false"
-     inkscape:zoom="3.2404919"
-     inkscape:cx="195.18642"
-     inkscape:cy="143.80533"
-     inkscape:window-width="2560"
-     inkscape:window-height="1415"
-     inkscape:window-x="2560"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="Black" />
-  <defs
-     id="defs909">
-    <style
-       id="style907">.cls-1{fill:#f1f5f9;}</style>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1562">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1564"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1566">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1568"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1570">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1572"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1574">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1576"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1578">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1580"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1582">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1584"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1586">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1588"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1590">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1592"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1594">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1596"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1598">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1600"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1602">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1604"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1606">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1608"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1610">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1612"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath1614">
-      <rect
-         style="fill:#6699ff;fill-opacity:0.519409;stroke-width:7.93701;stroke-linecap:round;stroke-dasharray:7.93701, 15.874"
-         id="rect1616"
-         width="92.929924"
-         height="92.929924"
-         x="81.084496"
-         y="162.05412" />
-    </clipPath>
-  </defs>
-  <title
-     id="title911">Horizontaled_Black</title>
-  <path
-     class="cls-1"
-     d="m 237.05,194.69 q 0,-21.88 -30.19,-21.89 h -24.27 v 74.08 h 20 v -27 h 5.07 l 15.71,27 h 22.69 L 224.49,214.6 q 12.57,-7.03 12.56,-19.91 z m -30.7,10.18 H 202.6 V 188 h 4 q 10.29,0 10.29,7.65 -0.05,9.22 -10.54,9.22 z"
-     id="path913"
-     clip-path="url(#clipPath1614)" />
-  <path
-     class="cls-1"
-     d="m 295.78,216.17 q 0,8 -2.77,11.53 -2.77,3.53 -8.89,3.52 -5.72,0 -8.66,-3.55 -2.94,-3.55 -2.94,-11.4 V 172.8 h -20.11 v 45 q 0,14.53 8.13,22.29 8.13,7.76 23.28,7.75 15.51,0 23.74,-8 8.23,-8 8.23,-22.52 V 172.8 h -20 z"
-     id="path915"
-     clip-path="url(#clipPath1610)" />
-  <path
-     class="cls-1"
-     d="m 364.33,188.15 a 28.57,28.57 0 0 1 8.81,1.32 69.17,69.17 0 0 1 8.21,3.24 L 387.48,177 a 52.64,52.64 0 0 0 -23,-5.22 37.59,37.59 0 0 0 -19.13,4.69 31,31 0 0 0 -12.46,13.4 44.83,44.83 0 0 0 -4.28,20.13 q 0,18.39 8.94,28.12 8.94,9.73 25.71,9.73 a 51.4,51.4 0 0 0 21,-4.1 v -16.89 a 93.71,93.71 0 0 1 -9.27,3.3 33.42,33.42 0 0 1 -9.53,1.36 q -16.26,0 -16.26,-21.38 0,-10.27 4,-16.13 a 12.77,12.77 0 0 1 11.13,-5.86 z"
-     id="path917"
-     clip-path="url(#clipPath1606)" />
-  <rect
-     class="cls-1"
-     x="398.67999"
-     y="172.8"
-     width="20.110001"
-     height="74.07"
-     id="rect919"
-     clip-path="url(#clipPath1602)" />
-  <path
-     class="cls-1"
-     d="m 495,181.31 q -9.12,-9.67 -26.81,-9.67 -17.69,0 -26.88,9.75 -9.24,9.75 -9.24,28.25 0,18.69 9.3,28.47 9.3,9.78 26.72,9.78 17.69,0 26.85,-9.73 9.16,-9.73 9.18,-28.42 0,-18.74 -9.12,-28.43 z M 479.37,226 q -3.67,5.22 -11.28,5.22 -14.94,0 -14.94,-21.48 0,-21.69 15,-21.69 7.4,0 11.12,5.3 3.72,5.3 3.73,16.39 0,11.04 -3.63,16.26 z"
-     id="path921"
-     clip-path="url(#clipPath1598)" />
-  <path
-     class="cls-1"
-     d="m 164.12,233.55 v 9.26 a 1.79,1.79 0 0 1 -1.79,1.78 H 96.24 a 1.78,1.78 0 0 1 -1.78,-1.78 h -3.3 a 5.09,5.09 0 0 0 5.08,5.08 h 66.09 a 5.09,5.09 0 0 0 5.08,-5.08 v -12.22 a 11.6,11.6 0 0 1 -3.29,2.96 z"
-     id="path923"
-     clip-path="url(#clipPath1594)"
-     transform="translate(-83.473852,-52.651303)" />
-  <path
-     class="cls-1"
-     d="m 164.12,176.72 v 36.8 a 11.57,11.57 0 0 1 3.29,3 v -39.8 a 5.09,5.09 0 0 0 -5.08,-5.08 h -37.15 v 3.29 h 37.15 a 1.79,1.79 0 0 1 1.79,1.79 z"
-     id="path925"
-     clip-path="url(#clipPath1590)"
-     transform="translate(-83.473852,-52.651303)" />
-  <path
-     class="cls-1"
-     d="m 162.92,215.14 -8.4,-4.84 v 0 L 145,204.79 v 0 a 11,11 0 0 0 -15,4 l -18.8,32.51 h 25.45 l 9.35,-16.17 3,1.72 a 9.7,9.7 0 1 0 14,-11.71 z m -19.36,-4.83 a 4,4 0 1 1 1.46,5.45 4,4 0 0 1 -1.46,-5.45 z m 22.37,17.77 a 9.07,9.07 0 0 1 -16.38,-1.44 l -0.08,-0.21 -0.2,-0.12 -3,-1.72 2.74,-4.74 c 0.11,-0.19 0.22,-0.39 0.31,-0.58 l 4.87,-8.43 8.4,4.84 a 9.09,9.09 0 0 1 3.34,12.4 z"
-     id="path927"
-     clip-path="url(#clipPath1586)"
-     transform="translate(-83.473852,-52.651303)" />
-  <circle
-     class="cls-1"
-     cx="164.08"
-     cy="223.16"
-     r="1.7"
-     id="circle929"
-     clip-path="url(#clipPath1582)"
-     transform="translate(-83.473852,-52.651303)" />
-  <path
-     class="cls-1"
-     d="m 110.09,238.4 -2.69,-1.55 1.56,-2.7 2.69,1.56 z m 3.11,-5.4 -2.69,-1.55 1.56,-2.69 2.69,1.55 z m 3.11,-5.38 -2.69,-1.56 1.56,-2.69 2.69,1.56 z m 3.11,-5.39 -2.69,-1.55 1.55,-2.69 2.7,1.55 z m 3.11,-5.38 -2.69,-1.56 1.55,-2.69 2.7,1.56 z m 3.11,-5.39 -2.64,-1.54 1.55,-2.69 2.7,1.55 z m 3.1,-5.17 -2.49,-1.86 a 15.84,15.84 0 0 1 2.32,-2.52 l 2.05,2.33 a 13.07,13.07 0 0 0 -1.88,2.06 z m 17.47,-3.59 a 13.72,13.72 0 0 0 -2.54,-1.14 l 1,-2.95 a 15.85,15.85 0 0 1 3.12,1.4 z m -13.32,-0.07 -1.53,-2.71 a 17.13,17.13 0 0 1 3.14,-1.36 l 0.94,3 a 14,14 0 0 0 -2.55,1.08 z M 141,201 a 12.92,12.92 0 0 0 -2.78,0 l -0.31,-3.1 a 16.29,16.29 0 0 1 3.42,0 z"
-     id="path931"
-     clip-path="url(#clipPath1578)"
-     transform="translate(-83.473852,-52.651303)" />
-  <path
-     class="cls-1"
-     d="m 111.56,181.07 a 0.68,0.68 0 0 1 0.69,-1.1 19.34,19.34 0 0 1 14.68,17.5 0.68,0.68 0 0 1 -1.2,0.48 z"
-     id="path933"
-     clip-path="url(#clipPath1574)"
-     transform="translate(-83.473852,-52.651303)" />
-  <path
-     class="cls-1"
-     d="m 96.6,189.58 a 0.86,0.86 0 0 0 -1.22,1.09 24.49,24.49 0 0 0 25.09,14.48 0.86,0.86 0 0 0 0.33,-1.6 z"
-     id="path935"
-     clip-path="url(#clipPath1570)"
-     transform="translate(-83.473852,-52.651303)" />
-  <circle
-     class="cls-1"
-     cx="149.3"
-     cy="212.22"
-     r="1.7"
-     id="circle937"
-     clip-path="url(#clipPath1566)"
-     transform="translate(-83.473852,-52.651303)" />
-  <path
-     class="cls-1"
-     d="m 166,228.18 a 48.63,48.63 0 0 1 -9,-0.84 l -0.3,1.57 a 49.3,49.3 0 0 0 8.15,0.86 9.46,9.46 0 0 0 1.18,-1.55 z"
-     id="path939"
-     clip-path="url(#clipPath1562)"
-     transform="translate(-83.473852,-52.651303)" />
-  <metadata
-     id="metadata1618">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:title>Horizontaled_Black</dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 28.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1"
+	 id="Black" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:svg="http://www.w3.org/2000/svg"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 90 90"
+	 style="enable-background:new 0 0 90 90;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#FFFFFF;stroke-width:1.5;stroke-miterlimit:10;}
+	.st1{fill:none;}
+	.st2{clip-path:url(#SVGID_00000000185275052644769830000013151746304174178444_);fill:#F1F5F9;}
+	.st3{clip-path:url(#SVGID_00000164491873591484695060000017781987653162969255_);fill:#F1F5F9;}
+	.st4{clip-path:url(#SVGID_00000055680628380204731340000001585535257883864966_);fill:#F1F5F9;}
+	.st5{clip-path:url(#SVGID_00000178201550676583312830000002490922547254918812_);}
+	.st6{fill:#FFFFFF;}
+	.st7{clip-path:url(#SVGID_00000115480045037265382040000013731665804703953590_);}
+</style>
+<sodipodi:namedview  bordercolor="#666666" borderopacity="1.0" id="namedview942" inkscape:current-layer="Black" inkscape:cx="195.18642" inkscape:cy="143.80533" inkscape:pagecheckerboard="true" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:window-height="1415" inkscape:window-maximized="1" inkscape:window-width="2560" inkscape:window-x="2560" inkscape:window-y="0" inkscape:zoom="3.2404919" pagecolor="#ffffff" showgrid="false">
+	</sodipodi:namedview>
+<path id="_x31_23" class="st0" d="M71.5,45.7L62,40.2c-5.2-3-12-1.2-15,4L28.2,76.7h25.4L63,60.5 M78.4,68 M83.8,63.8
+	c-2.6,4.6-8.4,6.1-13,3.5c-1.9-1.1-3.4-2.9-4.2-5l-0.1-0.2L66.3,62l-3.1-1.8l2.9-5c0.1-0.2,0.2-0.4,0.3-0.6l5.1-8.9l8.8,5.1
+	C84.8,53.4,86.4,59.2,83.8,63.8L83.8,63.8z M67.4,52.8"/>
+<rect x="-1.9" y="-2.5" class="st1" width="92.9" height="92.9"/>
+<g>
+	<defs>
+		<rect id="SVGID_1_" x="-1.9" y="-2.5" width="92.9" height="92.9"/>
+	</defs>
+	<clipPath id="SVGID_00000119078286352185343890000000418817882382010806_">
+		<use xlink:href="#SVGID_1_"  style="overflow:visible;"/>
+	</clipPath>
+	<path id="path923" style="clip-path:url(#SVGID_00000119078286352185343890000000418817882382010806_);fill:#F1F5F9;" d="
+		M81.1,68.9v9.3c0,1-0.8,1.8-1.8,1.8H13.2c-1,0-1.8-0.8-1.8-1.8H8.1c0,2.8,2.3,5.1,5.1,5.1h66.1c2.8,0,5.1-2.3,5.1-5.1V66
+		C83.5,67.2,82.4,68.2,81.1,68.9z"/>
+</g>
+<g>
+	<defs>
+		<rect id="SVGID_00000013901827037532009000000005864913473442283939_" x="-1.9" y="-2.5" width="92.9" height="92.9"/>
+	</defs>
+	<clipPath id="SVGID_00000005981698896827115930000011079790462740163970_">
+		<use xlink:href="#SVGID_00000013901827037532009000000005864913473442283939_"  style="overflow:visible;"/>
+	</clipPath>
+	<path id="path925" style="clip-path:url(#SVGID_00000005981698896827115930000011079790462740163970_);fill:#F1F5F9;" d="
+		M81.1,12.1v36.8c1.3,0.8,2.4,1.8,3.3,3V12.1c0-2.8-2.3-5.1-5.1-5.1H42.1v3.3h37.2C80.3,10.3,81.1,11.1,81.1,12.1L81.1,12.1z"/>
+</g>
+<g>
+	<defs>
+		<rect id="SVGID_00000077282837425409563650000011904556358143225005_" x="-1.9" y="-2.5" width="92.9" height="92.9"/>
+	</defs>
+	<clipPath id="SVGID_00000176732679073666135040000013513732868104191900_">
+		<use xlink:href="#SVGID_00000077282837425409563650000011904556358143225005_"  style="overflow:visible;"/>
+	</clipPath>
+	<path id="path931" style="clip-path:url(#SVGID_00000176732679073666135040000013513732868104191900_);fill:#F1F5F9;" d="
+		M27.1,73.8l-2.7-1.6l1.6-2.7l2.7,1.6L27.1,73.8z M30.2,68.4l-2.7-1.6l1.6-2.7l2.7,1.6L30.2,68.4z M33.3,63l-2.7-1.6l1.6-2.7
+		l2.7,1.6L33.3,63z M36.4,57.6l-2.7-1.6l1.6-2.7l2.7,1.6L36.4,57.6z M39.5,52.2l-2.7-1.6l1.6-2.7l2.7,1.6L39.5,52.2z M42.6,46.9
+		L40,45.3l1.6-2.7l2.7,1.6L42.6,46.9z M45.7,41.7l-2.5-1.9c0.7-0.9,1.5-1.8,2.3-2.5l2.1,2.3C46.9,40.3,46.3,40.9,45.7,41.7
+		L45.7,41.7z M63.2,38.1c-0.8-0.5-1.7-0.8-2.5-1.1l1-2.9c1.1,0.4,2.1,0.8,3.1,1.4L63.2,38.1z M49.9,38l-1.5-2.7c1-0.6,2.1-1,3.1-1.4
+		l0.9,3C51.5,37.2,50.7,37.6,49.9,38L49.9,38z M58,36.4c-0.9-0.1-1.9-0.1-2.8,0l-0.3-3.1c1.1-0.1,2.3-0.1,3.4,0L58,36.4z"/>
+</g>
+<g>
+	<defs>
+		<rect id="SVGID_00000103243503020625058930000000550668017229146548_" x="-1.9" y="-2.5" width="92.9" height="92.9"/>
+	</defs>
+	<clipPath id="SVGID_00000083777692206228215260000005517089058463512977_">
+		<use xlink:href="#SVGID_00000103243503020625058930000000550668017229146548_"  style="overflow:visible;"/>
+	</clipPath>
+	<g id="path933" style="clip-path:url(#SVGID_00000083777692206228215260000005517089058463512977_);">
+		<path class="st6" d="M31.5,17.7c5.3,2.2,9.2,6.9,10.5,12.5L31.5,17.7 M29,15.3c-0.2,0-0.3,0.1-0.4,0.2c-0.3,0.2-0.3,0.7-0.1,1
+			l14.2,16.9c0.1,0.2,0.3,0.2,0.5,0.2c0,0,0,0,0,0c0.4,0,0.7-0.3,0.6-0.7c-0.6-8.4-6.5-15.5-14.7-17.5C29.2,15.4,29.1,15.3,29,15.3
+			L29,15.3z"/>
+	</g>
+</g>
+<g>
+	<defs>
+		<rect id="SVGID_00000058574431188709972230000017354267694343325337_" x="-1.9" y="-2.5" width="92.9" height="92.9"/>
+	</defs>
+	<clipPath id="SVGID_00000050657604186042270690000003659351601250460576_">
+		<use xlink:href="#SVGID_00000058574431188709972230000017354267694343325337_"  style="overflow:visible;"/>
+	</clipPath>
+	<g id="path935" style="clip-path:url(#SVGID_00000050657604186042270690000003659351601250460576_);">
+		<path class="st6" d="M14.6,27.3l20.5,11.9c-0.1,0-0.3,0-0.4,0C26.3,39.2,18.7,34.6,14.6,27.3 M13.1,24.9c-0.3,0-0.6,0.2-0.7,0.4
+			c-0.1,0.2-0.2,0.5,0,0.8c3.9,9,12.8,14.6,22.4,14.6c0.9,0,1.8,0,2.7-0.1c0.5-0.1,0.8-0.5,0.8-1c0-0.3-0.2-0.5-0.4-0.6L13.6,25
+			C13.4,24.9,13.3,24.9,13.1,24.9L13.1,24.9z"/>
+	</g>
+</g>
+<path class="st6" d="M80.4,51.1l-8.7-4.9l-5,8.5c-0.1,0.2-0.2,0.4-0.3,0.6l-2.8,4.8l3.1,1.7l0.2,0.1l0.1,0.2c0.8,2,2.2,3.7,4.1,4.8
+	c4.5,2.5,10.2,1,12.8-3.4l0,0C86.4,59.3,84.8,53.7,80.4,51.1z M80.9,56.6c0.9,0,1.7,0.8,1.7,1.7S81.8,60,80.9,60s-1.7-0.8-1.7-1.7
+	S79.9,56.6,80.9,56.6z M81.7,64.9c-2.7-0.1-5.5-0.3-8.2-0.9l0.3-1.6c3,0.6,6,0.8,9,0.8l0,0C82.5,63.9,82.1,64.4,81.7,64.9z"/>
+<path class="st6" d="M65.8,44.2c-2-1.2-4.6-0.5-5.8,1.6c-1.2,2-0.5,4.6,1.5,5.8c0,0,0,0,0,0c2,1.2,4.6,0.5,5.8-1.6
+	S67.9,45.4,65.8,44.2z M65.8,49.7c-0.9,0-1.7-0.8-1.7-1.7c0-0.9,0.8-1.7,1.7-1.7c0.9,0,1.7,0.8,1.7,1.7
+	C67.5,48.9,66.8,49.7,65.8,49.7z"/>
 </svg>


### PR DESCRIPTION
Added a dark mode logo – an inverted version of the old logo matching the style of the official Rucio website.