### PR TITLE
fix: add trailing slash to RSE attributes endpoint URLs 

### DIFF
--- a/src/lib/infrastructure/gateway/rse-gateway/endpoints/get-rse-attributes-endpoint.ts
+++ b/src/lib/infrastructure/gateway/rse-gateway/endpoints/get-rse-attributes-endpoint.ts
@@ -11,7 +11,7 @@ export default class GetRSEAttributesEndpoint extends BaseEndpoint<RSEAttributeD
 
     async initialize(): Promise<void> {
         await super.initialize();
-        this.url = `${this.rucioHost}/rses/${this.rseName}/attr`;
+        this.url = `${this.rucioHost}/rses/${this.rseName}/attr/`;
         const request: HTTPRequest = {
             method: 'GET',
             url: this.url,

--- a/test/api/rse/get-rse-attributes.test.ts
+++ b/test/api/rse/get-rse-attributes.test.ts
@@ -14,9 +14,9 @@ describe('GET RSE Attributes API Test', () => {
     beforeEach(() => {
         fetchMock.doMock();
         const getRSEAttributesMockEndpoint: MockEndpoint = {
-            url: `${MockRucioServerFactory.RUCIO_HOST}/rses/MOCK3/attr`,
+            url: `${MockRucioServerFactory.RUCIO_HOST}/rses/MOCK3/attr/`,
             method: 'GET',
-            includes: '/rses/MOCK3/attr',
+            includes: '/rses/MOCK3/attr/',
             response: {
                 status: 200,
                 headers: {

--- a/test/gateway/rse/rse-gateway-get-rse-attributes.test.ts
+++ b/test/gateway/rse/rse-gateway-get-rse-attributes.test.ts
@@ -7,7 +7,7 @@ describe('RSEGateway GET RSE Attributes Endpoint Tests', () => {
     beforeEach(() => {
         fetchMock.doMock();
         const getRSEAttributesMockEndpoint: MockEndpoint = {
-            url: `${MockRucioServerFactory.RUCIO_HOST}/rses/MOCK3/attr`,
+            url: `${MockRucioServerFactory.RUCIO_HOST}/rses/MOCK3/attr/`,
             method: 'GET',
             includes: '/rses/MOCK3/attr',
             response: {


### PR DESCRIPTION
Fix #598

This pull request standardizes the URL format for the RSE Attributes API by ensuring all URLs include a trailing slash. Corresponding updates were made in both the endpoint implementation and related test cases.

### Updates to URL formatting:

* [`src/lib/infrastructure/gateway/rse-gateway/endpoints/get-rse-attributes-endpoint.ts`](diffhunk://#diff-64d7c8223fe13fdcba8708a954a9b21ff577e8baec986240355a827aa474f696L14-R14): Updated the `url` property in `GetRSEAttributesEndpoint` to include a trailing slash (`/rses/${this.rseName}/attr/`).

### Updates to test cases:

* [`test/api/rse/get-rse-attributes.test.ts`](diffhunk://#diff-7ad81307662c9a0aaca0824b7f7e885ab3f0e99f615119368c89b60c30ddcc53L17-R19): Modified the mock endpoint URL and `includes` property to include a trailing slash for consistency in the `GET RSE Attributes API Test`.
* [`test/gateway/rse/rse-gateway-get-rse-attributes.test.ts`](diffhunk://#diff-1e909e2d71fa7e5abcf832dd6ddc58630925714148901e4dbf5b8563ce94aa37L10-R10): Adjusted the mock endpoint URL to include a trailing slash in the `RSEGateway GET RSE Attributes Endpoint Tests`.