### PR TITLE
feat: Implement responsive grid layout for Rule details meta section

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rucio-webui",
-  "version": "37.2.0",
+  "version": "38.1.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .next .swc",

--- a/src/component-library/pages/Rule/details/DetailsRuleMeta.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRuleMeta.tsx
@@ -13,6 +13,20 @@ import { RuleNotificationBadge } from '@/component-library/features/badges/Rule/
 import { ClickableCell } from '@/component-library/features/table/cells/ClickableCell';
 import { CopyableLinkCell } from '@/component-library/features/table/cells/CopyableCell';
 
+/**
+ * A responsive divider component for rule sections.
+ * 
+ * Renders a full-width divider that is only visible on screens smaller than the 'lg' breakpoint.
+ * Useful for visually separating sections in mobile and tablet layouts.
+ *
+ * @returns {JSX.Element} The divider element.
+ */
+const RuleSectionDivider = () => (
+    <div className="w-full lg:hidden my-4">
+        <Divider />
+    </div>
+);
+
 export const DetailsRuleMeta = ({ meta }: { meta: RuleMetaViewModel }) => {
     const getExpiredField = () => {
         if (meta.expires_at) {
@@ -23,89 +37,100 @@ export const DetailsRuleMeta = ({ meta }: { meta: RuleMetaViewModel }) => {
     };
 
     return (
-        <KeyValueWrapper className="flex flex-col py-3 px-5">
-            <div className="flex flex-col grow">
-                <KeyValueRow name="State">
-                    <RuleStateBadge value={meta.state} />
-                </KeyValueRow>
-                <KeyValueRow name="DID">
-                    <div className="flex flex-row gap-2 overflow-hidden items-center">
-                        <CopyableLinkCell
-                            text={`${meta.scope}:${meta.name}`}
-                            href={`/did/page/${encodeURIComponent(meta.scope)}/${encodeURIComponent(meta.name)}`}
-                        >
-                            <Field>
-                                {meta.scope}:{meta.name}
-                            </Field>
-                        </CopyableLinkCell>
-                        <DIDTypeBadge value={meta.did_type} />
-                    </div>
-                </KeyValueRow>
-                <KeyValueRow name="RSE Expression">
-                    <Field>{meta.rse_expression}</Field>
-                </KeyValueRow>
-                <KeyValueRow name="Account">
-                    <Field>{meta.account}</Field>
-                </KeyValueRow>
-
-                <Divider />
-
-                <KeyValueRow name="Locks OK">
-                    <Field>{meta.locks_ok_cnt}</Field>
-                </KeyValueRow>
-                <KeyValueRow name="Locks Replicating">
-                    <Field>{meta.locks_replicating_cnt}</Field>
-                </KeyValueRow>
-                <KeyValueRow name="Locks Stuck">
-                    <Field>{meta.locks_stuck_cnt}</Field>
-                </KeyValueRow>
-
-                <Divider />
-
-                <KeyValueRow name="Created At">
-                    <Field>{formatDate(meta.created_at)}</Field>
-                </KeyValueRow>
-                <KeyValueRow name="Updated At">
-                    <Field>{formatDate(meta.updated_at)}</Field>
-                </KeyValueRow>
-                <KeyValueRow name="Expires At">{getExpiredField()}</KeyValueRow>
-
-                <Divider />
-
-                <KeyValueRow name="Copies">
-                    <Field>{meta.copies}</Field>
-                </KeyValueRow>
-                <KeyValueRow name="Grouping">
-                    <RuleGroupingBadge value={meta.grouping} />
-                </KeyValueRow>
-                <KeyValueRow name="Notification">
-                    <RuleNotificationBadge value={meta.notification} />
-                </KeyValueRow>
-                <KeyValueRow name="Priority">
-                    <Field>{meta.priority}</Field>
-                </KeyValueRow>
-                <KeyValueRow name="Activity">
-                    <Field>{meta.activity}</Field>
-                </KeyValueRow>
-
-                <Divider />
-
-                <KeyValueRow name="Purge Replicas">
-                    <Checkbox checked={meta.purge_replicas} />
-                </KeyValueRow>
-                <KeyValueRow name="Split Container">
-                    <Checkbox checked={meta.split_container} />
-                </KeyValueRow>
-                <KeyValueRow name="Ignore Account Limit">
-                    <Checkbox checked={meta.ignore_account_limit} />
-                </KeyValueRow>
-                <KeyValueRow name="Ignore Availability">
-                    <Checkbox checked={meta.ignore_availability} />
-                </KeyValueRow>
-                <KeyValueRow name="Locked">
-                    <Checkbox checked={meta.locked} />
-                </KeyValueRow>
+        <KeyValueWrapper className="w-full p-4 flex flex-col ">
+            <div className="w-full flex flex-col lg:flex-row justify-between">
+                <div className="flex flex-col">
+                    <KeyValueRow name="State">
+                        <RuleStateBadge value={meta.state} />
+                    </KeyValueRow>
+                    <KeyValueRow name="DID">
+                        <div className="flex flex-row gap-2 overflow-hidden items-center">
+                            <CopyableLinkCell
+                                text={`${meta.scope}:${meta.name}`}
+                                href={`/did/page/${encodeURIComponent(meta.scope)}/${encodeURIComponent(meta.name)}`}
+                            >
+                                <Field>
+                                    {meta.scope}:{meta.name}
+                                </Field>
+                            </CopyableLinkCell>
+                        </div>
+                    </KeyValueRow>
+                    <KeyValueRow name="DID Type">
+                        <DIDTypeBadge value={meta.did_type} className="w-full" />
+                    </KeyValueRow>
+                    <KeyValueRow name="RSE Expression">
+                        <Field>{meta.rse_expression}</Field>
+                    </KeyValueRow>
+                    <KeyValueRow name="Account">
+                        <Field>{meta.account}</Field>
+                    </KeyValueRow>
+                </div>
+                <RuleSectionDivider />
+                <div className="flex flex-col">
+                    <KeyValueRow name="Locks OK">
+                        <Field>{meta.locks_ok_cnt}</Field>
+                    </KeyValueRow>
+                    <KeyValueRow name="Locks Replicating">
+                        <Field>{meta.locks_replicating_cnt}</Field>
+                    </KeyValueRow>
+                    <KeyValueRow name="Locks Stuck">
+                        <Field>{meta.locks_stuck_cnt}</Field>
+                    </KeyValueRow>
+                </div>
+                <RuleSectionDivider />
+                <div className="flex flex-col">
+                    <KeyValueRow name="Created At">
+                        <Field>{formatDate(meta.created_at)}</Field>
+                    </KeyValueRow>
+                    <KeyValueRow name="Updated At">
+                        <Field>{formatDate(meta.updated_at)}</Field>
+                    </KeyValueRow>
+                    <KeyValueRow name="Expires At">{getExpiredField()}</KeyValueRow>
+                </div>
             </div>
+            <Divider />
+            <div className="w-full flex flex-col lg:flex-row justify-between">
+                <div className="flex flex-col">
+                    <KeyValueRow name="Copies">
+                        <Field>{meta.copies}</Field>
+                    </KeyValueRow>
+                    <KeyValueRow name="Grouping">
+                        <RuleGroupingBadge value={meta.grouping} />
+                    </KeyValueRow>
+                    <KeyValueRow name="Notification">
+                        <RuleNotificationBadge value={meta.notification} />
+                    </KeyValueRow>
+                    <KeyValueRow name="Priority">
+                        <Field>{meta.priority}</Field>
+                    </KeyValueRow>
+                    <KeyValueRow name="Activity">
+                        <Field>{meta.activity}</Field>
+                    </KeyValueRow>
+                </div>
+                <RuleSectionDivider />
+                <div className="flex flex-col">
+                    <KeyValueRow name="Purge Replicas">
+                        <Checkbox checked={meta.purge_replicas} />
+                    </KeyValueRow>
+                    <KeyValueRow name="Split Container">
+                        <Checkbox checked={meta.split_container} />
+                    </KeyValueRow>
+                    <KeyValueRow name="Locked">
+                        <Checkbox checked={meta.locked} />
+                    </KeyValueRow>
+                </div>
+                <RuleSectionDivider />
+                <div className="flex flex-col">
+                     <KeyValueRow name="Ignore Account Limit">
+                        <Checkbox checked={meta.ignore_account_limit} />
+                    </KeyValueRow>
+                    <KeyValueRow name="Ignore Availability">
+                        <Checkbox checked={meta.ignore_availability} />
+                    </KeyValueRow>
+                </div>
+            </div>
+
+            <Divider />
         </KeyValueWrapper>
     );
 };


### PR DESCRIPTION
## Summary
- Reorganized Rule details meta section with responsive grid layout
- Improved checkbox alignment and visual grouping
- Added mobile-responsive section dividers

## Changes
- Split metadata and checkboxes into logical column groups
- Grouped related checkboxes (locks/replication vs account settings)
- Added responsive breakpoints for mobile/tablet/desktop views
- Improved visual hierarchy and spacing

## Test plan
- [x] Verify layout on desktop (lg breakpoint and above)
- [x] Verify layout on tablet/mobile (below lg breakpoint)
- [x] Confirm checkbox alignment is consistent
- [x] Test with different data values

Closes #626
Closes #652