### PR TITLE
fix(subscription page, rse page): decode path parameters before sending requests to rucio server

### DIFF
--- a/src/app/(rucio)/rse/page/[name]/page.tsx
+++ b/src/app/(rucio)/rse/page/[name]/page.tsx
@@ -8,7 +8,8 @@ import { getRucioAuthToken } from '@/lib/infrastructure/auth/nextauth-session-ut
 import { MockSignal } from '@/lib/infrastructure/utils/mock-signal';
 
 export default async function Page({ params }: { params: Promise<{ name: string }> }) {
-    const { name } = await params;
+    const { name: rawName } = await params;
+    const name = decodeURIComponent(rawName);
     const usecaseFactory = appContainer.get<TUseCaseFactory<GetRSERequest>>(USECASE_FACTORY.GET_RSE);
 
     const signal = new MockSignal<RSEDetailsViewModel>();

--- a/src/app/(rucio)/subscription/page/[account]/[name]/page.tsx
+++ b/src/app/(rucio)/subscription/page/[account]/[name]/page.tsx
@@ -6,5 +6,5 @@ import { DetailsSubscription } from '@/component-library/pages/Subscriptions/det
 export default function PageSubscription({ params }: { params: Promise<{ account: string; name: string }> }) {
     const { account, name } = use(params);
 
-    return <DetailsSubscription account={account} name={name} />;
+    return <DetailsSubscription account={decodeURIComponent(account)} name={decodeURIComponent(name)} />;
 }


### PR DESCRIPTION
This pull request improves the handling of URL parameters by ensuring they are properly decoded before use in the affected pages. This change helps prevent issues caused by encoded characters in route parameters.

**Parameter decoding improvements:**

* Decoded the `name` parameter using `decodeURIComponent` in the `Page` component for the `rse` route to ensure proper handling of special characters in the RSE name. ([src/app/(rucio)/rse/page/[name]/page.tsxL11-R12](diffhunk://#diff-5d3160d5245a560c10748fcd7f464559687f201bd50ed80e7424d36b79f02f8fL11-R12))
* Decoded both `account` and `name` parameters using `decodeURIComponent` in the `PageSubscription` component for the `subscription` route to handle any encoded values. ([src/app/(rucio)/subscription/page/[account]/[name]/page.tsxL9-R9](diffhunk://#diff-249a6f65f12fe5619042f12c55fc43597ae1f7630bb5f43c9f2b80e8b6bd06d9L9-R9))

Close #700