### PR TITLE
feat: Add click-to-copy functionality for DIDs in rule page

### DIFF
--- a/src/component-library/features/table/cells/CopyableCell.stories.tsx
+++ b/src/component-library/features/table/cells/CopyableCell.stories.tsx
@@ -1,0 +1,216 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { CopyableCell, CopyableLinkCell } from './CopyableCell';
+import { Toaster } from '@/component-library/atoms/toast/Toaster';
+
+/**
+ * CopyableCell components provide click-to-copy functionality for table cells.
+ * They display content with an optional copy icon and show toast notifications when content is copied.
+ */
+const meta = {
+    title: 'Components/Table/CopyableCell',
+    decorators: [
+        (Story) => (
+            <div className="p-4">
+                <Story />
+                <Toaster />
+            </div>
+        ),
+    ],
+} satisfies Meta;
+
+export default meta;
+
+/**
+ * Basic CopyableCell that copies text to clipboard when clicked
+ */
+export const BasicCopyableCell: StoryObj<typeof CopyableCell> = {
+    render: () => (
+        <div className="space-y-4">
+            <h3 className="text-lg font-semibold">Click anywhere on the cell to copy</h3>
+            <table className="border-collapse">
+                <tbody>
+                    <tr>
+                        <td className="border p-2">
+                            <CopyableCell text="user.scope:dataset_name_001">
+                                user.scope:dataset_name_001
+                            </CopyableCell>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="border p-2">
+                            <CopyableCell text="mc16_13TeV:AOD.123456._000001.pool.root.1">
+                                mc16_13TeV:AOD.123456._000001.pool.root.1
+                            </CopyableCell>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    ),
+};
+
+/**
+ * CopyableCell without the copy icon
+ */
+export const WithoutIcon: StoryObj<typeof CopyableCell> = {
+    render: () => (
+        <div className="space-y-4">
+            <h3 className="text-lg font-semibold">Copy functionality without visible icon</h3>
+            <table className="border-collapse">
+                <tbody>
+                    <tr>
+                        <td className="border p-2">
+                            <CopyableCell text="user.scope:dataset_name_002" showIcon={false}>
+                                user.scope:dataset_name_002
+                            </CopyableCell>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    ),
+};
+
+/**
+ * CopyableLinkCell combines copy functionality with navigation
+ */
+export const LinkWithCopy: StoryObj<typeof CopyableLinkCell> = {
+    render: () => (
+        <div className="space-y-4">
+            <h3 className="text-lg font-semibold">
+                Click the icon to copy, click the text to navigate (opens in new tab)
+            </h3>
+            <table className="border-collapse">
+                <tbody>
+                    <tr>
+                        <td className="border p-2">
+                            <CopyableLinkCell
+                                text="user.scope:dataset_name_003"
+                                href="/did/page/user.scope/dataset_name_003"
+                            >
+                                user.scope:dataset_name_003
+                            </CopyableLinkCell>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td className="border p-2">
+                            <CopyableLinkCell
+                                text="data18_13TeV:AOD.987654._000002.pool.root.1"
+                                href="/did/page/data18_13TeV/AOD.987654._000002.pool.root.1"
+                            >
+                                data18_13TeV:AOD.987654._000002.pool.root.1
+                            </CopyableLinkCell>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    ),
+};
+
+/**
+ * Multiple CopyableCells in a table demonstrating real-world usage
+ */
+export const InTableContext: StoryObj = {
+    render: () => (
+        <div className="space-y-4">
+            <h3 className="text-lg font-semibold">DIDs Table with Copy Functionality</h3>
+            <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-800">
+                    <tr>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            DID
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            Type
+                        </th>
+                        <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                            Size
+                        </th>
+                    </tr>
+                </thead>
+                <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
+                    <tr>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                            <CopyableLinkCell
+                                text="user.jdoe:MyDataset.v1"
+                                href="/did/page/user.jdoe/MyDataset.v1"
+                            >
+                                user.jdoe:MyDataset.v1
+                            </CopyableLinkCell>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800">
+                                Dataset
+                            </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">2.5 GB</td>
+                    </tr>
+                    <tr>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                            <CopyableLinkCell
+                                text="mc16_13TeV:AOD.28395012._000001.pool.root.1"
+                                href="/did/page/mc16_13TeV/AOD.28395012._000001.pool.root.1"
+                            >
+                                mc16_13TeV:AOD.28395012._000001.pool.root.1
+                            </CopyableLinkCell>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">
+                                File
+                            </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">1.2 GB</td>
+                    </tr>
+                    <tr>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                            <CopyableLinkCell
+                                text="data18_13TeV:physics_Main.period_A"
+                                href="/did/page/data18_13TeV/physics_Main.period_A"
+                            >
+                                data18_13TeV:physics_Main.period_A
+                            </CopyableLinkCell>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                            <span className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-purple-100 text-purple-800">
+                                Container
+                            </span>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">15.8 TB</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    ),
+};
+
+/**
+ * Demonstrating custom styling with className prop
+ */
+export const CustomStyling: StoryObj<typeof CopyableCell> = {
+    render: () => (
+        <div className="space-y-4">
+            <h3 className="text-lg font-semibold">Custom styled CopyableCells</h3>
+            <div className="space-y-2">
+                <CopyableCell
+                    text="user.scope:highlighted_dataset"
+                    className="bg-yellow-100 dark:bg-yellow-900 p-2 rounded"
+                >
+                    user.scope:highlighted_dataset
+                </CopyableCell>
+                <CopyableCell
+                    text="user.scope:important_dataset"
+                    className="text-red-600 dark:text-red-400 font-bold p-2"
+                >
+                    user.scope:important_dataset
+                </CopyableCell>
+                <CopyableCell
+                    text="user.scope:large_dataset"
+                    className="text-lg p-2 border-l-4 border-blue-500"
+                >
+                    user.scope:large_dataset
+                </CopyableCell>
+            </div>
+        </div>
+    ),
+};

--- a/src/component-library/features/table/cells/CopyableCell.tsx
+++ b/src/component-library/features/table/cells/CopyableCell.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { HiOutlineClipboardCopy } from 'react-icons/hi';
+import { cn } from '@/component-library/utils';
+import { useToast } from '@/lib/infrastructure/hooks/useToast';
+import { copiedToast, errorCopyingToast } from '@/component-library/features/utils/list-toasts';
+
+/**
+ * Props for the CopyableCell component
+ */
+interface CopyableCellProps {
+    /**
+     * The text to be copied to clipboard when clicked
+     */
+    text: string;
+
+    /**
+     * Content to display in the cell. If not provided, the text prop will be displayed
+     */
+    children?: React.ReactNode;
+
+    /**
+     * Additional CSS classes to apply to the cell container
+     */
+    className?: string;
+
+    /**
+     * Whether to show the copy icon. Defaults to true
+     */
+    showIcon?: boolean;
+}
+
+/**
+ * A table cell component that allows copying its content to clipboard on click.
+ * Displays a copy icon and shows a toast notification when content is copied.
+ *
+ * @example
+ * ```tsx
+ * <CopyableCell text="scope:dataset_name">
+ *   scope:dataset_name
+ * </CopyableCell>
+ * ```
+ */
+export const CopyableCell = ({ text, children, className, showIcon = true }: CopyableCellProps) => {
+    const { toast } = useToast();
+
+    const handleCopy = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        navigator.clipboard
+            .writeText(text)
+            .then(() => {
+                toast(copiedToast);
+            })
+            .catch(() => {
+                toast(errorCopyingToast);
+            });
+    };
+
+    return (
+        <div className={cn('flex items-center gap-1 cursor-pointer', className)} onClick={handleCopy}>
+            {showIcon && (
+                <HiOutlineClipboardCopy className="flex-shrink-0 h-4 w-4 text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200" />
+            )}
+            {children || <span>{text}</span>}
+        </div>
+    );
+};
+
+/**
+ * Props for the CopyableLinkCell component
+ */
+interface CopyableLinkCellProps extends CopyableCellProps {
+    /**
+     * The URL to navigate to when the link is clicked
+     */
+    href: string;
+}
+
+/**
+ * A table cell component that combines copy-to-clipboard functionality with a clickable link.
+ * The copy icon copies the text to clipboard, while clicking the content navigates to the href.
+ *
+ * @example
+ * ```tsx
+ * <CopyableLinkCell
+ *   text="scope:dataset_name"
+ *   href="/did/page/scope/dataset_name"
+ * >
+ *   scope:dataset_name
+ * </CopyableLinkCell>
+ * ```
+ */
+export const CopyableLinkCell = ({ text, href, children, className, showIcon = true }: CopyableLinkCellProps) => {
+    const { toast } = useToast();
+
+    const handleCopy = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        navigator.clipboard
+            .writeText(text)
+            .then(() => {
+                toast(copiedToast);
+            })
+            .catch(() => {
+                toast(errorCopyingToast);
+            });
+    };
+
+    const handleLink = (e: React.MouseEvent) => {
+        // Only navigate if clicking on the text, not the icon
+        if (e.target === e.currentTarget || (e.target as HTMLElement).tagName !== 'svg') {
+            window.open(href, '_blank', 'noopener,noreferrer');
+        }
+    };
+
+    return (
+        <div className={cn('flex items-center gap-1', className)}>
+            {showIcon && (
+                <HiOutlineClipboardCopy
+                    className="flex-shrink-0 h-4 w-4 text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 cursor-pointer"
+                    onClick={handleCopy}
+                    title="Copy to clipboard"
+                />
+            )}
+            <div className="cursor-pointer hover:underline" onClick={handleLink}>
+                {children || <span>{text}</span>}
+            </div>
+        </div>
+    );
+};

--- a/src/component-library/pages/Rule/details/DetailsRuleLocks.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRuleLocks.tsx
@@ -10,10 +10,12 @@ import { LockState } from '@/lib/core/entity/rucio';
 import { LockStateBadge } from '@/component-library/features/badges/Rule/LockStateBadge';
 import useTableStreaming from '@/lib/infrastructure/hooks/useTableStreaming';
 import { ClickableCell } from '@/component-library/features/table/cells/ClickableCell';
+import { CopyableLinkCell } from '@/component-library/features/table/cells/CopyableCell';
 import { Button } from '@/component-library/atoms/form/button';
 import { FTSLinkViewModel } from '@/lib/infrastructure/data/view-model/request';
 import { useToast } from '@/lib/infrastructure/hooks/useToast';
 import { LoadingSpinner } from '@/component-library/atoms/loading/LoadingSpinner';
+import { HiExternalLink } from 'react-icons/hi';
 
 type DetailsRuleLocksTableProps = {
     streamingHook: UseStreamReader<ListRuleReplicaLockStatesViewModel>;
@@ -22,10 +24,14 @@ type DetailsRuleLocksTableProps = {
 
 const ClickableDID = (props: { value: string[] }) => {
     const [scope, name] = props.value;
+    const didString = `${scope}:${name}`;
     return (
-        <ClickableCell href={`/did/page/${encodeURIComponent(scope)}/${encodeURIComponent(name)}`}>
-            {scope}:{name}
-        </ClickableCell>
+        <CopyableLinkCell
+            text={didString}
+            href={`/did/page/${encodeURIComponent(scope)}/${encodeURIComponent(name)}`}
+        >
+            {didString}
+        </CopyableLinkCell>
     );
 };
 

--- a/src/component-library/pages/Rule/details/DetailsRuleMeta.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRuleMeta.tsx
@@ -11,6 +11,7 @@ import { RuleStateBadge } from '@/component-library/features/badges/Rule/RuleSta
 import { RuleGroupingBadge } from '@/component-library/features/badges/Rule/RuleGroupingBadge';
 import { RuleNotificationBadge } from '@/component-library/features/badges/Rule/RuleNotificationBadge';
 import { ClickableCell } from '@/component-library/features/table/cells/ClickableCell';
+import { CopyableLinkCell } from '@/component-library/features/table/cells/CopyableCell';
 
 export const DetailsRuleMeta = ({ meta }: { meta: RuleMetaViewModel }) => {
     const getExpiredField = () => {
@@ -28,15 +29,17 @@ export const DetailsRuleMeta = ({ meta }: { meta: RuleMetaViewModel }) => {
                     <RuleStateBadge value={meta.state} />
                 </KeyValueRow>
                 <KeyValueRow name="DID">
-                    <ClickableCell
-                        className="flex flex-row gap-2 overflow-hidden"
-                        href={`/did/page/${encodeURIComponent(meta.scope)}/${encodeURIComponent(meta.name)}`}
-                    >
-                        <Field>
-                            {meta.scope}:{meta.name}
-                        </Field>
+                    <div className="flex flex-row gap-2 overflow-hidden items-center">
+                        <CopyableLinkCell
+                            text={`${meta.scope}:${meta.name}`}
+                            href={`/did/page/${encodeURIComponent(meta.scope)}/${encodeURIComponent(meta.name)}`}
+                        >
+                            <Field>
+                                {meta.scope}:{meta.name}
+                            </Field>
+                        </CopyableLinkCell>
                         <DIDTypeBadge value={meta.did_type} />
-                    </ClickableCell>
+                    </div>
                 </KeyValueRow>
                 <KeyValueRow name="RSE Expression">
                     <Field>{meta.rse_expression}</Field>


### PR DESCRIPTION
## Summary
- Adds click-to-copy functionality for DIDs in the rule details page
- Implements reusable CopyableCell and CopyableLinkCell components
- Maintains existing navigation while adding copy capability

## Changes
- Created `CopyableCell` and `CopyableLinkCell` components with copy-to-clipboard functionality
- Updated `DetailsRuleMeta` to show copy icon for the DID field
- Updated `DetailsRuleLocks` table to enable copying DIDs from each row
- Added comprehensive Storybook stories with usage examples
- Integrated toast notifications for user feedback

## Testing
- Component functionality can be tested via Storybook
- Copy functionality works on both the rule meta section and locks table
- Existing navigation to DID pages remains functional

# Snapshots
<img width="624" height="254" alt="image" src="https://github.com/user-attachments/assets/3f5a53e3-30b5-4163-bd2d-d7acec5c5060" />

<img width="453" height="236" alt="image" src="https://github.com/user-attachments/assets/b07d680e-c861-429c-bac4-098710d6d096" />

Closes #649