### PR TITLE
refactor: remove unnecessary encoding/decoding of query parametears

### DIFF
--- a/src/component-library/pages/DID/list/ListDID.tsx
+++ b/src/component-library/pages/DID/list/ListDID.tsx
@@ -42,7 +42,7 @@ export const ListDID = (props: ListDIDProps) => {
 
     const queryMeta = async () => {
         if (selectedItem !== null) {
-            const params = new URLSearchParams({ scope: encodeURIComponent(selectedItem.scope), name: encodeURIComponent(selectedItem.name) });
+            const params = new URLSearchParams({ scope: selectedItem.scope, name: selectedItem.name });
             const url = '/api/feature/get-did-meta?' + params;
 
             const res = await fetch(url);

--- a/src/pages/api/feature/get-did-meta.ts
+++ b/src/pages/api/feature/get-did-meta.ts
@@ -25,8 +25,8 @@ async function getDIDMeta(req: NextApiRequest, res: NextApiResponse, rucioAuthTo
     const controller = appContainer.get<BaseController<DIDMetaControllerParameters, void>>(CONTROLLERS.DID_META);
     const controllerParameters: DIDMetaControllerParameters = {
         response: res,
-        scope: decodeURIComponent(scope),
-        name: decodeURIComponent(name),
+        scope: scope,
+        name: name,
         rucioAuthToken: rucioAuthToken,
     };
 


### PR DESCRIPTION
#548 
This pull request simplifies the handling of URL encoding and decoding for `scope` and `name` parameters in the DID metadata functionality. The changes remove redundant encoding and decoding steps, ensuring cleaner and more efficient code.

### Simplification of URL parameter handling:

* [`src/component-library/pages/DID/list/ListDID.tsx`](diffhunk://#diff-648f1c34b0e3faed8cc63f3aa4d3136bf7bf1727977f64ed3a8dec3a870ce94eL45-R45): Removed the redundant use of `encodeURIComponent` when constructing the `URLSearchParams` for `scope` and `name` in the `queryMeta` function.
* [`src/pages/api/feature/get-did-meta.ts`](diffhunk://#diff-1167e176f87e3d841936e4fac379c17ae6135c2dd9a2e3a00cc96ce697794066L28-R29): Removed the unnecessary `decodeURIComponent` calls for `scope` and `name` when initializing `controllerParameters` in the `getDIDMeta` function.