### PR TITLE
fix: suppress noisy "No Entries Found" toast for inactive tabs #740

### DIFF
--- a/src/component-library/features/table/StreamedTable/StreamedTable.tsx
+++ b/src/component-library/features/table/StreamedTable/StreamedTable.tsx
@@ -6,11 +6,13 @@ import { useToast } from '@/lib/infrastructure/hooks/useToast';
 
 export interface StreamedTableProps extends RegularTableProps {
     streamingHook: UseStreamReader<any>;
+    isActive?: boolean;
 }
 
 export const StreamedTable = (props: StreamedTableProps) => {
     const { toast } = useToast();
     const { error, status } = props.streamingHook;
+    const { isActive } = props;
 
     const showErrorToast = () => {
         if (!error) return;
@@ -34,10 +36,12 @@ export const StreamedTable = (props: StreamedTableProps) => {
         } else {
             gridApi?.hideOverlay();
         }
-        showErrorToast();
+        if (isActive !== false) {
+            showErrorToast();
+        }
     }, [error, status]);
 
-    const { noRowsOverlayComponent, streamingHook: _, ...otherProps } = props;
+    const { noRowsOverlayComponent, streamingHook: _, isActive: _isActive, ...otherProps } = props;
 
     const getDefaultNoRowsElement = (gridProps: any) => {
         return <NoLoadedRowsOverlay error={error} status={status} {...gridProps} />;

--- a/src/component-library/pages/DID/details/DetailsDID.tsx
+++ b/src/component-library/pages/DID/details/DetailsDID.tsx
@@ -73,7 +73,7 @@ export const DetailsDIDTables = ({ scope, name, type }: DetailsDIDTablesProps) =
 
                 return (
                     <div key={tabName} className={viewClasses}>
-                        <ViewComponent scope={scope} name={name} />
+                        <ViewComponent scope={scope} name={name} isActive={index === activeIndex} />
                     </div>
                 );
             })}

--- a/src/component-library/pages/DID/details/tables/DetailsDIDFileReplicasTable.tsx
+++ b/src/component-library/pages/DID/details/tables/DetailsDIDFileReplicasTable.tsx
@@ -13,6 +13,7 @@ import { StreamedTable } from '@/component-library/features/table/StreamedTable/
 type DetailsDIDFileReplicasTableProps = {
     streamingHook: UseStreamReader<FileReplicaStateViewModel>;
     onGridReady: (event: GridReadyEvent) => void;
+    isActive?: boolean;
 };
 
 const ClickableRSE = (props: { value: string }) => {

--- a/src/component-library/pages/DID/details/tables/DetailsDIDSimpleTable.tsx
+++ b/src/component-library/pages/DID/details/tables/DetailsDIDSimpleTable.tsx
@@ -15,6 +15,7 @@ type DetailsDIDSimpleTableProps = {
     streamingHook: UseStreamReader<DIDViewModel>;
     onSelectionChanged?: (event: SelectionChangedEvent) => void;
     onGridReady: (event: GridReadyEvent) => void;
+    isActive?: boolean;
 };
 
 const ClickableDID = (props: { value: string[] }) => {

--- a/src/component-library/pages/DID/details/views/DetailsDIDContents.tsx
+++ b/src/component-library/pages/DID/details/views/DetailsDIDContents.tsx
@@ -4,7 +4,7 @@ import { DetailsDIDView, DetailsDIDProps } from '@/component-library/pages/DID/d
 import useTableStreaming from '@/lib/infrastructure/hooks/useTableStreaming';
 import { DetailsDIDSimpleTable } from '@/component-library/pages/DID/details/tables/DetailsDIDSimpleTable';
 
-export const DetailsDIDContents: DetailsDIDView = ({ scope, name }: DetailsDIDProps) => {
+export const DetailsDIDContents: DetailsDIDView = ({ scope, name, isActive }: DetailsDIDProps) => {
     const { gridApi, onGridReady, streamingHook, startStreaming, stopStreaming } = useTableStreaming<DIDViewModel>();
 
     useEffect(() => {
@@ -14,5 +14,5 @@ export const DetailsDIDContents: DetailsDIDView = ({ scope, name }: DetailsDIDPr
         }
     }, [gridApi]);
 
-    return <DetailsDIDSimpleTable streamingHook={streamingHook} onGridReady={onGridReady} />;
+    return <DetailsDIDSimpleTable streamingHook={streamingHook} onGridReady={onGridReady} isActive={isActive} />;
 };

--- a/src/component-library/pages/DID/details/views/DetailsDIDContentsReplicas.tsx
+++ b/src/component-library/pages/DID/details/views/DetailsDIDContentsReplicas.tsx
@@ -6,7 +6,7 @@ import { DetailsDIDSimpleTable } from '@/component-library/pages/DID/details/tab
 import { SelectionChangedEvent } from 'ag-grid-community';
 import { DetailsDIDFileReplicasTable } from '@/component-library/pages/DID/details/tables/DetailsDIDFileReplicasTable';
 
-export const DetailsDIDContentsReplicas: DetailsDIDView = ({ scope, name }: DetailsDIDProps) => {
+export const DetailsDIDContentsReplicas: DetailsDIDView = ({ scope, name, isActive }: DetailsDIDProps) => {
     const {
         gridApi: contentsGridApi,
         onGridReady: onContentsGridReady,
@@ -59,10 +59,11 @@ export const DetailsDIDContentsReplicas: DetailsDIDView = ({ scope, name }: Deta
                     streamingHook={contentsStreamingHook}
                     onGridReady={onContentsGridReady}
                     onSelectionChanged={onSelectionChanged}
+                    isActive={isActive}
                 />
             </div>
             <div className="flex flex-col grow">
-                <DetailsDIDFileReplicasTable streamingHook={replicasStreamingHook} onGridReady={onReplicasGridReady} />
+                <DetailsDIDFileReplicasTable streamingHook={replicasStreamingHook} onGridReady={onReplicasGridReady} isActive={isActive} />
             </div>
         </div>
     );

--- a/src/component-library/pages/DID/details/views/DetailsDIDDatasetReplicas.tsx
+++ b/src/component-library/pages/DID/details/views/DetailsDIDDatasetReplicas.tsx
@@ -47,7 +47,7 @@ const ReplicaStateDisplayNames = {
     [ReplicaState.UNAVAILABLE]: 'Unavailable',
 };
 
-export const DetailsDIDDatasetReplicas: DetailsDIDView = ({ scope, name }: DetailsDIDProps) => {
+export const DetailsDIDDatasetReplicas: DetailsDIDView = ({ scope, name, isActive }: DetailsDIDProps) => {
     const { gridApi, onGridReady, streamingHook, startStreaming, stopStreaming } = useTableStreaming<DIDDatasetReplicasViewModel>();
     const gridRef = useRef<AgGridReact>(null);
 
@@ -102,5 +102,14 @@ export const DetailsDIDDatasetReplicas: DetailsDIDView = ({ scope, name }: Detai
         },
     ]);
 
-    return <StreamedTable columnDefs={columnDefs} tableRef={gridRef} onGridReady={onGridReady} streamingHook={streamingHook} rowHeight={75} />;
+    return (
+        <StreamedTable
+            columnDefs={columnDefs}
+            tableRef={gridRef}
+            onGridReady={onGridReady}
+            streamingHook={streamingHook}
+            rowHeight={75}
+            isActive={isActive}
+        />
+    );
 };

--- a/src/component-library/pages/DID/details/views/DetailsDIDFileReplicas.tsx
+++ b/src/component-library/pages/DID/details/views/DetailsDIDFileReplicas.tsx
@@ -4,7 +4,7 @@ import { DetailsDIDView, DetailsDIDProps } from '@/component-library/pages/DID/d
 import useTableStreaming from '@/lib/infrastructure/hooks/useTableStreaming';
 import { DetailsDIDFileReplicasTable } from '@/component-library/pages/DID/details/tables/DetailsDIDFileReplicasTable';
 
-export const DetailsDIDFileReplicas: DetailsDIDView = ({ scope, name }: DetailsDIDProps) => {
+export const DetailsDIDFileReplicas: DetailsDIDView = ({ scope, name, isActive }: DetailsDIDProps) => {
     const { gridApi, onGridReady, streamingHook, startStreaming, stopStreaming } = useTableStreaming<FileReplicaStateViewModel>();
 
     useEffect(() => {
@@ -14,5 +14,5 @@ export const DetailsDIDFileReplicas: DetailsDIDView = ({ scope, name }: DetailsD
         }
     }, [gridApi]);
 
-    return <DetailsDIDFileReplicasTable streamingHook={streamingHook} onGridReady={onGridReady} />;
+    return <DetailsDIDFileReplicasTable streamingHook={streamingHook} onGridReady={onGridReady} isActive={isActive} />;
 };

--- a/src/component-library/pages/DID/details/views/DetailsDIDParents.tsx
+++ b/src/component-library/pages/DID/details/views/DetailsDIDParents.tsx
@@ -4,7 +4,7 @@ import { DetailsDIDView, DetailsDIDProps } from '@/component-library/pages/DID/d
 import useTableStreaming from '@/lib/infrastructure/hooks/useTableStreaming';
 import { DetailsDIDSimpleTable } from '@/component-library/pages/DID/details/tables/DetailsDIDSimpleTable';
 
-export const DetailsDIDParents: DetailsDIDView = ({ scope, name }: DetailsDIDProps) => {
+export const DetailsDIDParents: DetailsDIDView = ({ scope, name, isActive }: DetailsDIDProps) => {
     const { gridApi, onGridReady, streamingHook, startStreaming, stopStreaming } = useTableStreaming<DIDViewModel>();
 
     useEffect(() => {
@@ -14,5 +14,5 @@ export const DetailsDIDParents: DetailsDIDView = ({ scope, name }: DetailsDIDPro
         }
     }, [gridApi]);
 
-    return <DetailsDIDSimpleTable streamingHook={streamingHook} onGridReady={onGridReady} />;
+    return <DetailsDIDSimpleTable streamingHook={streamingHook} onGridReady={onGridReady} isActive={isActive} />;
 };

--- a/src/component-library/pages/DID/details/views/DetailsDIDRules.tsx
+++ b/src/component-library/pages/DID/details/views/DetailsDIDRules.tsx
@@ -23,6 +23,7 @@ import { ruleActivityComparator, remainingLifetimeComparator, ruleStateComparato
 type DetailsDIDRulesTableProps = {
     streamingHook: UseStreamReader<DIDRulesViewModel>;
     onGridReady: (event: GridReadyEvent) => void;
+    isActive?: boolean;
 };
 
 const ClickableId = (props: { value: string }) => {
@@ -148,7 +149,7 @@ export const DetailsDIDRulesTable = (props: DetailsDIDRulesTableProps) => {
     return <StreamedTable columnDefs={columnDefs} tableRef={tableRef} {...props} onGridReady={onGridReady} />;
 };
 
-export const DetailsDIDRules: DetailsDIDView = ({ scope, name }: DetailsDIDProps) => {
+export const DetailsDIDRules: DetailsDIDView = ({ scope, name, isActive }: DetailsDIDProps) => {
     const { gridApi, onGridReady, streamingHook, startStreaming, stopStreaming } = useTableStreaming<DIDRulesViewModel>();
 
     useEffect(() => {
@@ -158,5 +159,5 @@ export const DetailsDIDRules: DetailsDIDView = ({ scope, name }: DetailsDIDProps
         }
     }, [gridApi]);
 
-    return <DetailsDIDRulesTable streamingHook={streamingHook} onGridReady={onGridReady} />;
+    return <DetailsDIDRulesTable streamingHook={streamingHook} onGridReady={onGridReady} isActive={isActive} />;
 };

--- a/src/component-library/pages/DID/details/views/DetailsDIDView.ts
+++ b/src/component-library/pages/DID/details/views/DetailsDIDView.ts
@@ -2,6 +2,7 @@ import React from 'react';
 export type DetailsDIDProps = {
     scope: string;
     name: string;
+    isActive?: boolean;
 };
 
 export type DetailsDIDView = (props: DetailsDIDProps) => React.ReactElement;

--- a/src/component-library/pages/Rule/approve/ApproveRule.tsx
+++ b/src/component-library/pages/Rule/approve/ApproveRule.tsx
@@ -121,7 +121,8 @@ export const ApproveRule = (props: ApproveRuleProps) => {
                             <span className="font-medium">View:</span> Opens the full rule detail page in a new tab for more information.
                         </li>
                         <li>
-                            <span className="font-medium">Filters:</span> Use the filter panel to narrow results by account, scope, activity, or date range.
+                            <span className="font-medium">Filters:</span> Use the filter panel to narrow results by account, scope, activity, or date
+                            range.
                         </li>
                     </ul>
                 )}
@@ -143,7 +144,13 @@ export const ApproveRule = (props: ApproveRuleProps) => {
                                 placeholder="Filter by account"
                                 value={filters.account}
                             />
-                            <Button className="px-3" variant="neutral" onClick={() => setIsFilterExpanded(!isFilterExpanded)} aria-expanded={isFilterExpanded} aria-label="Toggle filters">
+                            <Button
+                                className="px-3"
+                                variant="neutral"
+                                onClick={() => setIsFilterExpanded(!isFilterExpanded)}
+                                aria-expanded={isFilterExpanded}
+                                aria-label="Toggle filters"
+                            >
                                 <HiFilter />
                                 {isFilterExpanded ? <HiChevronUp className="ml-1" /> : <HiChevronDown className="ml-1" />}
                             </Button>
@@ -152,13 +159,29 @@ export const ApproveRule = (props: ApproveRuleProps) => {
                             <div className="rounded-lg bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 p-6 space-y-6">
                                 <div className="flex flex-col sm:flex-row w-full gap-4">
                                     <div className="grow flex-1">
-                                        <label htmlFor="filter-activity" className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">Activity</label>
-                                        <Input id="filter-activity" className="w-full" value={filters.activity} onChange={(e: ChangeEvent<HTMLInputElement>) => handleFiltersChange({ activity: e.target.value })} placeholder="Any Activity" />
+                                        <label
+                                            htmlFor="filter-activity"
+                                            className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block"
+                                        >
+                                            Activity
+                                        </label>
+                                        <Input
+                                            id="filter-activity"
+                                            className="w-full"
+                                            value={filters.activity}
+                                            onChange={(e: ChangeEvent<HTMLInputElement>) => handleFiltersChange({ activity: e.target.value })}
+                                            placeholder="Any Activity"
+                                        />
                                     </div>
                                 </div>
                                 <div className="flex flex-col sm:flex-row w-full gap-4">
                                     <div className="grow flex-1">
-                                        <label htmlFor="filter-scope" className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">Scope</label>
+                                        <label
+                                            htmlFor="filter-scope"
+                                            className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block"
+                                        >
+                                            Scope
+                                        </label>
                                         <Input
                                             id="filter-scope"
                                             className="w-full"
@@ -168,18 +191,48 @@ export const ApproveRule = (props: ApproveRuleProps) => {
                                         />
                                     </div>
                                     <div className="grow flex-1">
-                                        <label htmlFor="filter-name" className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">Name</label>
-                                        <Input id="filter-name" className="w-full" value={filters.name} onChange={(e: ChangeEvent<HTMLInputElement>) => handleFiltersChange({ name: e.target.value })} />
+                                        <label
+                                            htmlFor="filter-name"
+                                            className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block"
+                                        >
+                                            Name
+                                        </label>
+                                        <Input
+                                            id="filter-name"
+                                            className="w-full"
+                                            value={filters.name}
+                                            onChange={(e: ChangeEvent<HTMLInputElement>) => handleFiltersChange({ name: e.target.value })}
+                                        />
                                     </div>
                                 </div>
                                 <div className="flex flex-col sm:flex-row w-full gap-4">
                                     <div className="grow flex-1">
-                                        <label htmlFor="filter-updated-after" className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">Updated After</label>
-                                        <DateInput id="filter-updated-after" onchange={(date: Date) => handleFiltersChange({ updatedAfter: date })} initialdate={filters.updatedAfter} placeholder="Select date" />
+                                        <label
+                                            htmlFor="filter-updated-after"
+                                            className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block"
+                                        >
+                                            Updated After
+                                        </label>
+                                        <DateInput
+                                            id="filter-updated-after"
+                                            onchange={(date: Date) => handleFiltersChange({ updatedAfter: date })}
+                                            initialdate={filters.updatedAfter}
+                                            placeholder="Select date"
+                                        />
                                     </div>
                                     <div className="grow flex-1">
-                                        <label htmlFor="filter-updated-before" className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">Updated Before</label>
-                                        <DateInput id="filter-updated-before" onchange={(date: Date) => handleFiltersChange({ updatedBefore: date })} initialdate={filters.updatedBefore} placeholder="Select date" />
+                                        <label
+                                            htmlFor="filter-updated-before"
+                                            className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block"
+                                        >
+                                            Updated Before
+                                        </label>
+                                        <DateInput
+                                            id="filter-updated-before"
+                                            onchange={(date: Date) => handleFiltersChange({ updatedBefore: date })}
+                                            initialdate={filters.updatedBefore}
+                                            placeholder="Select date"
+                                        />
                                     </div>
                                 </div>
                             </div>

--- a/src/component-library/pages/Rule/details/DetailsRule.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRule.tsx
@@ -14,7 +14,16 @@ import { DetailsRuleMeta } from '@/component-library/pages/Rule/details/DetailsR
 import { Alert } from '@/component-library/atoms/feedback/Alert';
 import { DetailActions } from '@/component-library/features/mutations/DetailActions';
 import { Button } from '@/component-library/atoms/form/button';
-import { HiOutlineLightningBolt, HiInformationCircle, HiChevronDown, HiOutlineClock, HiOutlineCheckCircle, HiOutlineBan, HiOutlineTrash, HiOutlineAnnotation } from 'react-icons/hi';
+import {
+    HiOutlineLightningBolt,
+    HiInformationCircle,
+    HiChevronDown,
+    HiOutlineClock,
+    HiOutlineCheckCircle,
+    HiOutlineBan,
+    HiOutlineTrash,
+    HiOutlineAnnotation,
+} from 'react-icons/hi';
 import { QUERY_KEYS, invalidateForMutation } from '@/lib/infrastructure/query';
 import { RuleState } from '@/lib/core/entity/rucio';
 import { UpdateLifetimeDialog } from '@/component-library/features/mutations/UpdateLifetimeDialog';
@@ -41,7 +50,7 @@ export const DetailsRuleTabs = ({ id, meta }: { id: string; meta: RuleMetaViewMo
             </div>
             <div className={getViewClasses(1)}>
                 <div className="rounded-lg bg-neutral-0 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 shadow-sm overflow-hidden h-[calc(100vh-20rem)]">
-                    <DetailsRuleLocks id={id} />
+                    <DetailsRuleLocks id={id} isActive={1 === activeIndex} />
                 </div>
             </div>
         </>
@@ -75,7 +84,7 @@ export const DetailsRule = ({ id }: { id: string }) => {
             }
             return viewModel;
         },
-        onSuccess: (viewModel) => {
+        onSuccess: viewModel => {
             toast({ variant: 'success', title: 'Rule Boosted', description: viewModel.message || 'Priority set to 5.' });
             invalidateForMutation(queryClient, 'update-rule');
         },
@@ -295,8 +304,7 @@ export const DetailsRule = ({ id }: { id: string }) => {
                         )}
                         {userCanApproveRule && meta.state === RuleState.WAITING_APPROVAL && (
                             <li>
-                                <span className="font-medium">Deny Rule:</span> Reject this rule. You may optionally provide a reason for
-                                the denial.
+                                <span className="font-medium">Deny Rule:</span> Reject this rule. You may optionally provide a reason for the denial.
                             </li>
                         )}
                         <li>

--- a/src/component-library/pages/Rule/details/DetailsRuleLocks.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRuleLocks.tsx
@@ -21,6 +21,7 @@ import { lockStateComparator } from '@/lib/core/utils/rule-sorting-utils';
 type DetailsRuleLocksTableProps = {
     streamingHook: UseStreamReader<ListRuleReplicaLockStatesViewModel>;
     onGridReady: (event: GridReadyEvent) => void;
+    isActive?: boolean;
 };
 
 const ClickableDID = (props: { value: string[] }) => {
@@ -178,7 +179,7 @@ const DetailsRuleLocksTable = (props: DetailsRuleLocksTableProps) => {
     return <StreamedTable columnDefs={columnDefs} tableRef={tableRef} {...props} onGridReady={onGridReady} />;
 };
 
-export const DetailsRuleLocks = ({ id }: { id: string }) => {
+export const DetailsRuleLocks = ({ id, isActive }: { id: string; isActive?: boolean }) => {
     const { gridApi, onGridReady, streamingHook, startStreaming, stopStreaming } = useTableStreaming<ListRuleReplicaLockStatesViewModel>();
 
     useEffect(() => {
@@ -188,5 +189,5 @@ export const DetailsRuleLocks = ({ id }: { id: string }) => {
         }
     }, [gridApi]);
 
-    return <DetailsRuleLocksTable streamingHook={streamingHook} onGridReady={onGridReady} />;
+    return <DetailsRuleLocksTable streamingHook={streamingHook} onGridReady={onGridReady} isActive={isActive} />;
 };

--- a/test/api/jest.api.config.js
+++ b/test/api/jest.api.config.js
@@ -31,7 +31,7 @@ const customJestConfig = {
     '^@auth/core/(.*)$': '<rootDir>/test/gateway/__mocks__/auth-core.js',
   },
   testEnvironment: 'jest-environment-jsdom',
-  testMatch: ['<rootDir>/test/api/**/*.test.ts', '<rootDir>/test/api/**/*.test.tsx'],
+  testRegex: 'test/api/.*\\.test\\.(ts|tsx)$',
 
 }
 

--- a/test/component/jest.component.config.js
+++ b/test/component/jest.component.config.js
@@ -24,7 +24,7 @@ const customJestConfig = {
         '@/(.*)$': '<rootDir>/src/$1',
     },
     testEnvironment: 'jest-environment-jsdom',
-    testMatch: ['<rootDir>/test/component/**/*.test.ts', '<rootDir>/test/component/**/*.test.tsx'],
+    testRegex: 'test/component/.*\\.test\\.(ts|tsx)$',
 
 }
 

--- a/test/gateway/jest.gateway.config.js
+++ b/test/gateway/jest.gateway.config.js
@@ -31,7 +31,7 @@ const customJestConfig = {
         '^@auth/core/(.*)$': '<rootDir>/test/gateway/__mocks__/auth-core.js',
     },
     testEnvironment: 'jest-environment-jsdom',
-    testMatch: ['<rootDir>/test/gateway/**/*.test.ts', '<rootDir>/test/gateway/**/*.test.tsx'],
+    testRegex: 'test/gateway/.*\\.test\\.(ts|tsx)$',
 
 }
 

--- a/test/hook/jest.hook.config.js
+++ b/test/hook/jest.hook.config.js
@@ -31,7 +31,7 @@ const customJestConfig = {
         '^@auth/core/(.*)$': '<rootDir>/test/gateway/__mocks__/auth-core.js',
     },
     testEnvironment: 'jest-environment-jsdom',
-    testMatch: ['<rootDir>/test/hook/**/*.test.ts', '<rootDir>/test/hook/**/*.test.tsx'],
+    testRegex: 'test/hook/.*\\.test\\.(ts|tsx)$',
 
 }
 

--- a/test/sdk/jest.sdk.config.js
+++ b/test/sdk/jest.sdk.config.js
@@ -32,11 +32,7 @@ const customJestConfig = {
     '^@auth/core/(.*)$': '<rootDir>/test/gateway/__mocks__/auth-core.js',
   },
   testEnvironment: 'jest-environment-jsdom',
-  testMatch: [
-    '<rootDir>/test/sdk/**/*.test.ts',
-    '<rootDir>/test/sdk/**/*.test.tsx',
-    '<rootDir>/src/lib/core/**/*.test.ts',
-  ],
+  testRegex: ['test/sdk/.*\\.test\\.(ts|tsx)$', 'src/lib/core/.*\\.test\\.ts$'],
 
 }
 


### PR DESCRIPTION
On DID and Rule detail pages, all tab components mount simultaneously with visibility controlled via CSS. Each tab begins streaming data on mount, and when a hidden tab receives an empty or NOT_FOUND response, `StreamedTable` fires an "Oops, No Entries Found!" toast — spamming the user with errors for tabs they never viewed.

## Changes

- Add optional `isActive?: boolean` prop to `StreamedTable`; when `false`, the error toast is suppressed. Default behavior (prop omitted or `true`) is unchanged for backward compatibility.
- Thread `isActive` through all DID detail tab views (`Rules`, `FileReplicas`, `Parents`, `Contents`, `ContentsReplicas`, `DatasetReplicas`) and intermediate table components (`DetailsDIDSimpleTable`, `DetailsDIDFileReplicasTable`).
- Thread `isActive` through `DetailsRuleLocks` on the Rule detail page.
- Tab containers (`DetailsDIDTables`, `DetailsRuleTabs`) pass `isActive={index === activeIndex}` to each view component.
- Add `htmlFor`/`id` pairs to ApproveRule filter labels for accessibility.
- Migrate jest `testMatch` to `testRegex` in all test suite configs for more reliable test discovery.