### PR TITLE
Bug 565. Enable display of RSEs with infinity quota

### DIFF
--- a/src/lib/sdk/stream-transformers.ts
+++ b/src/lib/sdk/stream-transformers.ts
@@ -45,10 +45,15 @@ export class NewlineDelimittedDataParser extends Transform {
      * @param chunk - The chunk to push to the next stream.
      */
     pushToNextStream(chunk: string): void {
+        /* 
+        This is a workaround for the fact that Rucio sometimes returns Infinity in JSON responses.
+        Infinity is not a valid JSON value, so we replace it with -1.
+        */
+        const infinityPatch = chunk.replace(/Infinity/g, '-1');
         try {
             // Check whether the chunk is a valid JSON string
-            JSON.parse(chunk);
-            this.push(JSON.stringify(chunk));
+            JSON.parse(infinityPatch);
+            this.push(JSON.stringify(infinityPatch));
         } catch (_) {
             // Don't push an invalid chunk
         }


### PR DESCRIPTION
Fix #565 

This required a hack for fixing stream parsing and adjustments to display for optimal UX.

The hack follows current fix in gateway-endpoints.ts. However, in future we might need to either handle the Rucio Server output or find a better internal representation for infinity values that doesn't clash with numeric values. My biggest concern currently is possible overhead of this approach.

The pie charts will look this way so that usage information is always visible.
![image](https://github.com/user-attachments/assets/4d8c09bc-903f-4553-8a46-fe943a4e1fb8)
