### PR TITLE
Bug 595. Fix column sizing flickers

### DIFF
--- a/src/component-library/features/table/RegularTable/RegularTable.tsx
+++ b/src/component-library/features/table/RegularTable/RegularTable.tsx
@@ -165,9 +165,9 @@ export const RegularTable = (props: RegularTableProps) => {
                         onPaginationChanged={onPaginationChanged}
                         suppressMovableColumns={true}
                         rowMultiSelectWithClick={true}
-                        defaultColDef={{ flex: 1 }}
-                        rowStyle={{
-                            userSelect: 'text', // Text selection without interfering with cell layout
+                        defaultColDef={{ 
+                            flex: 1,
+                            cellStyle: { userSelect: 'text' },
                         }}
                         //asyncTransactionWaitMillis={500}
                     />


### PR DESCRIPTION
Fix #595 

This was introduced by a previous commit with in-table selection implemented. This reintegrates the selection in a way that doesn't cause the bug.