### PR TITLE
feat(ux, rules): enable sorting by state in rule lock states table

### DIFF
--- a/src/lib/core/utils/rule-sorting-utils.test.ts
+++ b/src/lib/core/utils/rule-sorting-utils.test.ts
@@ -1,0 +1,69 @@
+import { LockState } from '@/lib/core/entity/rucio';
+import { lockStateComparator } from './rule-sorting-utils';
+
+describe('lockStateComparator', () => {
+    describe('with single-character LockState enum values', () => {
+        it('sorts STUCK (S) before REPLICATING (R)', () => {
+            // comparator returns negative when A should come first (desc sort: priorityB - priorityA < 0 means A has higher priority)
+            const result = lockStateComparator(LockState.STUCK, LockState.REPLICATING);
+            expect(result).toBeLessThan(0);
+        });
+
+        it('sorts REPLICATING (R) before OK (O)', () => {
+            const result = lockStateComparator(LockState.REPLICATING, LockState.OK);
+            expect(result).toBeLessThan(0);
+        });
+
+        it('sorts OK (O) before UNKNOWN (U)', () => {
+            const result = lockStateComparator(LockState.OK, LockState.UNKNOWN);
+            expect(result).toBeLessThan(0);
+        });
+
+        it('sorts STUCK (S) before OK (O)', () => {
+            const result = lockStateComparator(LockState.STUCK, LockState.OK);
+            expect(result).toBeLessThan(0);
+        });
+
+        it('sorts STUCK (S) before UNKNOWN (U)', () => {
+            const result = lockStateComparator(LockState.STUCK, LockState.UNKNOWN);
+            expect(result).toBeLessThan(0);
+        });
+
+        it('returns 0 for equal states', () => {
+            expect(lockStateComparator(LockState.STUCK, LockState.STUCK)).toBe(0);
+            expect(lockStateComparator(LockState.REPLICATING, LockState.REPLICATING)).toBe(0);
+            expect(lockStateComparator(LockState.OK, LockState.OK)).toBe(0);
+            expect(lockStateComparator(LockState.UNKNOWN, LockState.UNKNOWN)).toBe(0);
+        });
+
+        it('returns positive when lower-priority state is first', () => {
+            const result = lockStateComparator(LockState.OK, LockState.STUCK);
+            expect(result).toBeGreaterThan(0);
+        });
+    });
+
+    describe('with full-name string values (compatibility)', () => {
+        it('sorts "stuck" before "replicating"', () => {
+            const result = lockStateComparator('stuck', 'replicating');
+            expect(result).toBeLessThan(0);
+        });
+
+        it('sorts "replicating" before "ok"', () => {
+            const result = lockStateComparator('replicating', 'ok');
+            expect(result).toBeLessThan(0);
+        });
+
+        it('returns 0 for equal full-name states', () => {
+            expect(lockStateComparator('ok', 'ok')).toBe(0);
+            expect(lockStateComparator('stuck', 'stuck')).toBe(0);
+        });
+    });
+
+    describe('priority ordering', () => {
+        it('all four LockState values sort in correct descending order: S > R > O > U', () => {
+            const states = [LockState.OK, LockState.UNKNOWN, LockState.STUCK, LockState.REPLICATING];
+            const sorted = [...states].sort(lockStateComparator);
+            expect(sorted).toEqual([LockState.STUCK, LockState.REPLICATING, LockState.OK, LockState.UNKNOWN]);
+        });
+    });
+});

--- a/src/lib/core/utils/rule-sorting-utils.ts
+++ b/src/lib/core/utils/rule-sorting-utils.ts
@@ -1,4 +1,4 @@
-import { RuleState } from '@/lib/core/entity/rucio';
+import { LockState, RuleState } from '@/lib/core/entity/rucio';
 
 /**
  * Interface for rule data that can be sorted by activity
@@ -82,10 +82,18 @@ export function remainingLifetimeComparator(valueA: number | null | undefined, v
 /**
  * Get priority score for lock states
  * Higher scores indicate higher priority (more urgent states)
+ * Handles both single-character LockState enum codes ('S', 'R', 'O', 'U')
+ * and full-name strings ('stuck', 'replicating', 'ok') for compatibility.
  */
 function getLockStatePriority(state: string): number {
-    const stateLower = state.toLowerCase();
+    // Handle single-character LockState enum codes (e.g. LockState.STUCK = 'S')
+    if (state === LockState.STUCK) return 3;
+    if (state === LockState.REPLICATING) return 2;
+    if (state === LockState.OK) return 1;
+    if (state === LockState.UNKNOWN) return 0;
 
+    // Fall back to full-name string comparison for compatibility
+    const stateLower = state.toLowerCase();
     if (stateLower.includes('error')) return 4;
     if (stateLower === 'stuck') return 3;
     if (stateLower === 'replicating') return 2;


### PR DESCRIPTION
This pull request improves accessibility in the `ApproveRule` component and enhances the sorting utility for lock states, including new comprehensive tests for the comparator logic. The most important changes are:

**Accessibility Improvements:**
* Added `htmlFor` and `id` attributes to all filter input labels and fields in `ApproveRule.tsx` to improve accessibility and ensure proper label-input association.

**Sorting Utility Enhancements:**
* Updated `getLockStatePriority` in `rule-sorting-utils.ts` to handle both single-character `LockState` enum codes and full-name string values, ensuring compatibility and correct priority assignment.
* Imported `LockState` into `rule-sorting-utils.ts` to support the improved lock state priority logic.

**Testing:**
* Added a comprehensive test suite for `lockStateComparator` in `rule-sorting-utils.test.ts`, covering both enum and string lock state values and verifying correct sorting order.

Closes #745