### PR TITLE
Bug 552. Allow creating rules on RSEs with infinite quota

### DIFF
--- a/src/component-library/features/table/cells/ClickableCell.tsx
+++ b/src/component-library/features/table/cells/ClickableCell.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { HiExternalLink } from 'react-icons/hi';
 import { twMerge } from 'tailwind-merge';
 
-export const ClickableCell = (props: { href: string; children: React.ReactNode, className?: string }) => {
+export const ClickableCell = (props: { href: string; children: React.ReactNode; className?: string }) => {
     return (
         <Link href={props.href}>
             <div className={twMerge(props.className)}>

--- a/src/component-library/pages/Rule/create/CreateRule.tsx
+++ b/src/component-library/pages/Rule/create/CreateRule.tsx
@@ -83,7 +83,13 @@ export const CreateRule = (props: CreateRuleProps) => {
 
         newOptionErrors.copiesInvalid = isNaN(copies) || copies < 1 || copies > parameters.rses.length;
         newOptionErrors.tooManyCopies =
-            !parameters.askApproval && parameters.rses.filter(rse => rse.bytes_remaining >= totalDataSize).length < copies;
+            !parameters.askApproval &&
+            parameters.rses.filter(rse => {
+                if (rse.bytes_remaining >= totalDataSize) return true;
+                // if the bytes_limit is -1, it means there is no limit (infinite quota)
+                if (rse.bytes_limit === -1 && rse.has_quota) return true;
+                return false;
+            }).length < copies;
 
         newOptionErrors.lifetimeInvalid = daysLifetime !== undefined && (isNaN(daysLifetime) || daysLifetime < 1);
 

--- a/src/component-library/pages/Rule/create/stage-rses/CreateRuleStageStorage.tsx
+++ b/src/component-library/pages/Rule/create/stage-rses/CreateRuleStageStorage.tsx
@@ -54,7 +54,12 @@ export const CreateRuleStageStorage = (props: CreateRuleStageStorageProps) => {
     };
 
     useEffect(() => {
-        const hasSingleSufficient = selectedItems.some(element => element.bytes_remaining >= totalDataSize);
+        const hasSingleSufficient = selectedItems.some(element => {
+            if (element.bytes_remaining >= totalDataSize) return true;
+            // if the bytes_limit is -1, it means there is no limit (infinite quota)
+            if (element.bytes_limit === -1 && element.has_quota) return true;
+            return false;
+        });
         const changeNeedsApproval = selectedItems.length > 0 && !hasSingleSufficient;
         setNeedsApproval(changeNeedsApproval);
         props.updateNeedsApproval(changeNeedsApproval);

--- a/src/component-library/pages/Rule/create/stage-rses/CreateRuleStageStorageTable.tsx
+++ b/src/component-library/pages/Rule/create/stage-rses/CreateRuleStageStorageTable.tsx
@@ -35,10 +35,12 @@ export const CreateRuleStageStorageTable: React.FC<StageStorageTableProps> = ({ 
         },
         {
             headerName: 'Quota',
-            field: 'bytes_limit',
             cellRenderer: (params: ICellRendererParams) => {
                 const item: RSEAccountUsageLimitViewModel = params.data;
-                const value = params.value < 0 ? 'No quota' : formatFileSize(params.value);
+                if (item.bytes_limit === -1 && item.has_quota) {
+                    return 'Infinite';
+                }
+                const value = item.bytes_limit < 0 ? 'No quota' : formatFileSize(item.bytes_limit);
                 return <WarningCell warn={!item.has_quota} {...params} value={value} />;
             },
             colSpan: (params: ColSpanParams) => {

--- a/src/component-library/pages/Rule/create/stage-summary/CreateRuleStageSummaryStorageTable.tsx
+++ b/src/component-library/pages/Rule/create/stage-summary/CreateRuleStageSummaryStorageTable.tsx
@@ -33,6 +33,9 @@ export const CreateRuleStageSummaryStorageTable: React.FC<StageSummaryStageTable
             field: 'bytes_limit',
             cellRenderer: (params: ICellRendererParams) => {
                 const item: RSEAccountUsageLimitViewModel = params.data;
+                if (item.bytes_limit === -1 && item.has_quota) {
+                    return 'Infinite';
+                }
                 const value = params.value < 0 ? 'No quota' : formatFileSize(params.value);
                 return <WarningCell warn={!item.has_quota} {...params} value={value} />;
             },

--- a/src/component-library/pages/legacy/Login/Login.tsx
+++ b/src/component-library/pages/legacy/Login/Login.tsx
@@ -178,127 +178,127 @@ export const Login = ({
     const getLoginForm = () => {
         return (
             <motion.div initial="hidden" animate="visible" variants={formVariants}>
-            <div
-                className={twMerge(
-                    'flex flex-col items-center justify-between',
-                    'border dark:border-2 rounded-xl p-6 flex flex-col justify-center space-y-4',
-                    'border-neutral-300 dark:border-neutral-700',
-                    'bg-neutral-50 dark:bg-neutral-900'
-                )}
-                id="root"
-            >
-                <MultipleAccountsModal
-                    submit={lastAuthMethod === 'x509' ? submitX509 : submitUserPass}
-                    availableAccounts={availableAccounts}
-                    onClose={() => setAvailableAccounts([])}
-                />
-                <Collapsible id="login-page-error" showIf={error !== undefined}>
-                    <Alert
-                        variant="error"
-                        message={error}
-                        onClose={() => {
-                            setError(undefined);
-                        }}
-                    />
-                </Collapsible>
-                <div className="flex flex-col items-center justify-between w-64 text-center text-text-1000 dark:text-text-0">
-                <motion.div initial="hidden" animate="visible" variants={logoVariants}>
-                    <Image src="/rucio-logo.png" alt="Rucio Logo" width={146} height={176} />
-                </motion.div>
-                </div>
-
                 <div
-                    className="flex flex-col space-y-4"
-                    onSubmit={e => {
-                        e.preventDefault();
-                    }} // TODO handle proper submit!
+                    className={twMerge(
+                        'flex flex-col items-center justify-between',
+                        'border dark:border-2 rounded-xl p-6 flex flex-col justify-center space-y-4',
+                        'border-neutral-300 dark:border-neutral-700',
+                        'bg-neutral-50 dark:bg-neutral-900',
+                    )}
+                    id="root"
                 >
-                    <Tabs
-                        tabs={loginViewModel.voList.map(vo => vo.name)}
-                        active={1}
-                        updateActive={(active: number) => {
-                            setSelectedVOTab(active);
-                        }}
-                        className={twMerge(loginViewModel.multiVOEnabled ? '' : 'hidden')}
+                    <MultipleAccountsModal
+                        submit={lastAuthMethod === 'x509' ? submitX509 : submitUserPass}
+                        availableAccounts={availableAccounts}
+                        onClose={() => setAvailableAccounts([])}
                     />
+                    <Collapsible id="login-page-error" showIf={error !== undefined}>
+                        <Alert
+                            variant="error"
+                            message={error}
+                            onClose={() => {
+                                setError(undefined);
+                            }}
+                        />
+                    </Collapsible>
+                    <div className="flex flex-col items-center justify-between w-64 text-center text-text-1000 dark:text-text-0">
+                        <motion.div initial="hidden" animate="visible" variants={logoVariants}>
+                            <Image src="/rucio-logo.png" alt="Rucio Logo" width={146} height={176} />
+                        </motion.div>
+                    </div>
 
-                    <div className="flex justify-center flex-col space-y-4" aria-label="Choose Login Method">
-                        {loginViewModel.oidcEnabled == true ? (
-                            <div
-                                className={twMerge(
-                                    'flex flex-row justify-center space-x-2',
-                                    loginViewModel.voList[selectedVOTab].oidcEnabled ? '' : 'hidden',
-                                )}
-                                aria-label="OIDC Login Buttons"
-                            >
-                                {loginViewModel.voList[selectedVOTab].oidcProviders.map((provider: OIDCProvider, index: number) => {
-                                    return <Button theme="orange" label={provider.name} key={index.toString()} icon={<MdAccountCircle />} />;
-                                })}
-                            </div>
-                        ) : (
-                            <></>
-                        )}
+                    <div
+                        className="flex flex-col space-y-4"
+                        onSubmit={e => {
+                            e.preventDefault();
+                        }} // TODO handle proper submit!
+                    >
+                        <Tabs
+                            tabs={loginViewModel.voList.map(vo => vo.name)}
+                            active={1}
+                            updateActive={(active: number) => {
+                                setSelectedVOTab(active);
+                            }}
+                            className={twMerge(loginViewModel.multiVOEnabled ? '' : 'hidden')}
+                        />
 
-                        <Button label="x509" onClick={() => submitX509(inputAccount)} />
-                        {loginViewModel.userpassEnabled && (
-                            <div id="userpass-login">
-                                <Button
-                                    label="Userpass"
-                                    onClick={() => {
-                                        setShowUserPassLoginForm(!showUserPassLoginForm);
-                                    }}
-                                />
-                                <form>
-                                    <fieldset
-                                        className={twMerge('flex flex-col space-y-4', 'mx-2 md:mx-10', showUserPassLoginForm ? '' : 'hidden')}
-                                        aria-label="Userpass Login Fields"
-                                        id="userpass-form"
-                                    >
-                                        <div className={twMerge('flex flex-col space-y-2 p-2')}>
-                                            <LabelledInput
-                                                label="Username"
-                                                idinput="username-input"
-                                                updateFunc={(data: string) => {
-                                                    setUsername(data);
-                                                }}
-                                            />
-                                            <LabelledInput
-                                                label="Password"
-                                                idinput="password-input"
-                                                updateFunc={(data: string) => {
-                                                    setPassword(data);
-                                                }}
-                                                password={true}
-                                            />
-                                            <LabelledInput
-                                                label="Account"
-                                                idinput="account-input"
-                                                updateFunc={(data: string) => {
-                                                    setInputAccount(data);
-                                                }}
-                                            />
-                                        </div>
-                                        <Button label="Login" type="submit" role="button" onClick={() => submitUserPass(inputAccount)} />
-                                    </fieldset>
-                                </form>
-                                <fieldset
-                                    className={twMerge('mx-2 md:mx-10 p-4', !showUserPassLoginForm ? 'block' : 'hidden')}
-                                    aria-label="Choose Account Name"
-                                    id="all-accounts"
+                        <div className="flex justify-center flex-col space-y-4" aria-label="Choose Login Method">
+                            {loginViewModel.oidcEnabled == true ? (
+                                <div
+                                    className={twMerge(
+                                        'flex flex-row justify-center space-x-2',
+                                        loginViewModel.voList[selectedVOTab].oidcEnabled ? '' : 'hidden',
+                                    )}
+                                    aria-label="OIDC Login Buttons"
                                 >
-                                    <LabelledInput
-                                        label="Account"
-                                        idinput="account-input-nouserpass"
-                                        updateFunc={(data: string) => {
-                                            setInputAccount(data);
+                                    {loginViewModel.voList[selectedVOTab].oidcProviders.map((provider: OIDCProvider, index: number) => {
+                                        return <Button theme="orange" label={provider.name} key={index.toString()} icon={<MdAccountCircle />} />;
+                                    })}
+                                </div>
+                            ) : (
+                                <></>
+                            )}
+
+                            <Button label="x509" onClick={() => submitX509(inputAccount)} />
+                            {loginViewModel.userpassEnabled && (
+                                <div id="userpass-login">
+                                    <Button
+                                        label="Userpass"
+                                        onClick={() => {
+                                            setShowUserPassLoginForm(!showUserPassLoginForm);
                                         }}
                                     />
-                                </fieldset>
-                            </div>
-                        )}
+                                    <form>
+                                        <fieldset
+                                            className={twMerge('flex flex-col space-y-4', 'mx-2 md:mx-10', showUserPassLoginForm ? '' : 'hidden')}
+                                            aria-label="Userpass Login Fields"
+                                            id="userpass-form"
+                                        >
+                                            <div className={twMerge('flex flex-col space-y-2 p-2')}>
+                                                <LabelledInput
+                                                    label="Username"
+                                                    idinput="username-input"
+                                                    updateFunc={(data: string) => {
+                                                        setUsername(data);
+                                                    }}
+                                                />
+                                                <LabelledInput
+                                                    label="Password"
+                                                    idinput="password-input"
+                                                    updateFunc={(data: string) => {
+                                                        setPassword(data);
+                                                    }}
+                                                    password={true}
+                                                />
+                                                <LabelledInput
+                                                    label="Account"
+                                                    idinput="account-input"
+                                                    updateFunc={(data: string) => {
+                                                        setInputAccount(data);
+                                                    }}
+                                                />
+                                            </div>
+                                            <Button label="Login" type="submit" role="button" onClick={() => submitUserPass(inputAccount)} />
+                                        </fieldset>
+                                    </form>
+                                    <fieldset
+                                        className={twMerge('mx-2 md:mx-10 p-4', !showUserPassLoginForm ? 'block' : 'hidden')}
+                                        aria-label="Choose Account Name"
+                                        id="all-accounts"
+                                    >
+                                        <LabelledInput
+                                            label="Account"
+                                            idinput="account-input-nouserpass"
+                                            updateFunc={(data: string) => {
+                                                setInputAccount(data);
+                                            }}
+                                        />
+                                    </fieldset>
+                                </div>
+                            )}
+                        </div>
                     </div>
                 </div>
-            </div>
             </motion.div>
         );
     };

--- a/src/lib/core/port/secondary/env-config-gateway-output-port.ts
+++ b/src/lib/core/port/secondary/env-config-gateway-output-port.ts
@@ -46,7 +46,7 @@ export default interface EnvConfigGatewayOutputPort {
      * @returns true if userpass is enabled, false otherwise.
      */
     userpassEnabled(): Promise<boolean>;
-    
+
     /**
      * @returns the URL of the Rucio Auth service
      * @throws {@link ConfigNotFound} if RUCIO_AUTH_HOST is not found

--- a/src/lib/infrastructure/gateway/env-config-gateway.ts
+++ b/src/lib/infrastructure/gateway/env-config-gateway.ts
@@ -161,7 +161,7 @@ class EnvConfigGateway implements EnvConfigGatewayOutputPort {
         }
         return Promise.resolve(true);
     }
-    
+
     async ruleActivity(): Promise<string> {
         const value = await this.get('RULE_ACTIVITY');
         // Return a default value if the environmental variable is not specified

--- a/src/lib/sdk/http.ts
+++ b/src/lib/sdk/http.ts
@@ -19,9 +19,7 @@ export type HTTPRequest = {
  * @param {HTTPRequest} request - The HTTP request to prepare arguments for.
  * @returns {{ url: string | URL; requestArgs: RequestInit }} - An object containing the URL and request arguments.
  */
-export function prepareRequestArgs(
-    request: HTTPRequest,
-): {
+export function prepareRequestArgs(request: HTTPRequest): {
     url: string | URL;
     requestArgs: RequestInit;
 } {


### PR DESCRIPTION
Fix #552 

Implemented checks for whether an account has infinite quote on an RSE. In the future, the response from the usecase might need some refactoring.

Currently RSEs with infinite quota aren't displayed on the dashboard widget. Testing this Rucio endpoint with Postman returns these RSEs, but they aren't received by the gateway. I will create a separate issue as this might require a deep dive.

This is the display of these RSEs. Please let me know if the label has to be edited.
![image](https://github.com/user-attachments/assets/db6bd8c1-04d8-4104-b778-6d011e2be783)
