### PR TITLE
gateway(replicas): add endpoints for suspicious replicas page

### DIFF
--- a/src/lib/core/dto/replica-dto.ts
+++ b/src/lib/core/dto/replica-dto.ts
@@ -20,3 +20,33 @@ export interface FileReplicaStateDTO extends BaseDTO, FileReplicaState {}
  * that works for all communities.
  */
 export interface DatasetReplicasDTO extends BaseDTO, Omit<DIDDatasetReplicas, 'rseblocked'> {}
+
+/**
+ * Represents a single suspicious replica returned by the list suspicious replicas endpoint.
+ */
+export interface SuspiciousReplicaDTO extends BaseDTO {
+    scope: string;
+    name: string;
+    rse: string;
+    rseId: string;
+    cnt: number;
+    createdAt: string;
+}
+
+/**
+ * Data Transfer Object for the list suspicious replicas endpoint.
+ * The Rucio server returns a single JSON array, so this DTO is non-streaming
+ * and exposes the full list of {@link SuspiciousReplicaDTO} items via `replicas`.
+ */
+export interface ListSuspiciousReplicasDTO extends BaseDTO {
+    replicas: SuspiciousReplicaDTO[];
+}
+
+/**
+ * Data Transfer Object for the DeclareBadPFNs endpoint.
+ * The Rucio server returns a plain-text `Created` body on success, so the DTO
+ * only carries a `created` flag plus the standard error metadata from BaseDTO.
+ */
+export interface DeclareBadPFNsDTO extends BaseDTO {
+    created: boolean;
+}

--- a/src/lib/core/port/secondary/replica-gateway-output-port.ts
+++ b/src/lib/core/port/secondary/replica-gateway-output-port.ts
@@ -1,5 +1,6 @@
 import { ListReplicasDTO } from '@/lib/core/dto/replica-dto';
 import { DatasetReplicasDTO } from '@/lib/core/dto/replica-dto';
+import { DeclareBadPFNsDTO, ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
 
 /**
  * Output port for the Replica Gateway, responsible for defining the methods that the Gateway will use to interact with the Rucio Server.
@@ -22,4 +23,30 @@ export default interface ReplicaGatewayOutputPort {
      * @returns A Promise that resolves to a ListReplicasDTO object.
      */
     listDatasetReplicas(rucioAuthToken: string, scope: string, name: string): Promise<ListReplicasDTO>;
+
+    /**
+     * Lists suspicious replicas. Each stream element is of type {@link SuspiciousReplicaDTO}.
+     * @param rucioAuthToken - The Rucio auth token to use for authentication.
+     * @param rseExpression - Optional RSE expression to filter the suspicious replicas.
+     * @param youngerThan - Optional date string; only replicas created after this date are returned.
+     * @param nattempts - Optional minimum number of access attempts to filter by.
+     * @returns A Promise that resolves to a ListSuspiciousReplicasDTO object.
+     */
+    listSuspiciousReplicas(
+        rucioAuthToken: string,
+        rseExpression?: string,
+        youngerThan?: string,
+        nattempts?: number,
+    ): Promise<ListSuspiciousReplicasDTO>;
+
+    /**
+     * Declares bad PFNs (physical file names) on the Rucio Server.
+     * @param rucioAuthToken - The Rucio auth token to use for authentication.
+     * @param pfns - The list of PFNs to declare.
+     * @param reason - The reason for declaring the PFNs as bad.
+     * @param state - The state to set for the declared PFNs (e.g. BAD, SUSPICIOUS, TEMPORARY_UNAVAILABLE).
+     * @param expiresAt - Optional expiry date string for the declaration.
+     * @returns A Promise that resolves to a DeclareBadPFNsDTO object.
+     */
+    declareBadPFNs(rucioAuthToken: string, pfns: string[], reason: string, state: string, expiresAt?: string | null): Promise<DeclareBadPFNsDTO>;
 }

--- a/src/lib/infrastructure/gateway/replica-gateway/endpoints/declare-bad-pfns-endpoint.ts
+++ b/src/lib/infrastructure/gateway/replica-gateway/endpoints/declare-bad-pfns-endpoint.ts
@@ -1,0 +1,70 @@
+import { DeclareBadPFNsDTO } from '@/lib/core/dto/replica-dto';
+import { BaseEndpoint, extractErrorMessage } from '@/lib/sdk/gateway-endpoints';
+import { HTTPRequest } from '@/lib/sdk/http';
+
+/**
+ * Endpoint for `POST /replicas/bad/pfns/`.
+ * The Rucio server responds with a `201 Created` and a plain-text body (`Created`),
+ * so the endpoint parses the response body as text.
+ */
+export default class DeclareBadPFNsEndpoint extends BaseEndpoint<DeclareBadPFNsDTO> {
+    constructor(
+        private readonly rucioAuthToken: string,
+        private readonly pfns: string[],
+        private readonly reason: string,
+        private readonly state: string,
+        private readonly expiresAt?: string | null,
+    ) {
+        // parse body as text
+        super(true);
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        const rucioHost = await this.envConfigGateway.rucioHost();
+        const endpoint = `${rucioHost}/replicas/bad/pfns/`;
+
+        const body: { [key: string]: any } = {
+            pfns: this.pfns,
+            reason: this.reason,
+            state: this.state,
+        };
+        if (this.expiresAt !== undefined) {
+            body.expires_at = this.expiresAt;
+        }
+
+        const request: HTTPRequest = {
+            method: 'POST',
+            url: endpoint,
+            headers: {
+                'X-Rucio-Auth-Token': this.rucioAuthToken,
+                'Content-Type': 'application/json',
+            },
+            body: body,
+        };
+        this.request = request;
+        this.initialized = true;
+    }
+
+    async reportErrors(statusCode: number, response: Response): Promise<DeclareBadPFNsDTO | undefined> {
+        const error = await extractErrorMessage(response);
+        const errorDTO: DeclareBadPFNsDTO = {
+            status: 'error',
+            created: false,
+            errorCode: statusCode,
+            errorName: 'Unknown Error',
+            errorType: 'gateway_endpoint_error',
+            errorMessage: `${error ?? 'No error details available from rucio'}`,
+        };
+        return Promise.resolve(errorDTO);
+    }
+
+    createDTO(data: object | string): DeclareBadPFNsDTO {
+        const dataStr = typeof data === 'string' ? data : JSON.stringify(data);
+        const dto: DeclareBadPFNsDTO = {
+            status: 'success',
+            created: dataStr.toLowerCase().includes('created'),
+        };
+        return dto;
+    }
+}

--- a/src/lib/infrastructure/gateway/replica-gateway/endpoints/list-suspicious-replicas-endpoint.ts
+++ b/src/lib/infrastructure/gateway/replica-gateway/endpoints/list-suspicious-replicas-endpoint.ts
@@ -1,0 +1,79 @@
+import { ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
+import { BaseEndpoint, extractErrorMessage } from '@/lib/sdk/gateway-endpoints';
+import { HTTPRequest } from '@/lib/sdk/http';
+import { convertToSuspiciousReplicaDTO, TRucioSuspiciousReplica } from '../replica-gateway-utils';
+
+/**
+ * Endpoint for `GET /replicas/suspicious/`.
+ *
+ * Unlike the sibling replica endpoints (e.g. list-file-replicas, list-dataset-replicas),
+ * which stream NDJSON (`application/x-json-stream`), the Rucio server returns the
+ * suspicious replicas as a single JSON array with Content-Type `application/json`.
+ *
+ * For that reason this is modelled as a non-streaming `BaseEndpoint` rather than a
+ * `BaseStreamableEndpoint`: the non-NDJSON streaming transform (`super(false)`) is
+ * unused across the codebase and mishandles multi-element arrays that arrive in a
+ * single chunk. `createDTO` therefore receives the full parsed array and maps it to
+ * a list of suspicious replica items (`ListSuspiciousReplicasDTO.replicas`).
+ */
+export default class ListSuspiciousReplicasEndpoint extends BaseEndpoint<ListSuspiciousReplicasDTO> {
+    constructor(
+        private readonly rucioAuthToken: string,
+        private readonly rseExpression?: string,
+        private readonly youngerThan?: string,
+        private readonly nattempts?: number,
+    ) {
+        super();
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        this.url = `${this.rucioHost}/replicas/suspicious/`;
+
+        const params: { [key: string]: string } = {};
+        if (this.rseExpression !== undefined) {
+            params.rse_expression = this.rseExpression;
+        }
+        if (this.youngerThan !== undefined) {
+            params.younger_than = this.youngerThan;
+        }
+        if (this.nattempts !== undefined) {
+            params.nattempts = this.nattempts.toString();
+        }
+
+        const request: HTTPRequest = {
+            method: 'GET',
+            url: this.url,
+            headers: {
+                'X-Rucio-Auth-Token': this.rucioAuthToken,
+                'Content-Type': 'application/json',
+            },
+            body: null,
+            params: Object.keys(params).length > 0 ? params : undefined,
+        };
+        this.request = request;
+        this.initialized = true;
+    }
+
+    async reportErrors(statusCode: number, response: Response): Promise<ListSuspiciousReplicasDTO | undefined> {
+        const errorDetails = await extractErrorMessage(response);
+        const dto: ListSuspiciousReplicasDTO = {
+            status: 'error',
+            replicas: [],
+            errorCode: statusCode,
+            errorName: 'Unknown Error',
+            errorType: 'gateway_endpoint_error',
+            errorMessage: `${errorDetails ?? 'No error details available from rucio'}`,
+        };
+        return Promise.resolve(dto);
+    }
+
+    createDTO(data: object | string): ListSuspiciousReplicasDTO {
+        const items: TRucioSuspiciousReplica[] = Array.isArray(data) ? (data as TRucioSuspiciousReplica[]) : [];
+        const dto: ListSuspiciousReplicasDTO = {
+            status: 'success',
+            replicas: items.map(item => convertToSuspiciousReplicaDTO(item)),
+        };
+        return dto;
+    }
+}

--- a/src/lib/infrastructure/gateway/replica-gateway/replica-gateway-utils.ts
+++ b/src/lib/infrastructure/gateway/replica-gateway/replica-gateway-utils.ts
@@ -1,4 +1,4 @@
-import { DatasetReplicasDTO, FileReplicaStateDTO } from '@/lib/core/dto/replica-dto';
+import { DatasetReplicasDTO, FileReplicaStateDTO, SuspiciousReplicaDTO } from '@/lib/core/dto/replica-dto';
 import { ReplicaState } from '@/lib/core/entity/rucio';
 
 export type TRucioFileReplica = {
@@ -41,6 +41,36 @@ export type TRucioDatasetReplica = {
     updated_at: string;
     accessed_at: string | null;
 };
+
+/**
+ * The type representing a Rucio Suspicious Replica returned by the Rucio REST API.
+ */
+export type TRucioSuspiciousReplica = {
+    scope: string;
+    name: string;
+    rse: string;
+    rse_id: string;
+    cnt: number;
+    created_at: string;
+};
+
+/**
+ * Convert a raw Rucio suspicious replica response into a SuspiciousReplicaDTO.
+ * @param data A single suspicious replica entry from the Rucio Server response.
+ * @returns A SuspiciousReplicaDTO object.
+ */
+export function convertToSuspiciousReplicaDTO(data: TRucioSuspiciousReplica): SuspiciousReplicaDTO {
+    const dto: SuspiciousReplicaDTO = {
+        status: 'success',
+        scope: data.scope,
+        name: data.name,
+        rse: data.rse,
+        rseId: data.rse_id,
+        cnt: data.cnt,
+        createdAt: data.created_at,
+    };
+    return dto;
+}
 
 function getReplicaState(state: string): ReplicaState {
     switch (state.toUpperCase()) {

--- a/src/lib/infrastructure/gateway/replica-gateway/replica-gateway.ts
+++ b/src/lib/infrastructure/gateway/replica-gateway/replica-gateway.ts
@@ -1,8 +1,10 @@
-import { ListReplicasDTO } from '@/lib/core/dto/replica-dto';
+import { DeclareBadPFNsDTO, ListReplicasDTO, ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
 import ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
 import { injectable } from 'inversify';
 import ListDatasetReplicasEndpoint from './endpoints/list-dataset-replicas-endpoint';
 import ListFileReplicasEndpoint from './endpoints/list-file-replicas-endpoint';
+import ListSuspiciousReplicasEndpoint from './endpoints/list-suspicious-replicas-endpoint';
+import DeclareBadPFNsEndpoint from './endpoints/declare-bad-pfns-endpoint';
 
 @injectable()
 export default class ReplicaGateway implements ReplicaGatewayOutputPort {
@@ -43,6 +45,51 @@ export default class ReplicaGateway implements ReplicaGatewayOutputPort {
             const errorDTO: ListReplicasDTO = {
                 status: 'error',
                 errorName: 'Exception occurred while fetching dataset replicas',
+                errorType: 'gateway_endpoint_error',
+                errorMessage: error?.toString(),
+            };
+            return Promise.resolve(errorDTO);
+        }
+    }
+
+    async listSuspiciousReplicas(
+        rucioAuthToken: string,
+        rseExpression?: string,
+        youngerThan?: string,
+        nattempts?: number,
+    ): Promise<ListSuspiciousReplicasDTO> {
+        try {
+            const endpoint = new ListSuspiciousReplicasEndpoint(rucioAuthToken, rseExpression, youngerThan, nattempts);
+            const dto: ListSuspiciousReplicasDTO = await endpoint.fetch();
+            return dto;
+        } catch (error) {
+            const errorDTO: ListSuspiciousReplicasDTO = {
+                status: 'error',
+                replicas: [],
+                errorName: 'Exception occurred while fetching suspicious replicas',
+                errorType: 'gateway_endpoint_error',
+                errorMessage: error?.toString(),
+            };
+            return Promise.resolve(errorDTO);
+        }
+    }
+
+    async declareBadPFNs(
+        rucioAuthToken: string,
+        pfns: string[],
+        reason: string,
+        state: string,
+        expiresAt?: string | null,
+    ): Promise<DeclareBadPFNsDTO> {
+        try {
+            const endpoint = new DeclareBadPFNsEndpoint(rucioAuthToken, pfns, reason, state, expiresAt);
+            const dto: DeclareBadPFNsDTO = await endpoint.fetch();
+            return dto;
+        } catch (error) {
+            const errorDTO: DeclareBadPFNsDTO = {
+                status: 'error',
+                created: false,
+                errorName: 'Exception occurred while declaring bad PFNs',
                 errorType: 'gateway_endpoint_error',
                 errorMessage: error?.toString(),
             };

--- a/test/gateway/replica/replica-gateway-declare-bad-pfns.test.ts
+++ b/test/gateway/replica/replica-gateway-declare-bad-pfns.test.ts
@@ -1,0 +1,52 @@
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+import ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
+import { DeclareBadPFNsDTO } from '@/lib/core/dto/replica-dto';
+
+describe('Replica Gateway: Declare Bad PFNs', () => {
+    beforeEach(() => {
+        fetchMock.doMock();
+        const declareBadPFNsEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/replicas/bad/pfns/`,
+            method: 'POST',
+            includes: 'replicas/bad/pfns',
+            response: {
+                status: 201,
+                headers: {
+                    'Content-Type': 'text/html; charset=utf-8',
+                },
+                body: 'Created',
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [declareBadPFNsEndpoint]);
+    });
+
+    afterEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('should successfully declare bad PFNs', async () => {
+        const rucioReplicaGateway: ReplicaGatewayOutputPort = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+        const dto: DeclareBadPFNsDTO = await rucioReplicaGateway.declareBadPFNs(
+            MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            ['root://xrd1:1094//rucio/test/80/25/file1'],
+            'corrupted file',
+            'BAD',
+        );
+        expect(dto.status).toBe('success');
+        expect(dto.created).toBe(true);
+    });
+
+    it('should fail with an auth error', async () => {
+        const rucioReplicaGateway: ReplicaGatewayOutputPort = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+        const dto: DeclareBadPFNsDTO = await rucioReplicaGateway.declareBadPFNs(
+            'invalid-token',
+            ['root://xrd1:1094//rucio/test/80/25/file1'],
+            'corrupted file',
+            'BAD',
+        );
+        expect(dto.status).toBe('error');
+        expect(dto.errorCode).toBe(401);
+    });
+});

--- a/test/gateway/replica/replica-gateway-list-suspicious-replicas.test.ts
+++ b/test/gateway/replica/replica-gateway-list-suspicious-replicas.test.ts
@@ -1,0 +1,70 @@
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+import ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
+import { ListSuspiciousReplicasDTO, SuspiciousReplicaDTO } from '@/lib/core/dto/replica-dto';
+
+describe('Replica Gateway: List Suspicious Replicas', () => {
+    beforeEach(() => {
+        fetchMock.doMock();
+        const listSuspiciousReplicasEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/replicas/suspicious/`,
+            method: 'GET',
+            includes: 'replicas/suspicious',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify([
+                    {
+                        scope: 'test',
+                        name: 'suspicious_test_file_1.dat',
+                        rse: 'MOCK_SUSPICIOUS',
+                        rse_id: '6762d2e939bd41a89a012f40d038843e',
+                        cnt: 3,
+                        created_at: 'Wed, 18 Mar 2026 09:08:23 UTC',
+                    },
+                    {
+                        scope: 'test',
+                        name: 'suspicious_test_file_2.dat',
+                        rse: 'MOCK_SUSPICIOUS',
+                        rse_id: '6762d2e939bd41a89a012f40d038843e',
+                        cnt: 5,
+                        created_at: 'Wed, 18 Mar 2026 10:08:23 UTC',
+                    },
+                ]),
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [listSuspiciousReplicasEndpoint]);
+    });
+
+    afterEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('should successfully fetch a list of suspicious replicas', async () => {
+        const rucioReplicaGateway: ReplicaGatewayOutputPort = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+        const dto: ListSuspiciousReplicasDTO = await rucioReplicaGateway.listSuspiciousReplicas(MockRucioServerFactory.VALID_RUCIO_TOKEN);
+        expect(dto.status).toBe('success');
+        expect(dto.replicas.length).toBe(2);
+        expect(dto.replicas[0]).toEqual({
+            status: 'success',
+            scope: 'test',
+            name: 'suspicious_test_file_1.dat',
+            rse: 'MOCK_SUSPICIOUS',
+            rseId: '6762d2e939bd41a89a012f40d038843e',
+            cnt: 3,
+            createdAt: 'Wed, 18 Mar 2026 09:08:23 UTC',
+        } as SuspiciousReplicaDTO);
+        expect(dto.replicas[1].name).toBe('suspicious_test_file_2.dat');
+        expect(dto.replicas[1].cnt).toBe(5);
+    });
+
+    it('should fail with an auth error', async () => {
+        const rucioReplicaGateway: ReplicaGatewayOutputPort = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+        const dto: ListSuspiciousReplicasDTO = await rucioReplicaGateway.listSuspiciousReplicas('invalid-token');
+        expect(dto.status).toBe('error');
+        expect(dto.errorCode).toBe(401);
+    });
+});


### PR DESCRIPTION
Closes #777

- Add `listSuspiciousReplicas` gateway endpoint (`GET /replicas/suspicious/`)
- Add `declareBadPFNs` gateway endpoint (`POST /replicas/bad/pfns/`)
- Generated from the WebUI scan of the suspicious_replicas page

Adds two new replica gateway endpoints needed by the suspicious_replicas page:

- **listSuspiciousReplicas** — modelled as a non-streaming `BaseEndpoint`. Unlike the sibling replica endpoints, `/replicas/suspicious/` returns a single JSON array (`application/json`), not NDJSON, so `createDTO` maps the full array to `ListSuspiciousReplicasDTO.replicas`.
- **declareBadPFNs** — a non-streaming mutation; the server responds `201` with a plain-text body. `DeclareBadPFNsDTO` carries a `created` boolean.

New DTOs (`SuspiciousReplicaDTO`, `ListSuspiciousReplicasDTO`, `DeclareBadPFNsDTO`), a `convertToSuspiciousReplicaDTO` mapper, output-port signatures, and gateway tests. IoC config untouched — the replica gateway was already registered.