### PR TITLE
fix(auth): resolve NextAuth session cookie decryption in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rucio-webui",
-  "version": "39.0.1",
+  "version": "39.0.2",
   "private": true,
   "scripts": {
     "clean": "rimraf .next .swc",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { getToken } from 'next-auth/jwt';
+import { getToken, decode } from 'next-auth/jwt';
 import type { SessionUser } from './lib/core/entity/auth-models';
 
 export const config = {
@@ -17,12 +17,12 @@ export const config = {
     ],
 };
 
-async function reLogin(request: NextRequest, publicHost: string) {
+function reLogin(request: NextRequest, publicHost: string) {
     const signoutPage = new URL(`/api/auth/signout?callbackUrl=${request.nextUrl.pathname}`, `${publicHost}`);
     return NextResponse.redirect(signoutPage);
 }
 
-async function initiateLogin(request: NextRequest, publicHost: string) {
+function initiateLogin(request: NextRequest, publicHost: string) {
     const loginPage = new URL(`/auth/login?callbackUrl=${request.nextUrl.pathname}`, `${publicHost}`);
     return NextResponse.redirect(loginPage);
 }
@@ -36,32 +36,86 @@ function isTokenExpired(user: SessionUser): boolean {
     return currentTime >= expirationTime;
 }
 
+/**
+ * Determine if we should use secure cookies based on NEXTAUTH_URL
+ */
+function shouldUseSecureCookies(): boolean {
+    const nextAuthUrl = process.env.NEXTAUTH_URL;
+    return nextAuthUrl?.startsWith('https://') ?? false;
+}
+
+/**
+ * Get the appropriate cookie name based on secure cookie setting
+ */
+function getSessionCookieName(): string {
+    return shouldUseSecureCookies()
+        ? '__Secure-authjs.session-token'
+        : 'authjs.session-token';
+}
+
 export async function middleware(request: NextRequest) {
     const publicHost = process.env.NEXT_PUBLIC_WEBUI_HOST || `${request.nextUrl.protocol}//${request.nextUrl.host}`;
+    const cookieName = getSessionCookieName();
+    const secret = process.env.NEXTAUTH_SECRET;
 
     try {
-        // Get the JWT token from the request
-        // This works in Edge Runtime without heavy dependencies
+        // Try getToken with explicit parameters
         const token = await getToken({
             req: request,
-            secret: process.env.NEXTAUTH_SECRET,
+            secret: secret,
+            secureCookie: shouldUseSecureCookies(),
+            cookieName: cookieName,
+            salt: cookieName,
         });
+
+        console.log('[Middleware] getToken result:', {
+            hasToken: !!token,
+            hasUser: !!token?.user,
+            cookieName,
+            useSecure: shouldUseSecureCookies(),
+        });
+
+        // If getToken failed, try manual decode to see the error
+        if (!token) {
+            const cookieValue = request.cookies.get(cookieName)?.value;
+            console.log('[Middleware] Cookie check:', {
+                cookieName,
+                hasCookie: !!cookieValue,
+                cookieLength: cookieValue?.length,
+            });
+
+            if (cookieValue) {
+                try {
+                    const decoded = await decode({
+                        token: cookieValue,
+                        secret: secret!,
+                        salt: cookieName,
+                    });
+                    console.log('[Middleware] Manual decode result:', {
+                        success: !!decoded,
+                        hasUser: !!decoded?.user,
+                    });
+                } catch (decodeError) {
+                    console.error('[Middleware] Manual decode error:', decodeError);
+                }
+            }
+        }
 
         // Check if token exists
         if (!token || !token.user) {
-            return await initiateLogin(request, publicHost);
+            return initiateLogin(request, publicHost);
         }
 
         const user = token.user as SessionUser;
 
         // Check if user is logged in and has a Rucio auth token
         if (!user.isLoggedIn || !user.rucioAuthToken) {
-            return await reLogin(request, publicHost);
+            return reLogin(request, publicHost);
         }
 
         // Check if rucio token is valid
         if (isTokenExpired(user)) {
-            return await reLogin(request, publicHost);
+            return reLogin(request, publicHost);
         }
 
         // All checks have passed, allow the request


### PR DESCRIPTION
## Summary

This PR fixes a critical authentication issue where users were redirected to the login page after successful authentication in production environments (Kubernetes with Apache proxy), while development mode worked correctly.

### Root Cause

The middleware's `getToken()` function from `next-auth/jwt` was unable to decrypt the session cookie in production because it requires explicit parameters to match how the token was encrypted:

| Parameter | Purpose |
|-----------|---------|
| `secret` | Decryption key |
| `secureCookie` | Determines cookie prefix (`__Secure-` for HTTPS) |
| `cookieName` | Which cookie to read |
| `salt` | HKDF key derivation salt (must match cookie name) |

In development (`http://localhost:3000`), the cookie name is `authjs.session-token` and defaults worked. In production (`https://...`), the cookie name is `__Secure-authjs.session-token` and explicit parameters are required.

### Changes

**Authentication middleware (`src/middleware.ts`):**
- Add explicit `getToken()` parameters for proper cookie decryption in HTTPS environments
- Dynamically detect secure cookie mode based on `NEXTAUTH_URL`
- Add debug logging for troubleshooting session issues
- Simplify redirect functions (remove unnecessary `async`)

**Version bump (`package.json`):**
- Updated version to `39.0.2`

### Why `auth()` wrapper wasn't used

The recommended Auth.js v5 pattern using the `auth()` wrapper failed due to Edge Runtime incompatibility - the import chain pulls in `reflect-metadata` (uses `eval`) and `node:stream` which are not allowed in Edge Runtime where middleware runs.

## Test Plan

- [x] Verify login works in development mode (`npm run dev`)
- [x] Verify login works in production behind HTTPS proxy
- [x] Verify protected routes redirect to login when not authenticated
- [x] Verify expired Rucio tokens trigger re-authentication