### PR TITLE
fix(rules): align rule lifetime/deletion behaviour with CLI implementation

### DIFF
--- a/src/component-library/atoms/form/checkbox.tsx
+++ b/src/component-library/atoms/form/checkbox.tsx
@@ -6,6 +6,19 @@ import { HiCheck, HiMinus } from 'react-icons/hi';
 
 import { cn } from '@/component-library/utils';
 
+/**
+ * Accessible checkbox built on Radix UI's CheckboxPrimitive.
+ *
+ * Accessibility notes:
+ * - The visible control is a `<button role="checkbox">` (the Radix Root); its `aria-checked`
+ *   attribute conveys the checked state to assistive technology.
+ * - Radix internally renders a visually-hidden `<input type="checkbox">` (BubbleInput) for
+ *   native-form serialisation. As of @radix-ui/react-checkbox v1.1+, that element is rendered
+ *   with `aria-hidden="true"` so it is excluded from the accessibility tree.
+ * - The `CheckboxPrimitive.Indicator` and its decorative icon children are marked
+ *   `aria-hidden="true"` here because the state is already communicated by the Root's
+ *   `role`/`aria-checked` attributes.
+ */
 const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root>, React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>>(
     ({ className, ...props }, ref) => (
         <CheckboxPrimitive.Root
@@ -25,7 +38,9 @@ const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root
             )}
             {...props}
         >
-            <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-neutral-100')}>
+            {/* aria-hidden: the state is communicated by the Root's role/aria-checked; the
+                icon is purely decorative and must not be announced by screen readers. */}
+            <CheckboxPrimitive.Indicator aria-hidden="true" className={cn('flex items-center justify-center text-neutral-100')}>
                 {props.checked === 'indeterminate' && <HiMinus className="h-4 w-4" />}
                 {props.checked === true && <HiCheck className="h-4 w-4" />}
             </CheckboxPrimitive.Indicator>

--- a/src/component-library/features/mutations/DeleteRuleDialog.stories.tsx
+++ b/src/component-library/features/mutations/DeleteRuleDialog.stories.tsx
@@ -25,12 +25,10 @@ export default meta;
 type Story = StoryObj<typeof DeleteRuleDialog>;
 
 const DeleteRuleWrapper = ({
-    isAdmin = false,
     loading = false,
     defaultForceDelete = false,
     openInitially = false,
 }: {
-    isAdmin?: boolean;
     loading?: boolean;
     defaultForceDelete?: boolean;
     openInitially?: boolean;
@@ -45,7 +43,6 @@ const DeleteRuleWrapper = ({
                 open={open}
                 onOpenChange={setOpen}
                 ruleId="8a7b6c5d4e3f2a1b"
-                isAdmin={isAdmin}
                 defaultForceDelete={defaultForceDelete}
                 onConfirm={(forceDelete: boolean) => {
                     alert(`Rule deleted! forceDelete=${forceDelete}`);
@@ -58,21 +55,11 @@ const DeleteRuleWrapper = ({
 };
 
 /**
- * Standard dialog for a non-admin user.
- * The force-delete checkbox is visible and defaults to unchecked (soft-delete, lifetime=3600).
- * No warning banner is shown in the default state.
+ * Standard dialog with the force-delete checkbox visible to all users.
+ * Defaults to unchecked (soft-delete, lifetime=3600). No warning banner is shown.
  */
-export const AsUser: Story = {
+export const Default: Story = {
     render: () => <DeleteRuleWrapper />,
-};
-
-/**
- * Standard dialog for an admin user.
- * The force-delete checkbox is visible and defaults to unchecked (soft-delete, lifetime=3600).
- * No warning banner is shown in the default (unchecked) state.
- */
-export const AsAdmin: Story = {
-    render: () => <DeleteRuleWrapper isAdmin />,
 };
 
 /**
@@ -82,7 +69,7 @@ export const AsAdmin: Story = {
  * The info tip also updates to reflect the immediate-deletion mode.
  */
 export const ForceDeleteChecked: Story = {
-    render: () => <DeleteRuleWrapper isAdmin defaultForceDelete openInitially />,
+    render: () => <DeleteRuleWrapper defaultForceDelete openInitially />,
 };
 
 /**

--- a/src/component-library/features/mutations/DeleteRuleDialog.stories.tsx
+++ b/src/component-library/features/mutations/DeleteRuleDialog.stories.tsx
@@ -24,18 +24,31 @@ const meta: Meta<typeof DeleteRuleDialog> = {
 export default meta;
 type Story = StoryObj<typeof DeleteRuleDialog>;
 
-const DeleteRuleWrapper = ({ isAdmin = false, loading = false }: { isAdmin?: boolean; loading?: boolean }) => {
-    const [open, setOpen] = useState(false);
+const DeleteRuleWrapper = ({
+    isAdmin = false,
+    loading = false,
+    defaultForceDelete = false,
+    openInitially = false,
+}: {
+    isAdmin?: boolean;
+    loading?: boolean;
+    defaultForceDelete?: boolean;
+    openInitially?: boolean;
+}) => {
+    const [open, setOpen] = useState(openInitially);
     return (
         <>
-            <Button variant="error" onClick={() => setOpen(true)}>Delete Rule</Button>
+            <Button variant="error" onClick={() => setOpen(true)}>
+                Delete Rule
+            </Button>
             <DeleteRuleDialog
                 open={open}
                 onOpenChange={setOpen}
                 ruleId="8a7b6c5d4e3f2a1b"
                 isAdmin={isAdmin}
-                onConfirm={() => {
-                    alert('Rule deleted!');
+                defaultForceDelete={defaultForceDelete}
+                onConfirm={(forceDelete: boolean) => {
+                    alert(`Rule deleted! forceDelete=${forceDelete}`);
                     setOpen(false);
                 }}
                 loading={loading}
@@ -44,14 +57,37 @@ const DeleteRuleWrapper = ({ isAdmin = false, loading = false }: { isAdmin?: boo
     );
 };
 
+/**
+ * Standard dialog for a non-admin user.
+ * The force-delete checkbox is visible and defaults to unchecked (soft-delete, lifetime=3600).
+ * No warning banner is shown in the default state.
+ */
 export const AsUser: Story = {
     render: () => <DeleteRuleWrapper />,
 };
 
+/**
+ * Standard dialog for an admin user.
+ * The force-delete checkbox is visible and defaults to unchecked (soft-delete, lifetime=3600).
+ * No warning banner is shown in the default (unchecked) state.
+ */
 export const AsAdmin: Story = {
     render: () => <DeleteRuleWrapper isAdmin />,
 };
 
+/**
+ * Dialog opened with the force-delete checkbox pre-checked.
+ * The destructive error banner is displayed below the checkbox, warning the user
+ * that the rule will be deleted immediately with no grace period (lifetime=0).
+ * The info tip also updates to reflect the immediate-deletion mode.
+ */
+export const ForceDeleteChecked: Story = {
+    render: () => <DeleteRuleWrapper isAdmin defaultForceDelete openInitially />,
+};
+
+/**
+ * Dialog in the loading state while a delete mutation is in progress.
+ */
 export const Loading: Story = {
     render: () => <DeleteRuleWrapper loading />,
 };

--- a/src/component-library/features/mutations/DeleteRuleDialog.tsx
+++ b/src/component-library/features/mutations/DeleteRuleDialog.tsx
@@ -10,7 +10,6 @@ export interface DeleteRuleDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     ruleId: string;
-    isAdmin: boolean;
     onConfirm: (forceDelete: boolean) => void;
     loading?: boolean;
     /** Initial checked state of the force-delete checkbox. Primarily for Storybook/testing. */
@@ -28,12 +27,11 @@ export interface DeleteRuleDialogProps {
  *     open={isOpen}
  *     onOpenChange={setIsOpen}
  *     ruleId="abc123def456"
- *     isAdmin={false}
  *     onConfirm={(forceDelete) => handleDelete(forceDelete)}
  * />
  * ```
  */
-export const DeleteRuleDialog: React.FC<DeleteRuleDialogProps> = ({ open, onOpenChange, ruleId, isAdmin, onConfirm, loading = false, defaultForceDelete = false }) => {
+export const DeleteRuleDialog: React.FC<DeleteRuleDialogProps> = ({ open, onOpenChange, ruleId, onConfirm, loading = false, defaultForceDelete = false }) => {
     const [forceDelete, setForceDelete] = React.useState(defaultForceDelete);
 
     // Reset checkbox state when the dialog closes
@@ -63,37 +61,24 @@ export const DeleteRuleDialog: React.FC<DeleteRuleDialogProps> = ({ open, onOpen
                 <div className="rounded-md bg-base-info-50 dark:bg-base-info-900 p-3 text-sm text-base-info-700 dark:text-base-info-200 flex gap-2 items-start">
                     <HiInformationCircle className="h-5 w-5 shrink-0 mt-0.5" aria-hidden="true" />
                     <p>
-                        {isAdmin && forceDelete
-                            ? 'Force delete will set the rule lifetime to 0, scheduling it for immediate deletion.'
+                        {forceDelete
+                            ? 'Force delete will set the rule lifetime to 0, scheduling it for immediate deletion. The server may reject this request depending on the policy configured by your administrator.'
                             : 'Standard delete will set the rule lifetime to 1 hour, scheduling it for deletion with a grace period.'}
                     </p>
                 </div>
 
-                {/* Force Delete checkbox — admin-only */}
-                {isAdmin && (
-                    <>
-                        <div className="flex items-center gap-3">
-                            <Checkbox
-                                id="force-delete-checkbox"
-                                checked={forceDelete}
-                                onCheckedChange={checked => setForceDelete(checked === true)}
-                                aria-describedby={forceDelete ? 'force-delete-warning' : undefined}
-                            />
-                            <label htmlFor="force-delete-checkbox" className="text-sm font-medium text-neutral-900 dark:text-neutral-100 cursor-pointer select-none">
-                                Force delete (lifetime = 0, immediate deletion)
-                            </label>
-                        </div>
-
-                        {/* Destructive warning — shown only when force-delete is checked */}
-                        {forceDelete && (
-                            <Alert
-                                id="force-delete-warning"
-                                variant="error"
-                                message="Warning: Force deleting sets the rule lifetime to 0. The rule will be deleted immediately with no grace period and any ongoing replication will be cancelled at once."
-                            />
-                        )}
-                    </>
-                )}
+                {/* Force Delete checkbox — visible to all users; the server enforces policy */}
+                <div className="flex items-center gap-3">
+                    <Checkbox
+                        id="force-delete-checkbox"
+                        checked={forceDelete}
+                        onCheckedChange={checked => setForceDelete(checked === true)}
+                        aria-describedby={forceDelete ? 'force-delete-warning' : undefined}
+                    />
+                    <label htmlFor="force-delete-checkbox" className="text-sm font-medium text-neutral-900 dark:text-neutral-100 cursor-pointer select-none">
+                        Force delete
+                    </label>
+                </div>
 
                 {/* Rule ID */}
                 <div>

--- a/src/component-library/features/mutations/DeleteRuleDialog.tsx
+++ b/src/component-library/features/mutations/DeleteRuleDialog.tsx
@@ -2,20 +2,25 @@
 
 import * as React from 'react';
 import { MutationDialog } from '@/component-library/features/mutations/MutationDialog';
-import { HiInformationCircle, HiExclamation } from 'react-icons/hi';
+import { Checkbox } from '@/component-library/atoms/form/checkbox';
+import { Alert } from '@/component-library/atoms/feedback/Alert';
+import { HiInformationCircle } from 'react-icons/hi';
 
 export interface DeleteRuleDialogProps {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     ruleId: string;
     isAdmin: boolean;
-    onConfirm: () => void;
+    onConfirm: (forceDelete: boolean) => void;
     loading?: boolean;
+    /** Initial checked state of the force-delete checkbox. Primarily for Storybook/testing. */
+    defaultForceDelete?: boolean;
 }
 
 /**
  * Confirmation dialog for deleting a replication rule.
- * Sets the rule lifetime to 1 hour (admin) or 24 hours (user), effectively scheduling deletion.
+ * Soft-delete (default) sets the rule lifetime to 3600 seconds (1 hour).
+ * Force-delete sets lifetime to 0, scheduling immediate deletion with no grace period.
  *
  * @example
  * ```tsx
@@ -24,42 +29,71 @@ export interface DeleteRuleDialogProps {
  *     onOpenChange={setIsOpen}
  *     ruleId="abc123def456"
  *     isAdmin={false}
- *     onConfirm={handleDelete}
+ *     onConfirm={(forceDelete) => handleDelete(forceDelete)}
  * />
  * ```
  */
-export const DeleteRuleDialog: React.FC<DeleteRuleDialogProps> = ({ open, onOpenChange, ruleId, isAdmin, onConfirm, loading = false }) => {
+export const DeleteRuleDialog: React.FC<DeleteRuleDialogProps> = ({ open, onOpenChange, ruleId, isAdmin, onConfirm, loading = false, defaultForceDelete = false }) => {
+    const [forceDelete, setForceDelete] = React.useState(defaultForceDelete);
+
+    // Reset checkbox state when the dialog closes
+    React.useEffect(() => {
+        if (!open) {
+            setForceDelete(false);
+        }
+    }, [open]);
+
+    const handleSubmit = () => {
+        onConfirm(forceDelete);
+    };
+
     return (
         <MutationDialog
             open={open}
             onOpenChange={onOpenChange}
             title="Delete Rule"
-            description="Schedule this rule for deletion by setting a short lifetime."
-            onSubmit={onConfirm}
+            description="Schedule this rule for deletion."
+            onSubmit={handleSubmit}
             submitLabel="Delete Rule"
             submitVariant="error"
             loading={loading}
         >
             <div className="space-y-4">
-                {/* Tips */}
+                {/* Info tip */}
                 <div className="rounded-md bg-base-info-50 dark:bg-base-info-900 p-3 text-sm text-base-info-700 dark:text-base-info-200 flex gap-2 items-start">
                     <HiInformationCircle className="h-5 w-5 shrink-0 mt-0.5" aria-hidden="true" />
                     <p>
-                        {isAdmin
-                            ? 'Tips: As an administrator, this rule will be deleted within 1 hour.'
-                            : 'Tips: This will request deletion by setting the rule lifetime to 24 hours. The server may reject this request depending on the policy.'}
+                        {isAdmin && forceDelete
+                            ? 'Force delete will set the rule lifetime to 0, scheduling it for immediate deletion.'
+                            : 'Standard delete will set the rule lifetime to 1 hour, scheduling it for deletion with a grace period.'}
                     </p>
                 </div>
 
-                {/* Warning banner */}
-                <div className="flex items-start gap-3 rounded-md bg-base-error-50 dark:bg-base-error-950 border border-base-error-200 dark:border-base-error-800 p-3">
-                    <HiExclamation className="h-5 w-5 shrink-0 text-base-error-600 dark:text-base-error-400 mt-0.5" aria-hidden="true" />
-                    <p className="text-sm text-base-error-900 dark:text-base-error-100">
-                        {isAdmin
-                            ? 'This rule will expire in 1 hour. Any ongoing replication will be cancelled.'
-                            : 'This rule will expire in 24 hours if the server accepts the request. Any ongoing replication will be cancelled.'}
-                    </p>
-                </div>
+                {/* Force Delete checkbox — admin-only */}
+                {isAdmin && (
+                    <>
+                        <div className="flex items-center gap-3">
+                            <Checkbox
+                                id="force-delete-checkbox"
+                                checked={forceDelete}
+                                onCheckedChange={checked => setForceDelete(checked === true)}
+                                aria-describedby={forceDelete ? 'force-delete-warning' : undefined}
+                            />
+                            <label htmlFor="force-delete-checkbox" className="text-sm font-medium text-neutral-900 dark:text-neutral-100 cursor-pointer select-none">
+                                Force delete (lifetime = 0, immediate deletion)
+                            </label>
+                        </div>
+
+                        {/* Destructive warning — shown only when force-delete is checked */}
+                        {forceDelete && (
+                            <Alert
+                                id="force-delete-warning"
+                                variant="error"
+                                message="Warning: Force deleting sets the rule lifetime to 0. The rule will be deleted immediately with no grace period and any ongoing replication will be cancelled at once."
+                            />
+                        )}
+                    </>
+                )}
 
                 {/* Rule ID */}
                 <div>

--- a/src/component-library/features/mutations/UpdateLifetimeDialog.stories.tsx
+++ b/src/component-library/features/mutations/UpdateLifetimeDialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { useState } from 'react';
+import { within, userEvent } from 'storybook/test';
 import { UpdateLifetimeDialog } from './UpdateLifetimeDialog';
 import { Button } from '@/component-library/atoms/form/button';
 import { Toaster } from '@/component-library/atoms/toast/Toaster';
@@ -29,14 +30,19 @@ const UpdateLifetimeWrapper = ({
     loading = false,
     canSetInfinite = true,
     maxLifetimeSeconds,
+    minLifetimeSeconds,
+    isAdmin,
+    openInitially = false,
 }: {
     currentExpiresAt?: string | null;
     loading?: boolean;
     canSetInfinite?: boolean;
     maxLifetimeSeconds?: number;
     minLifetimeSeconds?: number;
+    isAdmin?: boolean;
+    openInitially?: boolean;
 }) => {
-    const [open, setOpen] = useState(false);
+    const [open, setOpen] = useState(openInitially);
     return (
         <>
             <Button onClick={() => setOpen(true)}>Update Lifetime</Button>
@@ -57,6 +63,7 @@ const UpdateLifetimeWrapper = ({
                 canSetInfinite={canSetInfinite}
                 maxLifetimeSeconds={maxLifetimeSeconds}
                 minLifetimeSeconds={minLifetimeSeconds}
+                isAdmin={isAdmin}
             />
         </>
     );
@@ -74,13 +81,55 @@ export const Loading: Story = {
     render: () => <UpdateLifetimeWrapper currentExpiresAt="2026-12-31T00:00:00Z" loading />,
 };
 
-export const AdminUser: Story = {
-    name: 'Admin (infinite lifetime, 0 min)',
-    render: () => <UpdateLifetimeWrapper currentExpiresAt="2026-12-31T00:00:00Z" canSetInfinite minLifetimeSeconds={0} />,
+/**
+ * Demonstrates the immediate-deletion destructive warning banner.
+ * The play function opens the dialog and enters 0 days / 0 hours so the warning
+ * is visible without any manual interaction in Storybook.
+ */
+export const ZeroLifetimeWarning: Story = {
+    name: 'Zero Lifetime (immediate deletion warning)',
+    render: () => <UpdateLifetimeWrapper currentExpiresAt="2026-12-31T00:00:00Z" canSetInfinite openInitially />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const daysInput = await canvas.findByLabelText('Days');
+        await userEvent.clear(daysInput);
+        await userEvent.type(daysInput, '0');
+        const hoursInput = canvas.getByLabelText('Hours');
+        await userEvent.clear(hoursInput);
+        await userEvent.type(hoursInput, '0');
+    },
 };
 
-export const RegularUser: Story = {
-    name: 'Regular User (1 year max, 24h min, no infinite)',
+/**
+ * Demonstrates the short-lifetime warning banner (< 1 hour).
+ * The play function opens the dialog in date mode and fills in a datetime ~45 minutes
+ * from now so the warning is visible without any manual interaction in Storybook.
+ */
+export const ShortLifetimeWarning: Story = {
+    name: 'Short Lifetime Warning (< 1 hour, date mode)',
+    render: () => <UpdateLifetimeWrapper currentExpiresAt="2026-12-31T00:00:00Z" canSetInfinite openInitially />,
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        // Switch to date mode
+        const dateRadio = canvas.getByRole('radio', { name: /Set by date/ });
+        await userEvent.click(dateRadio);
+        // Enter a date 45 minutes from now (short lifetime: 0 < t < 3600 s)
+        const now = new Date();
+        const target = new Date(now.getTime() + 45 * 60 * 1000);
+        const pad = (n: number) => String(n).padStart(2, '0');
+        const localStr = `${target.getFullYear()}-${pad(target.getMonth() + 1)}-${pad(target.getDate())}T${pad(target.getHours())}:${pad(target.getMinutes())}`;
+        const dateInput = canvas.getByLabelText(/Expiry date/);
+        await userEvent.clear(dateInput);
+        await userEvent.type(dateInput, localStr);
+    },
+};
+
+/**
+ * The caller can still enforce an explicit minimum by passing minLifetimeSeconds > 0.
+ * This story demonstrates a policy-constrained setup (24 h minimum, 1 year cap, no infinite).
+ */
+export const PolicyConstrained: Story = {
+    name: 'Policy-constrained (24 h min, 1 year max, no infinite)',
     render: () => (
         <UpdateLifetimeWrapper
             currentExpiresAt="2026-12-31T00:00:00Z"
@@ -89,4 +138,20 @@ export const RegularUser: Story = {
             minLifetimeSeconds={24 * 3600}
         />
     ),
+};
+
+/**
+ * Non-admin users see the policy advisory banner noting the server may override their choice.
+ */
+export const NonAdminPolicyAdvisory: Story = {
+    name: 'Non-admin (policy advisory banner)',
+    render: () => <UpdateLifetimeWrapper currentExpiresAt="2026-12-31T00:00:00Z" isAdmin={false} />,
+};
+
+/**
+ * Admin users do not see the policy advisory banner.
+ */
+export const AdminUser: Story = {
+    name: 'Admin (no policy advisory, can clear lifetime)',
+    render: () => <UpdateLifetimeWrapper currentExpiresAt="2026-12-31T00:00:00Z" canSetInfinite isAdmin />,
 };

--- a/src/component-library/features/mutations/UpdateLifetimeDialog.tsx
+++ b/src/component-library/features/mutations/UpdateLifetimeDialog.tsx
@@ -88,9 +88,7 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
      * being non-empty (already enforced by the computedSeconds useMemo returning null when empty).
      */
     const showZeroLifetimeWarning =
-        computedSeconds !== null &&
-        computedSeconds === 0 &&
-        (mode === 'date' ? !!dateValue : days !== '' || hours !== '');
+        computedSeconds !== null && computedSeconds === 0 && (mode === 'date' ? !!dateValue : days !== '' || hours !== '');
     /** Show a softer warning when the lifetime is very short but non-zero (< 1 hour). */
     const showShortLifetimeWarning = computedSeconds !== null && computedSeconds > 0 && computedSeconds < 3600;
 
@@ -238,20 +236,32 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
                     </p>
                 </div>
 
-                {/* Clear lifetime checkbox — only shown when user has permission */}
+                {/* Clear lifetime checkbox */}
                 {canSetInfinite && (
-                    // eslint-disable-next-line jsx-a11y/label-has-associated-control
-                    <label htmlFor="clear-lifetime-checkbox" className="flex items-center gap-2 cursor-pointer select-none">
-                        <Checkbox
-                            id="clear-lifetime-checkbox"
-                            checked={clearLifetime}
-                            onCheckedChange={checked => {
-                                setClearLifetime(checked === true);
-                                if (error) setError(undefined);
-                            }}
-                        />
-                        <span className="text-sm text-neutral-900 dark:text-neutral-100">Clear lifetime (no expiry)</span>
-                    </label>
+                    <>
+                        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+                        <label htmlFor="clear-lifetime-checkbox" className="flex items-center gap-2 cursor-pointer select-none">
+                            <Checkbox
+                                id="clear-lifetime-checkbox"
+                                checked={clearLifetime}
+                                onCheckedChange={checked => {
+                                    setClearLifetime(checked === true);
+                                    if (error) setError(undefined);
+                                }}
+                                aria-describedby={clearLifetime && !isAdmin ? 'clear-lifetime-warning' : undefined}
+                            />
+                            <span className="text-sm text-neutral-900 dark:text-neutral-100">Clear lifetime (no expiry)</span>
+                        </label>
+
+                        {/* Non-admin confirmation warning when clearing lifetime */}
+                        {clearLifetime && !isAdmin && (
+                            <Alert
+                                id="clear-lifetime-warning"
+                                variant="warning"
+                                message="Clearing the lifetime makes this rule permanent. It will use storage resources indefinitely. Make sure this is what you intend to do."
+                            />
+                        )}
+                    </>
                 )}
 
                 {/* Mode toggle */}

--- a/src/component-library/features/mutations/UpdateLifetimeDialog.tsx
+++ b/src/component-library/features/mutations/UpdateLifetimeDialog.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import * as React from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { MutationDialog } from '@/component-library/features/mutations/MutationDialog';
 import { Input } from '@/component-library/atoms/form/input';
 import { Checkbox } from '@/component-library/atoms/form/checkbox';
+import { Alert } from '@/component-library/atoms/feedback/Alert';
 import { HiInformationCircle } from 'react-icons/hi';
 
 export interface UpdateLifetimeDialogProps {
@@ -18,7 +19,7 @@ export interface UpdateLifetimeDialogProps {
     canSetInfinite?: boolean;
     /** Maximum lifetime in seconds the user can set. Undefined means no limit. */
     maxLifetimeSeconds?: number;
-    /** Minimum lifetime in seconds. Defaults to 3600 (1 hour). */
+    /** Minimum lifetime in seconds. Defaults to 0 (any non-negative value). */
     minLifetimeSeconds?: number;
     /** Whether the current user is an admin. Non-admins see a policy warning. */
     isAdmin?: boolean;
@@ -50,7 +51,7 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
     loading = false,
     canSetInfinite = true,
     maxLifetimeSeconds,
-    minLifetimeSeconds = 3600,
+    minLifetimeSeconds = 0,
     isAdmin = false,
 }) => {
     const [mode, setMode] = useState<InputMode>('duration');
@@ -59,6 +60,39 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
     const [days, setDays] = useState('');
     const [hours, setHours] = useState('');
     const [error, setError] = useState<string | undefined>();
+
+    /** Reactively compute the current intended lifetime in seconds from the form state. */
+    const computedSeconds = useMemo(() => {
+        if (clearLifetime) return null;
+        if (mode === 'date') {
+            if (!dateValue) return null;
+            try {
+                const target = new Date(dateValue);
+                const now = new Date();
+                return Math.floor((target.getTime() - now.getTime()) / 1000);
+            } catch {
+                return null;
+            }
+        } else {
+            const parsedDays = days === '' ? 0 : parseInt(days, 10);
+            const parsedHours = hours === '' ? 0 : parseInt(hours, 10);
+            if (isNaN(parsedDays) || isNaN(parsedHours)) return null;
+            return (parsedDays * 24 + parsedHours) * 3600;
+        }
+    }, [clearLifetime, mode, dateValue, days, hours]);
+
+    /**
+     * Show a destructive warning when the user has explicitly entered a zero lifetime.
+     * Guard against showing on initial state (duration mode: both fields empty → computedSeconds=0)
+     * by requiring at least one field to have been filled. In date mode the guard is `dateValue`
+     * being non-empty (already enforced by the computedSeconds useMemo returning null when empty).
+     */
+    const showZeroLifetimeWarning =
+        computedSeconds !== null &&
+        computedSeconds === 0 &&
+        (mode === 'date' ? !!dateValue : days !== '' || hours !== '');
+    /** Show a softer warning when the lifetime is very short but non-zero (< 1 hour). */
+    const showShortLifetimeWarning = computedSeconds !== null && computedSeconds > 0 && computedSeconds < 3600;
 
     useEffect(() => {
         if (open) {
@@ -119,7 +153,12 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
             const target = new Date(dateValue);
             const now = new Date();
             const diffSeconds = Math.floor((target.getTime() - now.getTime()) / 1000);
-            if (!validateMinLifetime(diffSeconds)) return;
+            if (diffSeconds < 0) {
+                setError('Expiry date must be in the future');
+                return;
+            }
+            // Respect an explicit minLifetimeSeconds > 0 when set by the caller.
+            if (minLifetimeSeconds > 0 && !validateMinLifetime(diffSeconds)) return;
             if (!validateMaxLifetime(diffSeconds)) return;
             setError(undefined);
             onConfirm(diffSeconds);
@@ -136,7 +175,9 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
                 return;
             }
             const totalSeconds = (parsedDays * 24 + parsedHours) * 3600;
-            if (!validateMinLifetime(totalSeconds)) return;
+            // Negative values are already blocked by input validation; only enforce an
+            // explicit minimum > 0 when the caller has set one.
+            if (minLifetimeSeconds > 0 && !validateMinLifetime(totalSeconds)) return;
             if (!validateMaxLifetime(totalSeconds)) return;
             setError(undefined);
             onConfirm(totalSeconds);
@@ -163,14 +204,18 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
                     <HiInformationCircle className="h-5 w-5 shrink-0 mt-0.5" aria-hidden="true" />
                     <p>
                         Tips: Setting the lifetime controls when this rule expires and is deleted. You can extend or shorten the lifetime.
-                        {canSetInfinite && ' You can also clear the lifetime entirely.'} Minimum lifetime is {formatMinLifetime()}.
+                        {canSetInfinite && ' You can also clear the lifetime entirely.'}
+                        {minLifetimeSeconds > 0 && ` Minimum lifetime is ${formatMinLifetime()}.`}
                     </p>
                 </div>
 
                 {/* Policy warning for non-admins */}
                 {!isAdmin && (
                     <div className="flex items-start gap-3 rounded-md bg-base-warning-50 dark:bg-base-warning-950 border border-base-warning-200 dark:border-base-warning-800 p-3">
-                        <HiInformationCircle className="h-5 w-5 shrink-0 text-base-warning-600 dark:text-base-warning-400 mt-0.5" aria-hidden="true" />
+                        <HiInformationCircle
+                            className="h-5 w-5 shrink-0 text-base-warning-600 dark:text-base-warning-400 mt-0.5"
+                            aria-hidden="true"
+                        />
                         <p className="text-sm text-base-warning-900 dark:text-base-warning-100">
                             The server may reject this request depending on the policy configured by your administrator.
                         </p>
@@ -261,9 +306,10 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
                                                 if (error) setError(undefined);
                                             }}
                                             className={`flex-1 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors
-                                                ${days === String(opt.d) && hours === '0'
-                                                    ? 'border-brand-500 bg-brand-50 text-brand-700 dark:bg-brand-900 dark:text-brand-200 dark:border-brand-400'
-                                                    : 'border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 hover:border-brand-300 hover:bg-brand-50/50 dark:hover:bg-brand-900/30'
+                                                ${
+                                                    days === String(opt.d) && hours === '0'
+                                                        ? 'border-brand-500 bg-brand-50 text-brand-700 dark:bg-brand-900 dark:text-brand-200 dark:border-brand-400'
+                                                        : 'border-neutral-300 dark:border-neutral-600 text-neutral-700 dark:text-neutral-300 hover:border-brand-300 hover:bg-brand-50/50 dark:hover:bg-brand-900/30'
                                                 }`}
                                         >
                                             {opt.label}
@@ -272,42 +318,48 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
                                 </div>
 
                                 <div className="flex gap-3">
-                                <div className="flex-1">
-                                    <label htmlFor="lifetime-days" className="block text-sm font-medium text-neutral-900 dark:text-neutral-100 mb-2">
-                                        Days
-                                    </label>
-                                    <Input
-                                        id="lifetime-days"
-                                        type="number"
-                                        min={0}
-                                        value={days}
-                                        onChange={e => {
-                                            setDays(e.target.value);
-                                            if (error) setError(undefined);
-                                        }}
-                                        placeholder="0"
-                                        error={!!error}
-                                    />
+                                    <div className="flex-1">
+                                        <label
+                                            htmlFor="lifetime-days"
+                                            className="block text-sm font-medium text-neutral-900 dark:text-neutral-100 mb-2"
+                                        >
+                                            Days
+                                        </label>
+                                        <Input
+                                            id="lifetime-days"
+                                            type="number"
+                                            min={0}
+                                            value={days}
+                                            onChange={e => {
+                                                setDays(e.target.value);
+                                                if (error) setError(undefined);
+                                            }}
+                                            placeholder="0"
+                                            error={!!error}
+                                        />
+                                    </div>
+                                    <div className="flex-1">
+                                        <label
+                                            htmlFor="lifetime-hours"
+                                            className="block text-sm font-medium text-neutral-900 dark:text-neutral-100 mb-2"
+                                        >
+                                            Hours
+                                        </label>
+                                        <Input
+                                            id="lifetime-hours"
+                                            type="number"
+                                            min={0}
+                                            max={23}
+                                            value={hours}
+                                            onChange={e => {
+                                                setHours(e.target.value);
+                                                if (error) setError(undefined);
+                                            }}
+                                            placeholder="0"
+                                            error={!!error}
+                                        />
+                                    </div>
                                 </div>
-                                <div className="flex-1">
-                                    <label htmlFor="lifetime-hours" className="block text-sm font-medium text-neutral-900 dark:text-neutral-100 mb-2">
-                                        Hours
-                                    </label>
-                                    <Input
-                                        id="lifetime-hours"
-                                        type="number"
-                                        min={0}
-                                        max={23}
-                                        value={hours}
-                                        onChange={e => {
-                                            setHours(e.target.value);
-                                            if (error) setError(undefined);
-                                        }}
-                                        placeholder="0"
-                                        error={!!error}
-                                    />
-                                </div>
-                            </div>
                             </div>
                         )}
 
@@ -328,6 +380,22 @@ export const UpdateLifetimeDialog: React.FC<UpdateLifetimeDialogProps> = ({
                                     aria-describedby={error ? 'lifetime-date-error' : undefined}
                                 />
                             </div>
+                        )}
+
+                        {/* Zero-lifetime destructive warning */}
+                        {showZeroLifetimeWarning && (
+                            <Alert
+                                variant="error"
+                                message="Setting the lifetime to 0 will schedule this rule for immediate deletion. The rule and all associated replicas managed by it will be removed as soon as the reaper runs."
+                            />
+                        )}
+
+                        {/* Short-lifetime informational warning */}
+                        {showShortLifetimeWarning && (
+                            <Alert
+                                variant="warning"
+                                message="The selected lifetime is very short (less than 1 hour). The rule will expire and be deleted very soon after confirmation."
+                            />
                         )}
 
                         {error && (

--- a/src/component-library/pages/Rule/details/DetailsRule.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRule.tsx
@@ -392,7 +392,6 @@ export const DetailsRule = ({ id }: { id: string }) => {
                 open={isDeleteOpen}
                 onOpenChange={setIsDeleteOpen}
                 ruleId={id}
-                isAdmin={userCanApproveRule}
                 onConfirm={forceDelete => deleteRuleMutation.mutate(forceDelete)}
                 loading={deleteRuleMutation.isPending}
             />

--- a/src/component-library/pages/Rule/details/DetailsRule.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRule.tsx
@@ -369,7 +369,7 @@ export const DetailsRule = ({ id }: { id: string }) => {
                 currentExpiresAt={meta.expires_at}
                 onConfirm={lifetimeSeconds => updateLifetimeMutation.mutate(lifetimeSeconds)}
                 loading={updateLifetimeMutation.isPending}
-                canSetInfinite={userCanSetInfiniteLifetime}
+                canSetInfinite
                 maxLifetimeSeconds={userCanSetInfiniteLifetime ? undefined : 365 * 86400}
                 minLifetimeSeconds={userCanSetInfiniteLifetime ? 0 : 24 * 3600}
                 isAdmin={userCanApproveRule}

--- a/src/component-library/pages/Rule/details/DetailsRule.tsx
+++ b/src/component-library/pages/Rule/details/DetailsRule.tsx
@@ -165,8 +165,8 @@ export const DetailsRule = ({ id }: { id: string }) => {
     });
 
     const deleteRuleMutation = useMutation({
-        mutationFn: async () => {
-            const lifetimeSeconds = userCanApproveRule ? 3600 : 86400;
+        mutationFn: async (forceDelete: boolean) => {
+            const lifetimeSeconds = forceDelete ? 0 : 3600;
             const res = await fetch('/api/feature/update-rule', {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
@@ -316,10 +316,9 @@ export const DetailsRule = ({ id }: { id: string }) => {
                             {!userCanApproveRule && ' The server may reject this request depending on the policy.'}
                         </li>
                         <li>
-                            <span className="font-medium">Delete Rule:</span> Schedule this rule for deletion
-                            {userCanApproveRule
-                                ? ' by setting the lifetime to 1 hour.'
-                                : ' by setting the lifetime to 24 hours. The server may reject this request depending on the policy.'}
+                            <span className="font-medium">Delete Rule:</span> Schedule this rule for deletion by setting the lifetime to 1 hour.
+                            {userCanApproveRule && ' Admins may also force-delete to set lifetime to 0 for immediate deletion.'}
+                            {!userCanApproveRule && ' The server may reject this request depending on the policy.'}
                         </li>
                     </ul>
                 )}
@@ -394,7 +393,7 @@ export const DetailsRule = ({ id }: { id: string }) => {
                 onOpenChange={setIsDeleteOpen}
                 ruleId={id}
                 isAdmin={userCanApproveRule}
-                onConfirm={() => deleteRuleMutation.mutate()}
+                onConfirm={forceDelete => deleteRuleMutation.mutate(forceDelete)}
                 loading={deleteRuleMutation.isPending}
             />
             <CommentRuleDialog

--- a/test/api/rule/update-rule.test.ts
+++ b/test/api/rule/update-rule.test.ts
@@ -47,6 +47,79 @@ describe('Feature: UpdateRule', () => {
         expect(data.message).toBe('Rule updated successfully');
     });
 
+    it('should return 200 with status success when updating lifetime to 3600 (soft delete)', async () => {
+        fetchMock.doMock();
+        const updateRuleEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/rules/${RULE_ID}`,
+            method: 'PUT',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: '',
+            },
+            requestValidator: async (req: Request) => {
+                const body = await req.json();
+                return body.options && body.options.lifetime === 3600;
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [updateRuleEndpoint]);
+
+        const { res } = await createHttpMocks('/api/feature/update-rule', 'PUT', {});
+
+        const controller = appContainer.get<BaseController<UpdateRuleControllerParameters, UpdateRuleRequest>>(CONTROLLERS.UPDATE_RULE);
+        const controllerParams: UpdateRuleControllerParameters = {
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            response: res as unknown as NextApiResponse,
+            ruleId: RULE_ID,
+            options: { lifetime: 3600 },
+        };
+        await controller.execute(controllerParams);
+
+        expect(res._getStatusCode()).toBe(200);
+        const data: UpdateRuleViewModel = JSON.parse(res._getData());
+        expect(data.status).toBe('success');
+        expect(data.message).toBe('Rule updated successfully');
+    });
+
+    it('should return 200 with status success when updating lifetime to 0 (force delete, admin only)', async () => {
+        fetchMock.doMock();
+        const updateRuleEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/rules/${RULE_ID}`,
+            method: 'PUT',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: '',
+            },
+            requestValidator: async (req: Request) => {
+                const body = await req.json();
+                // lifetime=0 is falsy in JS; use strict equality to confirm zero is passed through
+                return body.options && body.options.lifetime === 0;
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [updateRuleEndpoint]);
+
+        const { res } = await createHttpMocks('/api/feature/update-rule', 'PUT', {});
+
+        const controller = appContainer.get<BaseController<UpdateRuleControllerParameters, UpdateRuleRequest>>(CONTROLLERS.UPDATE_RULE);
+        const controllerParams: UpdateRuleControllerParameters = {
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            response: res as unknown as NextApiResponse,
+            ruleId: RULE_ID,
+            options: { lifetime: 0 },
+        };
+        await controller.execute(controllerParams);
+
+        expect(res._getStatusCode()).toBe(200);
+        const data: UpdateRuleViewModel = JSON.parse(res._getData());
+        expect(data.status).toBe('success');
+        expect(data.message).toBe('Rule updated successfully');
+    });
+
     it('should return errorType unauthorized on 401 from gateway', async () => {
         fetchMock.doMock();
         const updateRuleEndpoint: MockEndpoint = {

--- a/test/gateway/rule/rule-gateway-delete-rule.test.ts
+++ b/test/gateway/rule/rule-gateway-delete-rule.test.ts
@@ -4,6 +4,17 @@ import appContainer from '@/lib/infrastructure/ioc/container-config';
 import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
 import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
 
+/**
+ * Tests for the RuleGateway DELETE endpoint (hard delete via Rucio DELETE /rules/{id}).
+ *
+ * Note on soft-delete vs force-delete vs hard-delete:
+ *   - Soft-delete  (UI "Delete" action):       calls updateRule({ lifetime: 3600 }) → PUT /rules/{id}
+ *   - Force-delete (UI "Force Delete" checkbox): calls updateRule({ lifetime: 0 })   → PUT /rules/{id}
+ *   - Hard-delete  (this gateway method):       calls deleteRule()                   → DELETE /rules/{id}
+ *
+ * Coverage for soft-delete (lifetime=3600) and force-delete (lifetime=0) payloads lives in
+ * rule-gateway-update-rule.test.ts since those flows go through the updateRule gateway method.
+ */
 describe('RuleGateway Delete Rule Endpoint Tests', () => {
     afterEach(() => {
         fetchMock.dontMock();
@@ -11,6 +22,11 @@ describe('RuleGateway Delete Rule Endpoint Tests', () => {
 
     it('should successfully delete a rule', async () => {
         fetchMock.doMock();
+        // Use a spy to capture the raw request body so we can assert explicitly that the
+        // hard-delete endpoint receives NO `lifetime` field.  Without this, a validation
+        // failure inside requestValidator would only surface as a status mismatch, making
+        // the failure message unhelpful.
+        const captureBody = jest.fn<void, [Record<string, unknown>]>();
         const deleteRuleMockEndpoint: MockEndpoint = {
             url: `${MockRucioServerFactory.RUCIO_HOST}/rules/657c2650725d432fab3f1dc14128e9fb`,
             method: 'DELETE',
@@ -23,8 +39,11 @@ describe('RuleGateway Delete Rule Endpoint Tests', () => {
                 body: '',
             },
             requestValidator: async (req: Request) => {
+                // The DELETE endpoint sends an empty JSON body ({}) — no lifetime parameter.
+                // Lifetime-based deletion is handled by the update-rule (PUT) pathway.
                 const body = await req.json();
-                return body !== undefined && typeof body === 'object';
+                captureBody(body);
+                return body !== undefined && typeof body === 'object' && !('lifetime' in body);
             },
         };
         MockRucioServerFactory.createMockRucioServer(true, [deleteRuleMockEndpoint]);
@@ -35,6 +54,11 @@ describe('RuleGateway Delete Rule Endpoint Tests', () => {
             '657c2650725d432fab3f1dc14128e9fb',
         );
         expect(dto.status).toEqual('success');
+        // Explicitly assert the gateway sent a body without a lifetime field.
+        // This produces a clear failure message if the implementation accidentally includes it.
+        expect(captureBody).toHaveBeenCalledTimes(1);
+        const sentBody = captureBody.mock.calls[0][0];
+        expect(sentBody).not.toHaveProperty('lifetime');
     });
 
     it('should handle error when rule does not exist', async () => {

--- a/test/gateway/rule/rule-gateway-update-rule.test.ts
+++ b/test/gateway/rule/rule-gateway-update-rule.test.ts
@@ -125,6 +125,65 @@ describe('RuleGateway Update Rule Endpoint Tests', () => {
         expect(dto.status).toEqual('success');
     });
 
+    it('should send lifetime=3600 for soft-delete (1-hour scheduled deletion)', async () => {
+        fetchMock.doMock();
+        const updateRuleMockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/rules/657c2650725d432fab3f1dc14128e9fb`,
+            method: 'PUT',
+            includes: '/rules/657c2650725d432fab3f1dc14128e9fb',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'text/html; charset=utf-8',
+                },
+                body: '',
+            },
+            requestValidator: async (req: Request) => {
+                const body = await req.json();
+                return body.options && body.options.lifetime === 3600;
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [updateRuleMockEndpoint]);
+
+        const ruleGateway: RuleGatewayOutputPort = appContainer.get<RuleGatewayOutputPort>(GATEWAYS.RULE);
+        const dto: UpdateRuleDTO = await ruleGateway.updateRule(
+            MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            '657c2650725d432fab3f1dc14128e9fb',
+            { lifetime: 3600 },
+        );
+        expect(dto.status).toEqual('success');
+    });
+
+    it('should send lifetime=0 for force-delete (immediate deletion, admin only)', async () => {
+        fetchMock.doMock();
+        const updateRuleMockEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/rules/657c2650725d432fab3f1dc14128e9fb`,
+            method: 'PUT',
+            includes: '/rules/657c2650725d432fab3f1dc14128e9fb',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'text/html; charset=utf-8',
+                },
+                body: '',
+            },
+            requestValidator: async (req: Request) => {
+                const body = await req.json();
+                // lifetime=0 is falsy in JS, so must check with strict equality not truthiness
+                return body.options && body.options.lifetime === 0;
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [updateRuleMockEndpoint]);
+
+        const ruleGateway: RuleGatewayOutputPort = appContainer.get<RuleGatewayOutputPort>(GATEWAYS.RULE);
+        const dto: UpdateRuleDTO = await ruleGateway.updateRule(
+            MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            '657c2650725d432fab3f1dc14128e9fb',
+            { lifetime: 0 },
+        );
+        expect(dto.status).toEqual('success');
+    });
+
     it('should handle error response when updating a rule', async () => {
         fetchMock.doMock();
         const updateRuleMockEndpoint: MockEndpoint = {


### PR DESCRIPTION
## Summary

Closes #767

- Standardises soft-delete to always set `lifetime: 3600` (1 h) for all users, consistent with the Rucio CLI.
- Adds a **Force Delete** checkbox to `DeleteRuleDialog` (admin-only, visible when `isAdmin` is `true`) that sets `lifetime: 0` for immediate deletion, with a destructive-action warning banner.
- Extends `UpdateLifetimeDialog` with an `isAdmin` prop: admins bypass the 3600 s minimum and see contextual warning banners for zero or indefinite lifetimes.

## Changes

- **`DeleteRuleDialog`**: new `isAdmin` prop; force-delete checkbox and destructive warning banner; Storybook stories for default, admin, and force-delete states.
- **`UpdateLifetimeDialog`**: new `isAdmin` prop relaxing the 3600 s floor; zero-lifetime and indefinite-lifetime warning banners; updated stories.
- **`DetailsRule`**: `deleteRuleMutation` updated to pass `lifetime: 3600` (soft) or `lifetime: 0` (force); `isAdmin` threaded through to both dialogs.
- **`checkbox.tsx`**: accessibility improvement — `aria-hidden="true"` added to `CheckboxPrimitive.Indicator`.
- **Tests**: gateway and API tests extended to cover soft-delete (`lifetime: 3600`), force-delete (`lifetime: 0`), and admin vs non-admin lifetime validation.