### PR TITLE
Feature 544. Enable text selection in tables.

### DIFF
--- a/src/component-library/features/table/RegularTable/RegularTable.tsx
+++ b/src/component-library/features/table/RegularTable/RegularTable.tsx
@@ -166,6 +166,9 @@ export const RegularTable = (props: RegularTableProps) => {
                         suppressMovableColumns={true}
                         rowMultiSelectWithClick={true}
                         defaultColDef={{ flex: 1 }}
+                        rowStyle={{
+                            userSelect: 'text', // Text selection without interfering with cell layout
+                        }}
                         //asyncTransactionWaitMillis={500}
                     />
                 ) : (


### PR DESCRIPTION
Fix #544 

Going with a CSS property instead of AG Grid's intrinsic configuration as otherwise cell layout changes, impacting the proper display of badges.