### PR TITLE
Remove `@next/font` from package.json to address deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@builder.io/partytown": "^0.7.6",
-    "@next/font": "13.1.6",
     "@preact/signals": "^1.2.2",
     "@primer/css": "^20.8.2",
     "@radix-ui/react-collapsible": "^1.1.0",


### PR DESCRIPTION
More info at https://nextjs.org/docs/messages/built-in-next-font