### PR TITLE
fix: encode URI components in ClickableDID components

### DIFF
--- a/src/component-library/pages/DID/details/tables/DetailsDIDSimpleTable.tsx
+++ b/src/component-library/pages/DID/details/tables/DetailsDIDSimpleTable.tsx
@@ -18,7 +18,7 @@ type DetailsDIDSimpleTableProps = {
 const ClickableDID = (props: { value: string[] }) => {
     const [scope, name] = props.value;
     return (
-        <ClickableCell href={`/did/page/${scope}/${name}`}>
+        <ClickableCell href={`/did/page/${encodeURIComponent(scope)}/${encodeURIComponent(name)}`}>
             {scope}:{name}
         </ClickableCell>
     );


### PR DESCRIPTION
This pull request updates the `ClickableDID` component in `DetailsDIDSimpleTable.tsx` to ensure that special characters in the `scope` and `name` values are properly encoded in the generated URLs.

### Key Change:
* Updated the `ClickableCell` component to use `encodeURIComponent` for both `scope` and `name` when constructing the `href` attribute. This prevents issues with special characters in URLs. (`[src/component-library/pages/DID/details/tables/DetailsDIDSimpleTable.tsxL21-R21](diffhunk://#diff-dddb8b44f8356889ea503fe2f9dc2841d4b6135741269f024971cdfc4003be2bL21-R21)`)

Fix #562 