### PR TITLE
fix: replace master branch references with main (#765)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Rucio WebUI Version
       description: The used Rucio WebUI Version.
-      placeholder: "e.g. 1.28.4, master"
+      placeholder: "e.g. 1.28.4, main"
 
   - type: textarea
     attributes:

--- a/.github/workflows/api-and-component.yml
+++ b/.github/workflows/api-and-component.yml
@@ -2,10 +2,10 @@ name: API, Component and Hook Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     name: Test API, Components and Hooks

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -2,10 +2,10 @@ name: Gateway Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     name: Gateway Tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ name: Prettier Code Check
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   prettier-check:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -2,10 +2,10 @@ name: SDK Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   test:
     name: Test WebUI SDK

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,7 +2,7 @@ name: Security Audit
 on:
     push:
         branches:
-            - master
+            - main
     pull_request:
     schedule:
         - cron: "0 8 * * 1"  # Every Monday at 08:00 UTC

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Rucio WebUI Component Library & React App
 on:
     push:
         branches:
-            - master
+            - main
 permissions:
     contents: write
 jobs:

--- a/tools/create-feature-branch
+++ b/tools/create-feature-branch
@@ -11,14 +11,14 @@ fi
 echo "Fetching upstream"
 git fetch upstream --progress
 
-echo "Switching to master"
-git checkout upstream/master -B master
+echo "Switching to main"
+git checkout upstream/main -B main
 if [ $? != 0 ]; then
-    echo "Can't reset and checkout master"
+    echo "Can't reset and checkout main"
     exit 1
 fi
 
-echo "Creating feature branch from master"
-git checkout -b feature-$1-${2//[^a-zA-Z0-9]/_} master
+echo "Creating feature branch from main"
+git checkout -b feature-$1-${2//[^a-zA-Z0-9]/_} main
 
 echo "Done"

--- a/tools/create-patch-branch
+++ b/tools/create-patch-branch
@@ -11,14 +11,14 @@ fi
 echo "Fetching upstream"
 git fetch upstream --progress
 
-echo "Switching to master"
-git checkout upstream/master -B master
+echo "Switching to main"
+git checkout upstream/main -B main
 if [ $? != 0 ]; then
-    echo "Can't reset and checkout master"
+    echo "Can't reset and checkout main"
     exit 1
 fi
 
 echo "Creating patch branch"
-git checkout -b patch-$1-${2//[^a-zA-Z0-9]/_} master
+git checkout -b patch-$1-${2//[^a-zA-Z0-9]/_} main
 
 echo "Done"

--- a/tools/deploy-to-gh-pages
+++ b/tools/deploy-to-gh-pages
@@ -2,7 +2,7 @@
 
 # install deps & project build done
 # control comes here only if install and build goes fine
-# assumes 'docs' to be present in the master branch
+# assumes 'docs' to be present in the main branch
 # assumes 'gh-pages' branch is present
 
 # set GitHub config credentials
@@ -11,16 +11,16 @@ git config user.email "rucio-dev@cern.ch"
 git config user.name "rucio-bot"
 
 # remove any changes by stashing
-# checkout to master
+# checkout to main
 
 git stash
-git checkout master
+git checkout main
 
 # checkout to the gh-pages, reset
 # sync the branch with our main
 
 git checkout gh-pages
-git reset --hard origin/master
+git reset --hard origin/main
 
 # delete everything on the directory
 # ignore the docs folder


### PR DESCRIPTION
## Summary
- Updates `.github/workflows/*.yml` triggers (api-and-component, gateway, lint, sdk, security, storybook) to listen on `main` instead of `master`
- Updates `tools/create-feature-branch`, `tools/create-patch-branch`, and `tools/deploy-to-gh-pages` to check out and reset against `main`
- Updates autopilot PR base branch in `.claude/autopilot/src/agents/master-agent.ts`
- Updates `master` placeholder in the bug report issue template

Closes #765