### PR TITLE
Explicitly encoded DID Name when sending requests to rucio server 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true,
-  "jest.jestCommandLine": "npm run test -- --watch --env=jsdom --runInBand",
-  "jest.autoRun": {
-    "onSave": false
-  },
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "typescript.enablePromptUseWorkspaceTsdk": true,
+    "jest.jestCommandLine": "npm run test -- --watch --env=jsdom --runInBand",
+    "jest.runMode": "on-demand"
 }

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-endpoint.ts
@@ -18,7 +18,7 @@ export default class GetDIDEndpoint extends BaseEndpoint<DIDExtendedDTO> {
      */
     async initialize(): Promise<void> {
         await super.initialize();
-        this.url = `${this.rucioHost}/dids/${this.scope}/${this.name}/status`;
+        this.url = `${this.rucioHost}/dids/${encodeURIComponent(this.scope)}/${encodeURIComponent(this.name)}/status`;
         if (this.dynamicDepth) {
             this.url += `?dynamic_depth=${this.dynamicDepth.toUpperCase()}`;
         }

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-keyvaluepairs-endpoint.ts
@@ -11,7 +11,9 @@ export default class GetDIDKeyValuePairsEndpoint extends BaseEndpoint<DIDKeyValu
 
     async initialize(): Promise<void> {
         await super.initialize();
-        this.url = `${this.rucioHost}/dids/${this.scope}/${this.name}/meta`;
+        const encodedScope = encodeURIComponent(this.scope);
+        const encodedName = encodeURIComponent(this.name);
+        this.url = `${this.rucioHost}/dids/${encodedScope}/${encodedName}/meta`;
         const request: HTTPRequest = {
             method: 'GET',
             url: this.url,

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-meta-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/get-did-meta-endpoint.ts
@@ -11,7 +11,7 @@ export default class GetDIDMetaEndpoint extends BaseEndpoint<DIDMetaDTO> {
 
     async initialize(): Promise<void> {
         await super.initialize();
-        this.url = `${this.rucioHost}/dids/${this.scope}/${this.name}/meta`;
+        this.url = `${this.rucioHost}/dids/${encodeURIComponent(this.scope)}/${encodeURIComponent(this.name)}/meta`;
         const request: HTTPRequest = {
             method: 'GET',
             url: this.url,

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/list-did-contents-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/list-did-contents-endpoint.ts
@@ -11,7 +11,7 @@ export default class ListDIDContentsEndpoint extends BaseStreamableEndpoint<List
     async initialize(): Promise<void> {
         await super.initialize();
         const rucioHost = await this.envConfigGateway.rucioHost();
-        const endpoint = `${rucioHost}/dids/${this.scope}/${this.name}/dids`;
+        const endpoint = `${rucioHost}/dids/${encodeURIComponent(this.scope)}/${encodeURIComponent(this.name)}/dids`;
         const request: HTTPRequest = {
             method: 'GET',
             url: endpoint,

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/list-did-parents-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/list-did-parents-endpoint.ts
@@ -14,7 +14,9 @@ export default class ListDIDParentsEndpoint extends BaseStreamableEndpoint<ListD
     async initialize(): Promise<void> {
         await super.initialize();
         const rucioHost = await this.envConfigGateway.rucioHost();
-        const endpoint = `${rucioHost}/dids/${this.scope}/${this.name}/parents`;
+        const encodedScope = encodeURIComponent(this.scope);
+        const encodedName = encodeURIComponent(this.name);
+        const endpoint = `${rucioHost}/dids/${encodedScope}/${encodedName}/parents`;
         const request: HTTPRequest = {
             method: 'GET',
             url: endpoint,

--- a/src/lib/infrastructure/gateway/did-gateway/endpoints/list-did-rules-endpoint.ts
+++ b/src/lib/infrastructure/gateway/did-gateway/endpoints/list-did-rules-endpoint.ts
@@ -15,7 +15,9 @@ export default class ListDIDRulesEndpoint extends BaseStreamableEndpoint<ListDID
     async initialize(): Promise<void> {
         await super.initialize();
         const rucioHost = await this.envConfigGateway.rucioHost();
-        const endpoint = `${rucioHost}/dids/${this.scope}/${this.name}/rules`;
+        const encodedScope = encodeURIComponent(this.scope);
+        const encodedName = encodeURIComponent(this.name);
+        const endpoint = `${rucioHost}/dids/${encodedScope}/${encodedName}/rules`;
         const request: HTTPRequest = {
             method: 'GET',
             url: endpoint,

--- a/src/lib/infrastructure/gateway/replica-gateway/endpoints/list-dataset-replicas-endpoint.ts
+++ b/src/lib/infrastructure/gateway/replica-gateway/endpoints/list-dataset-replicas-endpoint.ts
@@ -11,7 +11,9 @@ export default class ListDatasetReplicasEndpoint extends BaseStreamableEndpoint<
     async initialize(): Promise<void> {
         await super.initialize();
         const rucioHost = await this.envConfigGateway.rucioHost();
-        const endpoint = `${rucioHost}/replicas/${this.scope}/${this.name}/datasets`;
+        const encodedScope = encodeURIComponent(this.scope);
+        const encodedName = encodeURIComponent(this.name);
+        const endpoint = `${rucioHost}/replicas/${encodedScope}/${encodedName}/datasets`;
         const request: HTTPRequest = {
             method: 'GET',
             url: endpoint,

--- a/src/lib/infrastructure/gateway/subscription-gateway/endpoints/get-subscription-endpoint.ts
+++ b/src/lib/infrastructure/gateway/subscription-gateway/endpoints/get-subscription-endpoint.ts
@@ -12,7 +12,7 @@ export default class GetSubscriptionEndpoint extends BaseEndpoint<SubscriptionDT
 
     async initialize(): Promise<void> {
         await super.initialize();
-        this.url = `${this.rucioHost}/subscriptions/${this.account}/${this.name}`;
+        this.url = `${this.rucioHost}/subscriptions/${this.account}/${encodeURIComponent(this.name)}`;
         const request: HTTPRequest = {
             method: 'GET',
             url: this.url,

--- a/src/lib/sdk/gateway-endpoints.ts
+++ b/src/lib/sdk/gateway-endpoints.ts
@@ -206,8 +206,7 @@ export abstract class BaseEndpoint<TDTO extends BaseDTO> {
             throw new Error(`Request not initialized for ${this.constructor.name}`);
         }
 
-        const encodeParams = await this.envConfigGateway.paramsEncodingEnabled();
-        const preparedRequest = prepareRequestArgs(this.request, encodeParams);
+        const preparedRequest = prepareRequestArgs(this.request);
 
         const response: Response = await fetch(preparedRequest.url, preparedRequest.requestArgs);
         if (!response.ok) {

--- a/src/lib/sdk/http.ts
+++ b/src/lib/sdk/http.ts
@@ -17,12 +17,10 @@ export type HTTPRequest = {
 /**
  * Prepares the request arguments for an HTTP request.
  * @param {HTTPRequest} request - The HTTP request to prepare arguments for.
- * @param {boolean} encodeParams - Whether the query parameters should get URI encoded
  * @returns {{ url: string | URL; requestArgs: RequestInit }} - An object containing the URL and request arguments.
  */
 export function prepareRequestArgs(
     request: HTTPRequest,
-    encodeParams: boolean = false,
 ): {
     url: string | URL;
     requestArgs: RequestInit;
@@ -31,7 +29,7 @@ export function prepareRequestArgs(
         const url = new URL(request.url);
         Object.keys(request.params).forEach(key => {
             const value = request.params![key];
-            url.searchParams.append(key, encodeParams ? encodeURIComponent(value) : value);
+            url.searchParams.append(key, value);
         });
         request.url = url.toString();
     }

--- a/src/lib/sdk/streaming-gateway.ts
+++ b/src/lib/sdk/streaming-gateway.ts
@@ -32,8 +32,7 @@ export default class StreamingGateway implements StreamGatewayOutputPort {
     }
 
     async getJSONChunks(request: HTTPRequest, ndjson: boolean = false): Promise<{ type: 'response' | 'stream'; content: PassThrough | Response }> {
-        const encodeParams = await this.envConfigGateway.paramsEncodingEnabled();
-        const { url, requestArgs } = prepareRequestArgs(request, encodeParams);
+        const { url, requestArgs } = prepareRequestArgs(request);
         const response = await fetch(url, requestArgs);
 
         if (!response.ok || response.body === null) {

--- a/src/lib/sdk/streaming-gateway.ts
+++ b/src/lib/sdk/streaming-gateway.ts
@@ -19,8 +19,7 @@ export default class StreamingGateway implements StreamGatewayOutputPort {
     });
 
     async getTextStream(request: HTTPRequest): Promise<PassThrough | Response> {
-        const encodeParams = await this.envConfigGateway.paramsEncodingEnabled();
-        const { url, requestArgs } = prepareRequestArgs(request, encodeParams);
+        const { url, requestArgs } = prepareRequestArgs(request);
 
         const response = await fetch(url, requestArgs);
         if (!response.ok || response.body === null) {

--- a/test/api/did/did-keyvaluepairs.test.ts
+++ b/test/api/did/did-keyvaluepairs.test.ts
@@ -7,11 +7,11 @@ import { createHttpMocks } from 'test/fixtures/http-fixtures';
 import { NextApiResponse } from 'next';
 import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
 
-describe('DID KeyValuePairs API Tests', () => {
+describe('DID KeyValuePairs API Tests: DID with encoded slashes', () => {
     beforeEach(() => {
         fetchMock.doMock();
         const didKeyValuePairsMockEndpoint: MockEndpoint = {
-            url: `${MockRucioServerFactory.RUCIO_HOST}/dids/test/dataset1/meta`,
+            url: `${MockRucioServerFactory.RUCIO_HOST}/dids/test/test%2Fdataset1/meta`,
             method: 'GET',
             includes: 'test/dataset1/meta',
             response: {
@@ -38,7 +38,7 @@ describe('DID KeyValuePairs API Tests', () => {
             CONTROLLERS.DID_KEYVALUEPAIRS,
         );
         const didKVControllerParams: DIDKeyValuePairsDataControllerParameters = {
-            name: 'test/dataset1',
+            name: 'test/dataset1', // Example of a DID with '/' in the name, this should be encoded
             scope: 'test',
             rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
             response: res as unknown as NextApiResponse,


### PR DESCRIPTION
This pull request introduces changes to ensure consistent and explicit URI encoding of dynamic parameters (`scope`, `name`, etc.) in API endpoint URLs and simplifies the request preparation logic by removing redundant parameter encoding configurations. Below is a categorized summary of the most important changes:

### URI Encoding Enhancements:
* Updated endpoint URLs across multiple classes to explicitly encode dynamic parameters (`scope`, `name`, etc.) using `encodeURIComponent`. This ensures proper handling of special characters in API requests. Examples include:
  - `GetDIDEndpoint` (`get-did-endpoint.ts`) now encodes `scope` and `name` in the URL.
  - `ListDIDContentsEndpoint` (`list-did-contents-endpoint.ts`) applies encoding to `scope` and `name`.
  - Similar updates were made in `ListDIDParentsEndpoint` [[1]](diffhunk://#diff-bd2864faf3aa7bd2951dbf995f5b01e1e72e91d69f864b4fbadda6282dae59deL17-R19) `ListDIDRulesEndpoint` [[2]](diffhunk://#diff-9a238087b3bbf050b66456c201f51e1210f7e051a9b546d2a1383f4fb65750e7L18-R20) and others.

### Simplification of Request Preparation:
* Removed the `encodeParams` argument from the `prepareRequestArgs` function in `http.ts`, as parameter encoding is now handled explicitly at the point of use:
  - Eliminated the `encodeParams` parameter and related logic in `prepareRequestArgs`. [[1]](diffhunk://#diff-b00f268de2c856c32cd2f300f01111f954dcafdcde7132b144207b649b3e1d96L20-L25) [[2]](diffhunk://#diff-b00f268de2c856c32cd2f300f01111f954dcafdcde7132b144207b649b3e1d96L34-R32)
  - Adjusted all calls to `prepareRequestArgs` to align with the updated function signature. [[1]](diffhunk://#diff-d684c90a9ec32a2b4463d81dca966000de7db3be876c36ea2f8409ef9d34cf60L209-R209) [[2]](diffhunk://#diff-48a5d5282b6b8e7f008377969140eaa39f92ed0dfb022c2c5275ccac48653b34L22-R22)

These changes improve the reliability of API requests by ensuring proper encoding and reduce complexity in the codebase by centralizing encoding logic.

Fix #512 
Fix #533