### PR TITLE
feat: prioritize stuck and replicating rules in default sort order

### DIFF
--- a/src/lib/core/utils/rule-sorting-utils.ts
+++ b/src/lib/core/utils/rule-sorting-utils.ts
@@ -1,0 +1,65 @@
+import { RuleState } from '@/lib/core/entity/rucio';
+
+/**
+ * Interface for rule data that can be sorted by activity
+ */
+export interface RuleWithActivity {
+    locks_stuck_cnt: number;
+    locks_replicating_cnt: number;
+    state: RuleState | string;
+}
+
+/**
+ * Calculate activity score for a rule based on stuck/replicating locks and state
+ * Higher scores indicate higher priority (more urgent rules)
+ */
+export function calculateRuleActivityScore(rule: RuleWithActivity): number {
+    let score = 0;
+
+    // Priority 1: Rules with stuck locks (highest priority)
+    if (rule.locks_stuck_cnt > 0) {
+        score += 1000 + rule.locks_stuck_cnt;
+    }
+
+    // Priority 2: Rules with replicating locks
+    if (rule.locks_replicating_cnt > 0) {
+        score += 500 + rule.locks_replicating_cnt;
+    }
+
+    // Priority 3: Rules in stuck or replicating state
+    if (rule.state === RuleState.STUCK || rule.state === 'Stuck') {
+        score += 200;
+    } else if (rule.state === RuleState.REPLICATING || rule.state === 'Replicating') {
+        score += 100;
+    }
+
+    return score;
+}
+
+/**
+ * Comparator function for ag-Grid that prioritizes rules with active issues
+ * (stuck or replicating locks/states)
+ */
+export function ruleActivityComparator(valueA: number, valueB: number, nodeA: any, nodeB: any): number {
+    const rowA = nodeA.data;
+    const rowB = nodeB.data;
+
+    const scoreA = calculateRuleActivityScore(rowA);
+    const scoreB = calculateRuleActivityScore(rowB);
+
+    // Higher scores first (more urgent rules)
+    return scoreB - scoreA;
+}
+
+/**
+ * Sort function for arrays of rules that prioritizes rules with active issues
+ */
+export function sortRulesByActivity<T extends RuleWithActivity>(rules: T[]): T[] {
+    return rules.sort((a, b) => {
+        const scoreA = calculateRuleActivityScore(a);
+        const scoreB = calculateRuleActivityScore(b);
+
+        // Higher scores first (more urgent rules)
+        return scoreB - scoreA;
+    });
+}


### PR DESCRIPTION
## Summary
- Added default sorting to prioritize rules with stuck or replicating locks across all rule tables
- Rules with active issues (stuck/replicating) now appear first in list views

## Changes
- Created shared utility functions in `rule-sorting-utils.ts` for consistent rule prioritization
- Updated ListRuleTable to sort by stuck/replicating rules by default
- Updated DetailsDIDRules table with same prioritization logic  
- Modified Dashboard TopRulesWidget to show stuck/replicating rules first
- Rules are prioritized by: stuck locks > replicating locks > rule state

## Related Issues
Closes #654

## Test Plan
- [x] Verified rules with stuck locks appear first in rule list page
- [x] Verified rules with replicating locks appear after stuck rules
- [x] Verified DID page rules table shows same prioritization
- [x] Verified dashboard widget prioritizes problematic rules
- [x] Build passes without errors