### PR TITLE
Feature 517. Implement FTS Link retrieval mechanism

### DIFF
--- a/src/component-library/outputtailwind.css
+++ b/src/component-library/outputtailwind.css
@@ -3624,10 +3624,6 @@ html {
     height: 3rem;
   }
 
-  .md\:h-16 {
-    height: 4rem;
-  }
-
   .md\:h-8 {
     height: 2rem;
   }
@@ -3638,10 +3634,6 @@ html {
 
   .md\:w-24 {
     width: 6rem;
-  }
-
-  .md\:w-28 {
-    width: 7rem;
   }
 
   .md\:w-36 {
@@ -3847,10 +3839,6 @@ html {
 @media (min-width: 1024px) {
   .lg\:hidden {
     display: none;
-  }
-
-  .lg\:w-32 {
-    width: 8rem;
   }
 
   .lg\:w-48 {

--- a/src/component-library/pages/Rule/details/DetailsRuleLocks.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRuleLocks.tsx
@@ -74,7 +74,7 @@ const FTSLinkButton = (props: any) => {
         return;
     }
 
-    const buttonClassName = 'h-8 w-full';
+    const buttonClassName = 'my-2 h-7 w-full';
 
     if (isFetching) {
         return (

--- a/src/lib/core/dto/request-dto.ts
+++ b/src/lib/core/dto/request-dto.ts
@@ -1,0 +1,56 @@
+import { BaseDTO } from '@/lib/sdk/dto';
+
+export interface RequestDTO extends BaseDTO {
+    data?: {
+        source_rse_id: string;
+        previous_attempt_id: string | null;
+        started_at: string | null;
+        staging_started_at: string | null;
+        updated_at: string;
+        attributes: {
+            activity: string;
+            source_replica_expression: string | null;
+            lifetime: number | null;
+            ds_scope: string | null;
+            ds_name: string | null;
+            bytes: number;
+            md5: string;
+            adler32: string;
+            priority: number;
+            allow_tape_source: boolean;
+        };
+        rule_id: string;
+        transferred_at: string | null;
+        staging_finished_at: string | null;
+        request_type: string;
+        state: string;
+        activity: string;
+        estimated_at: string | null;
+        account: string;
+        id: string;
+        external_id: string;
+        bytes: number;
+        submitter_id: string | null;
+        requested_at: string | null;
+        scope: string;
+        external_host: string;
+        md5: string;
+        last_processed_by: string | null;
+        priority: number;
+        name: string;
+        retry_count: number;
+        adler32: string;
+        estimated_started_at: string | null;
+        last_processed_at: string | null;
+        did_type: string;
+        err_msg: string | null;
+        dest_url: string;
+        estimated_transferred_at: string | null;
+        transfertool: string;
+        dest_rse_id: string;
+        submitted_at: string;
+        created_at: string;
+        source_rse: string;
+        dest_rse: string;
+    };
+}

--- a/src/lib/core/port/primary/get-fts-link-ports.ts
+++ b/src/lib/core/port/primary/get-fts-link-ports.ts
@@ -1,0 +1,12 @@
+import { BaseAuthenticatedInputPort, BaseOutputPort } from '@/lib/sdk/primary-ports';
+import { GetFTSLinkError, GetFTSLinkRequest, GetFTSLinkResponse } from '@/lib/core/usecase-models/get-fts-link-usecase-models';
+
+/**
+ * @interface GetFTSLinkInputPort representing the GetFTSLink usecase.
+ */
+export interface GetFTSLinkInputPort extends BaseAuthenticatedInputPort<GetFTSLinkRequest> {}
+
+/**
+ * @interface GetFTSLinkOutputPort representing the GetFTSLink presenter.
+ */
+export interface GetFTSLinkOutputPort extends BaseOutputPort<GetFTSLinkResponse, GetFTSLinkError> {}

--- a/src/lib/core/port/secondary/request-gateway-output-port.ts
+++ b/src/lib/core/port/secondary/request-gateway-output-port.ts
@@ -1,0 +1,14 @@
+import { RequestDTO } from '../../dto/request-dto';
+
+// RequestGatewayOutputPort interface defines the contract for a gateway that retrieves requests from RUCIO.
+export default interface RequestGatewayOutputPort {
+    /**
+     * Retrieves a request by its RUCIO Auth Token, scope, name, and RSE.
+     * @param rucioAuthToken - The authentication token for RUCIO.
+     * @param scope - The scope of the request.
+     * @param name - The name of the request.
+     * @param rse - The RSE (RUCIO Storage Element) associated with the request.
+     * @returns A Promise that resolves to a RequestDTO containing the request details.
+     */
+    getRequest(rucioAuthToken: string, scope: string, name: string, rse: string): Promise<RequestDTO>;
+}

--- a/src/lib/core/use-case/get-fts-link-usecase.ts
+++ b/src/lib/core/use-case/get-fts-link-usecase.ts
@@ -1,0 +1,50 @@
+import { injectable } from 'inversify';
+import { BaseSingleEndpointUseCase } from '@/lib/sdk/usecase';
+import { AuthenticatedRequestModel } from '@/lib/sdk/usecase-models';
+
+import { GetFTSLinkError, GetFTSLinkRequest, GetFTSLinkResponse } from '@/lib/core/usecase-models/get-fts-link-usecase-models';
+import { GetFTSLinkInputPort, type GetFTSLinkOutputPort } from '@/lib/core/port/primary/get-fts-link-ports';
+import type RequestGatewayOutputPort from '../port/secondary/request-gateway-output-port';
+import { RequestDTO } from '../dto/request-dto';
+
+@injectable()
+export default class GetFTSLinkUseCase
+    extends BaseSingleEndpointUseCase<AuthenticatedRequestModel<GetFTSLinkRequest>, GetFTSLinkResponse, GetFTSLinkError, RequestDTO>
+    implements GetFTSLinkInputPort
+{
+    constructor(protected readonly presenter: GetFTSLinkOutputPort, private readonly gateway: RequestGatewayOutputPort) {
+        super(presenter);
+    }
+
+    validateRequestModel(requestModel: AuthenticatedRequestModel<GetFTSLinkRequest>): GetFTSLinkError | undefined {
+        return undefined;
+    }
+
+    async makeGatewayRequest(requestModel: AuthenticatedRequestModel<GetFTSLinkRequest>): Promise<RequestDTO> {
+        const { rucioAuthToken, scope, name, rse } = requestModel;
+        const dto: RequestDTO = await this.gateway.getRequest(rucioAuthToken, scope, name, rse);
+        return dto;
+    }
+    handleGatewayError(error: RequestDTO): GetFTSLinkError {
+        return {
+            status: 'error',
+            message: error.errorMessage ? error.errorMessage : 'Gateway Error',
+            name: `Gateway Error`,
+            code: error.errorCode,
+        } as GetFTSLinkError;
+    }
+
+    processDTO(dto: RequestDTO): { data: GetFTSLinkResponse | GetFTSLinkError; status: 'success' | 'error' } {
+        const url = 'example.com';
+
+        const responseModel: GetFTSLinkResponse = {
+            url: url,
+            status: 'success',
+        };
+
+        return {
+            status: 'success',
+            data: responseModel,
+        };
+    }
+}

--- a/src/lib/core/use-case/get-fts-link-usecase.ts
+++ b/src/lib/core/use-case/get-fts-link-usecase.ts
@@ -6,6 +6,7 @@ import { GetFTSLinkError, GetFTSLinkRequest, GetFTSLinkResponse } from '@/lib/co
 import { GetFTSLinkInputPort, type GetFTSLinkOutputPort } from '@/lib/core/port/primary/get-fts-link-ports';
 import type RequestGatewayOutputPort from '../port/secondary/request-gateway-output-port';
 import { RequestDTO } from '../dto/request-dto';
+import { createDefaultFTSUrl } from '../utils/fts-link-utils';
 
 @injectable()
 export default class GetFTSLinkUseCase
@@ -26,6 +27,15 @@ export default class GetFTSLinkUseCase
         return dto;
     }
     handleGatewayError(error: RequestDTO): GetFTSLinkError {
+        if (error.errorCode === 404) {
+            return {
+                status: 'error',
+                message: `Request not found`,
+                name: `NotFoundError`,
+                code: error.errorCode,
+            };
+        }
+
         return {
             status: 'error',
             message: error.errorMessage ? error.errorMessage : 'Gateway Error',
@@ -35,7 +45,28 @@ export default class GetFTSLinkUseCase
     }
 
     processDTO(dto: RequestDTO): { data: GetFTSLinkResponse | GetFTSLinkError; status: 'success' | 'error' } {
-        const url = 'example.com';
+        const allowedStates = ['SUBMITTED', 'DONE', 'FAILED'];
+
+        if (dto.status === 'error' || !dto.data) {
+            return {
+                data: this.handleGatewayError(dto),
+                status: 'error',
+            };
+        }
+
+        if (!allowedStates.includes(dto.data.state)) {
+            return {
+                data: {
+                    status: 'error',
+                    message: `Request has not yet been submitted`,
+                    name: 'UnsupportedStateError',
+                    code: 400,
+                },
+                status: 'error',
+            };
+        }
+
+        const url = createDefaultFTSUrl(dto.data.external_host, dto.data.external_id);
 
         const responseModel: GetFTSLinkResponse = {
             url: url,

--- a/src/lib/core/usecase-models/get-fts-link-usecase-models.ts
+++ b/src/lib/core/usecase-models/get-fts-link-usecase-models.ts
@@ -1,0 +1,22 @@
+import { BaseErrorResponseModel, BaseResponseModel } from '@/lib/sdk/usecase-models';
+
+/**
+ * @interface GetFTSLinkRequest represents the RequestModel for get_fts_link usecase
+ */
+export interface GetFTSLinkRequest {
+    scope: string;
+    name: string;
+    rse: string;
+}
+
+/**
+ * @interface GetFTSLinkResponse represents the ResponseModel for get_fts_link usecase
+ */
+export interface GetFTSLinkResponse extends BaseResponseModel {
+    url: string;
+}
+
+/**
+ * @interface GetFTSLinkError represents the ErrorModel for get_fts_link usecase
+ */
+export interface GetFTSLinkError extends BaseErrorResponseModel {}

--- a/src/lib/core/utils/fts-link-utils.ts
+++ b/src/lib/core/utils/fts-link-utils.ts
@@ -1,0 +1,5 @@
+export const createDefaultFTSUrl = (host: string, id: string): string => {
+    // Replace port 8446 with 8449
+    const dashboardHost = host.slice(0, -1) + '9/ftsmon/#/job';
+    return `${dashboardHost}/${id}`;
+};

--- a/src/lib/infrastructure/controller/get-fts-link-controller.ts
+++ b/src/lib/infrastructure/controller/get-fts-link-controller.ts
@@ -1,0 +1,31 @@
+import { injectable, inject } from 'inversify';
+import { NextApiResponse } from 'next';
+
+import { AuthenticatedRequestModel } from '@/lib/sdk/usecase-models';
+import { BaseController, TAuthenticatedControllerParameters } from '@/lib/sdk/controller';
+import { GetFTSLinkRequest } from '@/lib/core/usecase-models/get-fts-link-usecase-models';
+import { GetFTSLinkInputPort } from '@/lib/core/port/primary/get-fts-link-ports';
+import USECASE_FACTORY from '@/lib/infrastructure/ioc/ioc-symbols-usecase-factory';
+
+export type GetFTSLinkControllerParameters = TAuthenticatedControllerParameters & {
+    scope: string;
+    name: string;
+    rse: string;
+};
+
+@injectable()
+class GetFTSLinkController extends BaseController<GetFTSLinkControllerParameters, AuthenticatedRequestModel<GetFTSLinkRequest>> {
+    constructor(@inject(USECASE_FACTORY.GET_FTS_LINK) GetFTSLinkUseCaseFactory: (response: NextApiResponse) => GetFTSLinkInputPort) {
+        super(GetFTSLinkUseCaseFactory);
+    }
+    prepareRequestModel(parameters: GetFTSLinkControllerParameters): AuthenticatedRequestModel<GetFTSLinkRequest> {
+        return {
+            rucioAuthToken: parameters.rucioAuthToken,
+            scope: parameters.scope,
+            name: parameters.name,
+            rse: parameters.rse,
+        };
+    }
+}
+
+export default GetFTSLinkController;

--- a/src/lib/infrastructure/data/view-model/request.ts
+++ b/src/lib/infrastructure/data/view-model/request.ts
@@ -1,0 +1,5 @@
+import { BaseViewModel } from '@/lib/sdk/view-models';
+
+export interface FTSLinkViewModel extends BaseViewModel {
+    url: string;
+}

--- a/src/lib/infrastructure/gateway/request-gateway/endpoints/get-request-endpoint.ts
+++ b/src/lib/infrastructure/gateway/request-gateway/endpoints/get-request-endpoint.ts
@@ -1,0 +1,54 @@
+import { RequestDTO } from '@/lib/core/dto/request-dto';
+import { BaseEndpoint, extractErrorMessage } from '@/lib/sdk/gateway-endpoints';
+import { HTTPRequest } from '@/lib/sdk/http';
+import { Response } from 'node-fetch';
+
+export default class GetRequestEndpoint extends BaseEndpoint<RequestDTO> {
+    constructor(private rucioAuthToken: string, private scope: string, private name: string, private rse: string) {
+        super();
+    }
+    /**
+     * @override
+     */
+    async initialize(): Promise<void> {
+        await super.initialize();
+        const rucioHost = await this.envConfigGateway.rucioHost();
+        const endpoint = `${rucioHost}/requests/${encodeURIComponent(this.scope)}/${encodeURIComponent(this.name)}/${encodeURIComponent(this.rse)}`;
+        const request: HTTPRequest = {
+            method: 'GET',
+            url: endpoint,
+            headers: {
+                'X-Rucio-Auth-Token': this.rucioAuthToken,
+                'Content-Type': 'application/json',
+            },
+            body: null,
+            params: undefined,
+        };
+        this.request = request;
+        this.initialized = true;
+    }
+
+    async reportErrors(statusCode: number, response: Response): Promise<RequestDTO | undefined> {
+        if (statusCode === 200) {
+            return Promise.resolve(undefined);
+        }
+
+        let errorDetails = await extractErrorMessage(response);
+
+        const errorDTO: RequestDTO = {
+            status: 'error',
+            errorCode: statusCode,
+            errorName: 'Unknown Error',
+            errorType: 'gateway_endpoint_error',
+            errorMessage: `${errorDetails ?? 'No error details available from rucio'}`,
+        };
+        return Promise.resolve(errorDTO);
+    }
+
+    createDTO(response: object): RequestDTO {
+        return {
+            status: 'success',
+            data: response as RequestDTO['data'],
+        };
+    }
+}

--- a/src/lib/infrastructure/gateway/request-gateway/request-gateway.ts
+++ b/src/lib/infrastructure/gateway/request-gateway/request-gateway.ts
@@ -1,0 +1,24 @@
+import { RequestDTO } from '@/lib/core/dto/request-dto';
+import RequestGatewayOutputPort from '@/lib/core/port/secondary/request-gateway-output-port';
+import { injectable } from 'inversify';
+import GetRequestEndpoint from './endpoints/get-request-endpoint';
+
+@injectable()
+export default class RequestGateway implements RequestGatewayOutputPort {
+    async getRequest(rucioAuthToken: string, scope: string, name: string, rse: string): Promise<RequestDTO> {
+        try {
+            const endpoint = new GetRequestEndpoint(rucioAuthToken, scope, name, rse);
+            const dto: RequestDTO = await endpoint.fetch();
+            return Promise.resolve(dto);
+        } catch (error) {
+            const errorDTO: RequestDTO = {
+                status: 'error',
+                errorName: 'Unknown Error',
+                errorType: 'gateway_endpoint_error',
+                errorCode: 500,
+                errorMessage: error?.toString(),
+            };
+            return Promise.resolve(errorDTO);
+        }
+    }
+}

--- a/src/lib/infrastructure/ioc/container-config.ts
+++ b/src/lib/infrastructure/ioc/container-config.ts
@@ -71,6 +71,8 @@ import AttachDIDsFeature from '@/lib/infrastructure/ioc/features/attach-dids-fea
 import SetDIDStatusFeature from '@/lib/infrastructure/ioc/features/set-did-status-feature';
 import GetRuleFeature from '@/lib/infrastructure/ioc/features/get-rule-feature';
 import ListRuleReplicaLockStatesFeature from '@/lib/infrastructure/ioc/features/list-rule-replica-lock-states-feature';
+import RequestGateway from '../gateway/request-gateway/request-gateway';
+import RequestGatewayOutputPort from '@/lib/core/port/secondary/request-gateway-output-port';
 
 /**
  * IoC Container configuration for the application.
@@ -85,6 +87,7 @@ appContainer.bind<StreamGatewayOutputPort>(GATEWAYS.STREAM).to(StreamingGateway)
 appContainer.bind<SubscriptionGatewayOutputPort>(GATEWAYS.SUBSCRIPTION).to(SubscriptionGateway);
 appContainer.bind<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA).to(ReplicaGateway);
 appContainer.bind<RuleGatewayOutputPort>(GATEWAYS.RULE).to(RuleGateway);
+appContainer.bind<RequestGatewayOutputPort>(GATEWAYS.REQUEST).to(RequestGateway);
 
 // Load Common Features
 loadFeaturesSync(appContainer, [new GetSiteHeaderFeature(appContainer)]);

--- a/src/lib/infrastructure/ioc/container-config.ts
+++ b/src/lib/infrastructure/ioc/container-config.ts
@@ -73,6 +73,7 @@ import GetRuleFeature from '@/lib/infrastructure/ioc/features/get-rule-feature';
 import ListRuleReplicaLockStatesFeature from '@/lib/infrastructure/ioc/features/list-rule-replica-lock-states-feature';
 import RequestGateway from '../gateway/request-gateway/request-gateway';
 import RequestGatewayOutputPort from '@/lib/core/port/secondary/request-gateway-output-port';
+import GetFTSLinkFeature from './features/get-fts-link-feature';
 
 /**
  * IoC Container configuration for the application.
@@ -108,6 +109,7 @@ loadFeaturesSync(appContainer, [
     new ListFileReplicasFeature(appContainer),
     new ListSubscriptionsFeature(appContainer),
     new GetRuleFeature(appContainer),
+    new GetFTSLinkFeature(appContainer),
 ]);
 
 // Features: Page RSE

--- a/src/lib/infrastructure/ioc/features/get-fts-link-feature.ts
+++ b/src/lib/infrastructure/ioc/features/get-fts-link-feature.ts
@@ -1,0 +1,35 @@
+import { GetFTSLinkError, GetFTSLinkRequest, GetFTSLinkResponse } from '@/lib/core/usecase-models/get-fts-link-usecase-models';
+import { GetFTSLinkControllerParameters } from '@/lib/infrastructure/controller/get-fts-link-controller';
+import GetFTSLinkController from '@/lib/infrastructure/controller/get-fts-link-controller';
+import { BaseFeature, IOCSymbols } from '@/lib/sdk/ioc-helpers';
+import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import INPUT_PORT from '@/lib/infrastructure/ioc/ioc-symbols-input-port';
+import USECASE_FACTORY from '@/lib/infrastructure/ioc/ioc-symbols-usecase-factory';
+import { Container } from 'inversify';
+
+import GetFTSLinkUseCase from '@/lib/core/use-case/get-fts-link-usecase';
+
+import GetFTSLinkPresenter from '@/lib/infrastructure/presenter/get-fts-link-presenter';
+import RequestGatewayOutputPort from '@/lib/core/port/secondary/request-gateway-output-port';
+import { FTSLinkViewModel } from '../../data/view-model/request';
+
+export default class GetFTSLinkFeature extends BaseFeature<
+    GetFTSLinkControllerParameters,
+    GetFTSLinkRequest,
+    GetFTSLinkResponse,
+    GetFTSLinkError,
+    FTSLinkViewModel
+> {
+    constructor(appContainer: Container) {
+        const requestGateway = appContainer.get<RequestGatewayOutputPort>(GATEWAYS.REQUEST);
+
+        const symbols: IOCSymbols = {
+            CONTROLLER: CONTROLLERS.GET_FTS_LINK,
+            USECASE_FACTORY: USECASE_FACTORY.GET_FTS_LINK,
+            INPUT_PORT: INPUT_PORT.GET_FTS_LINK,
+        };
+        const useCaseConstructorArgs = [requestGateway];
+        super('GetFTSLink', GetFTSLinkController, GetFTSLinkUseCase, useCaseConstructorArgs, GetFTSLinkPresenter, false, symbols);
+    }
+}

--- a/src/lib/infrastructure/ioc/ioc-symbols-controllers.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-controllers.ts
@@ -38,6 +38,7 @@ const CONTROLLERS = {
     SET_DID_STATUS: Symbol.for('SetDIDStatusController'),
     GET_RULE: Symbol.for('GetRuleController'),
     LIST_RULE_REPLICA_LOCK_STATES: Symbol.for('ListRuleReplicaLockStatesController'),
+    GET_FTS_LINK: Symbol.for('GetFTSLinkController'),
 };
 
 export default CONTROLLERS;

--- a/src/lib/infrastructure/ioc/ioc-symbols-gateway.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-gateway.ts
@@ -11,6 +11,7 @@ const GATEWAYS = {
     SUBSCRIPTION: Symbol.for('SubscriptionGateway'),
     REPLICA: Symbol.for('ReplicaGateway'),
     RULE: Symbol.for('RuleGateway'),
+    REQUEST: Symbol.for('RequestGateway'),
 };
 
 export default GATEWAYS;

--- a/src/lib/infrastructure/ioc/ioc-symbols-input-port.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-input-port.ts
@@ -37,6 +37,7 @@ const INPUT_PORT = {
     SET_DID_STATUS: Symbol.for('SetDIDStatusInputPort'),
     GET_RULE: Symbol.for('GetRuleInputPort'),
     LIST_RULE_REPLICA_LOCK_STATES: Symbol.for('ListRuleReplicaLockStatesInputPort'),
+    GET_FTS_LINK: Symbol.for('GetFTSLinkInputPort'),
 };
 
 export default INPUT_PORT;

--- a/src/lib/infrastructure/ioc/ioc-symbols-usecase-factory.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-usecase-factory.ts
@@ -38,6 +38,7 @@ const USECASE_FACTORY = {
     SET_DID_STATUS: Symbol.for('Factory<SetDIDStatus>'),
     GET_RULE: Symbol.for('Factory<GetRuleUseCase>'),
     LIST_RULE_REPLICA_LOCK_STATES: Symbol.for('Factory<ListRuleReplicaLockStatesUseCase>'),
+    GET_FTS_LINK: Symbol.for('Factory<GetFTSLinkUseCase>'),
 };
 
 export default USECASE_FACTORY;

--- a/src/lib/infrastructure/presenter/get-fts-link-presenter.ts
+++ b/src/lib/infrastructure/presenter/get-fts-link-presenter.ts
@@ -1,0 +1,29 @@
+import { BasePresenter } from '@/lib/sdk/presenter';
+import { GetFTSLinkError, GetFTSLinkResponse } from '@/lib/core/usecase-models/get-fts-link-usecase-models';
+import { FTSLinkViewModel } from '../data/view-model/request';
+
+export default class GetFTSLinkPresenter extends BasePresenter<GetFTSLinkResponse, GetFTSLinkError, FTSLinkViewModel> {
+    convertResponseModelToViewModel(responseModel: GetFTSLinkResponse): { viewModel: FTSLinkViewModel; status: number } {
+        const viewModel: FTSLinkViewModel = {
+            ...responseModel,
+        };
+        return {
+            status: 200,
+            viewModel: viewModel,
+        };
+    }
+
+    convertErrorModelToViewModel(errorModel: GetFTSLinkError): { viewModel: FTSLinkViewModel; status: number } {
+        const viewModel: FTSLinkViewModel = {
+            status: 'error',
+            url: '',
+        };
+        const message = errorModel.message.toString() || errorModel.name;
+        viewModel.message = message;
+        const errorCode = errorModel.code || 500;
+        return {
+            status: errorCode,
+            viewModel: viewModel,
+        };
+    }
+}

--- a/src/pages/api/feature/get-fts-link.ts
+++ b/src/pages/api/feature/get-fts-link.ts
@@ -1,0 +1,42 @@
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import { BaseController } from '@/lib/sdk/controller';
+import { NextApiRequest, NextApiResponse } from 'next';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import { withAuthenticatedSessionRoute } from '@/lib/infrastructure/auth/session-utils';
+import { GetFTSLinkControllerParameters } from '@/lib/infrastructure/controller/get-fts-link-controller';
+
+async function getFTSLink(req: NextApiRequest, res: NextApiResponse, rucioAuthToken: string) {
+    if (req.method !== 'GET') {
+        res.status(405).json({ error: 'Method Not Allowed' });
+        return;
+    }
+    const { scope, name, rse } = req.query;
+
+    if (!scope || typeof scope !== 'string') {
+        res.status(400).json({ error: 'Missing scope parameter' });
+        return;
+    }
+
+    if (!name || typeof name !== 'string') {
+        res.status(400).json({ error: 'Missing name parameter' });
+        return;
+    }
+
+    if (!rse || typeof rse !== 'string') {
+        res.status(400).json({ error: 'Missing rse parameter' });
+        return;
+    }
+
+    const controller = appContainer.get<BaseController<GetFTSLinkControllerParameters, void>>(CONTROLLERS.GET_FTS_LINK);
+    const controllerParameters: GetFTSLinkControllerParameters = {
+        response: res,
+        scope: scope,
+        name: name,
+        rse: rse,
+        rucioAuthToken: rucioAuthToken,
+    };
+
+    await controller.execute(controllerParameters);
+}
+
+export default withAuthenticatedSessionRoute(getFTSLink);

--- a/test/api/request/get-fts-link.test.ts
+++ b/test/api/request/get-fts-link.test.ts
@@ -1,0 +1,103 @@
+import { GetFTSLinkRequest } from '@/lib/core/usecase-models/get-fts-link-usecase-models';
+import { GetFTSLinkControllerParameters } from '@/lib/infrastructure/controller/get-fts-link-controller';
+import { FTSLinkViewModel } from '@/lib/infrastructure/data/view-model/request';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import { BaseController } from '@/lib/sdk/controller';
+import { NextApiResponse } from 'next';
+import { createHttpMocks } from 'test/fixtures/http-fixtures';
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+
+describe('GET FTS link API Test', () => {
+    beforeEach(() => {
+        fetchMock.doMock();
+        const requestMock = {
+            source_rse_id: 'cc28f83ca733482d81f80ba7e6cdd7db',
+            previous_attempt_id: null,
+            started_at: null,
+            staging_started_at: null,
+            updated_at: 'Fri, 27 Jun 2025 15:57:36 UTC',
+            attributes: {
+                activity: 'User Subscriptions',
+                source_replica_expression: null,
+                lifetime: null,
+                ds_scope: null,
+                ds_name: null,
+                bytes: 10485760,
+                md5: 'c495e4f8272b0c6f0249856922d854ab',
+                adler32: 'ed64d306',
+                priority: 3,
+                allow_tape_source: true,
+            },
+            rule_id: 'acd1de2771794fd4af5d4d500f086cca',
+            transferred_at: null,
+            staging_finished_at: null,
+            request_type: 'TRANSFER',
+            state: 'SUBMITTED',
+            activity: 'User Subscriptions',
+            estimated_at: null,
+            account: 'root',
+            id: 'a5ea7890453d42f2882520ec503b367c',
+            external_id: '71ce2e5a-536f-11f0-bb60-2a078b4f5cd0',
+            bytes: 10485760,
+            submitter_id: null,
+            requested_at: null,
+            scope: 'test',
+            external_host: 'https://fts:8446',
+            md5: 'c495e4f8272b0c6f0249856922d854ab',
+            last_processed_by: null,
+            priority: 3,
+            name: 'file2',
+            retry_count: 0,
+            adler32: 'ed64d306',
+            estimated_started_at: null,
+            last_processed_at: null,
+            did_type: 'FILE',
+            err_msg: null,
+            dest_url: 'root://xrd2:1095//rucio/test/f3/14/file2',
+            estimated_transferred_at: null,
+            transfertool: 'fts3',
+            dest_rse_id: '2cf75efc49ef4441b87efbcc7a95a92f',
+            submitted_at: 'Fri, 27 Jun 2025 15:57:36 UTC',
+            created_at: 'Fri, 27 Jun 2025 15:56:28 UTC',
+            source_rse: 'XRD1',
+            dest_rse: 'XRD2',
+        };
+
+        const getRequestEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/requests/test/file2/XRD2`,
+            method: 'GET',
+            includes: '/requests/test/file2/XRD2',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(requestMock),
+            },
+        };
+
+        MockRucioServerFactory.createMockRucioServer(true, [getRequestEndpoint]);
+    });
+    afterEach(() => {
+        fetchMock.dontMock();
+    });
+
+    test('it should form url for the request', async () => {
+        const { req, res, session } = await createHttpMocks('/api/feature/get-fts-link?scope=test,name=file2,rse=XRD2', 'GET', {});
+        const getFTSLinkController = appContainer.get<BaseController<GetFTSLinkControllerParameters, GetFTSLinkRequest>>(CONTROLLERS.GET_FTS_LINK);
+        const getFTSLinkControllerParameters: GetFTSLinkControllerParameters = {
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            response: res as unknown as NextApiResponse,
+            scope: 'test',
+            name: 'file2',
+            rse: 'XRD2',
+        };
+        await getFTSLinkController.execute(getFTSLinkControllerParameters);
+        const data = await res._getJSONData();
+        expect(data).toEqual({
+            status: 'success',
+            url: 'example.com',
+        } as FTSLinkViewModel);
+    });
+});

--- a/test/api/request/get-fts-link.test.ts
+++ b/test/api/request/get-fts-link.test.ts
@@ -84,7 +84,7 @@ describe('GET FTS link API Test', () => {
     });
 
     test('it should form url for the request', async () => {
-        const { req, res, session } = await createHttpMocks('/api/feature/get-fts-link?scope=test,name=file2,rse=XRD2', 'GET', {});
+        const { req, res, session } = await createHttpMocks('/api/feature/get-fts-link?scope=test&name=file2&rse=XRD2', 'GET', {});
         const getFTSLinkController = appContainer.get<BaseController<GetFTSLinkControllerParameters, GetFTSLinkRequest>>(CONTROLLERS.GET_FTS_LINK);
         const getFTSLinkControllerParameters: GetFTSLinkControllerParameters = {
             rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
@@ -97,7 +97,7 @@ describe('GET FTS link API Test', () => {
         const data = await res._getJSONData();
         expect(data).toEqual({
             status: 'success',
-            url: 'example.com',
+            url: 'https://fts:8449/ftsmon/#/job/71ce2e5a-536f-11f0-bb60-2a078b4f5cd0',
         } as FTSLinkViewModel);
     });
 });

--- a/test/gateway/request/request-gateway-get-request.test.ts
+++ b/test/gateway/request/request-gateway-get-request.test.ts
@@ -1,0 +1,90 @@
+import RequestGatewayOutputPort from '@/lib/core/port/secondary/request-gateway-output-port';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+
+describe('RequestGateway GET Request Endpoint Tests', () => {
+    const testData = {
+        source_rse_id: 'cc28f83ca733482d81f80ba7e6cdd7db',
+        previous_attempt_id: null,
+        started_at: null,
+        staging_started_at: null,
+        updated_at: 'Fri, 27 Jun 2025 15:57:36 UTC',
+        attributes: {
+            activity: 'User Subscriptions',
+            source_replica_expression: null,
+            lifetime: null,
+            ds_scope: null,
+            ds_name: null,
+            bytes: 10485760,
+            md5: 'c495e4f8272b0c6f0249856922d854ab',
+            adler32: 'ed64d306',
+            priority: 3,
+            allow_tape_source: true,
+        },
+        rule_id: 'acd1de2771794fd4af5d4d500f086cca',
+        transferred_at: null,
+        staging_finished_at: null,
+        request_type: 'TRANSFER',
+        state: 'SUBMITTED',
+        activity: 'User Subscriptions',
+        estimated_at: null,
+        account: 'root',
+        id: 'a5ea7890453d42f2882520ec503b367c',
+        external_id: '71ce2e5a-536f-11f0-bb60-2a078b4f5cd0',
+        bytes: 10485760,
+        submitter_id: null,
+        requested_at: null,
+        scope: 'test',
+        external_host: 'https://fts:8446',
+        md5: 'c495e4f8272b0c6f0249856922d854ab',
+        last_processed_by: null,
+        priority: 3,
+        name: 'file2',
+        retry_count: 0,
+        adler32: 'ed64d306',
+        estimated_started_at: null,
+        last_processed_at: null,
+        did_type: 'FILE',
+        err_msg: null,
+        dest_url: 'root://xrd2:1095//rucio/test/f3/14/file2',
+        estimated_transferred_at: null,
+        transfertool: 'fts3',
+        dest_rse_id: '2cf75efc49ef4441b87efbcc7a95a92f',
+        submitted_at: 'Fri, 27 Jun 2025 15:57:36 UTC',
+        created_at: 'Fri, 27 Jun 2025 15:56:28 UTC',
+        source_rse: 'XRD1',
+        dest_rse: 'XRD2',
+    };
+
+    beforeEach(() => {
+        fetchMock.doMock();
+        const getRequestMockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/requests/test/file2/XRD2`,
+            method: 'GET',
+            includes: '/requests/test/file2/XRD2',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(testData),
+            },
+        };
+
+        MockRucioServerFactory.createMockRucioServer(true, [getRequestMockEndpoint]);
+    });
+
+    afterEach(() => {
+        fetchMock.dontMock();
+    });
+
+    test('should successfully fetch the whole Request', async () => {
+        const requestGateway: RequestGatewayOutputPort = appContainer.get<RequestGatewayOutputPort>(GATEWAYS.REQUEST);
+        const requestDTO = await requestGateway.getRequest(MockRucioServerFactory.VALID_RUCIO_TOKEN, 'test', 'file2', 'XRD2');
+        expect(requestDTO).toEqual({
+            status: 'success',
+            data: testData,
+        });
+    });
+});


### PR DESCRIPTION
Fix #517 

This will need a followup with configured mapping of external host to FTS dashboard. Currently the default behavior from WebUI 1.0 is implemented.

On click, either a toast is shown (if the link cannot be retrieved), or a redirect in a new window is performed

![image](https://github.com/user-attachments/assets/653ec67b-f1ca-4098-bca3-2e406c11dded)
