### PR TITLE
feat(replicas): suspicious replicas page with bulk declare-bad (#710)

### DIFF
--- a/src/app/(rucio)/suspicious-replicas/page.tsx
+++ b/src/app/(rucio)/suspicious-replicas/page.tsx
@@ -1,0 +1,23 @@
+import { ListSuspiciousReplicas } from '@/component-library/pages/Replica/suspicious/ListSuspiciousReplicas';
+
+export default async function Page() {
+    return (
+        <main className="min-h-screen bg-neutral-0 dark:bg-neutral-900 transition-colors duration-200">
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 lg:py-10">
+                <header className="mb-8">
+                    <h1 className="text-3xl sm:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-2">Suspicious Replicas</h1>
+                    <p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400">
+                        Monitor files with suspicious replica states across storage elements
+                    </p>
+                </header>
+                <section aria-label="Suspicious Replicas Filter and Results">
+                    <ListSuspiciousReplicas />
+                </section>
+            </div>
+        </main>
+    );
+}
+
+export const metadata = {
+    title: 'Suspicious Replicas - Rucio',
+};

--- a/src/app/api/feature/declare-bad-replicas/route.ts
+++ b/src/app/api/feature/declare-bad-replicas/route.ts
@@ -1,0 +1,55 @@
+import 'reflect-metadata';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import { BaseController } from '@/lib/sdk/controller';
+import { DeclareBadReplicasControllerParameters } from '@/lib/infrastructure/controller/declare-bad-replicas-controller';
+import { DeclareBadReplicasRequest } from '@/lib/core/usecase-models/declare-bad-replicas-usecase-models';
+import { executeAuthenticatedController, parseRequestBody } from '@/lib/infrastructure/adapters/app-router-controller-adapter';
+
+const DeclareBadReplicasSchema = z.object({
+    dids: z
+        .array(
+            z.object({
+                scope: z.string().min(1),
+                name: z.string().min(1),
+            }),
+        )
+        .min(1),
+    rse: z.string().min(1),
+    reason: z.string().min(1),
+    expiresAt: z.string().nullable().optional(),
+});
+
+/**
+ * POST /api/feature/declare-bad-replicas
+ * Body: { dids: [{scope, name}], rse, reason, expiresAt? }
+ * Marks the supplied replicas as BAD on the specified RSE via Rucio's
+ * `POST /replicas/bad/dids` endpoint.
+ */
+export async function POST(request: NextRequest) {
+    try {
+        const body = await parseRequestBody(request);
+        if (!body) {
+            return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+        }
+
+        const params = DeclareBadReplicasSchema.safeParse(body);
+        if (!params.success) {
+            return NextResponse.json(
+                { error: 'Missing required parameters or provided parameters are invalid', details: params.error.errors },
+                { status: 400 },
+            );
+        }
+
+        const controller = appContainer.get<BaseController<DeclareBadReplicasControllerParameters, DeclareBadReplicasRequest>>(
+            CONTROLLERS.DECLARE_BAD_REPLICAS,
+        );
+
+        return executeAuthenticatedController(controller, params.data);
+    } catch (error) {
+        console.error('Error in declare-bad-replicas:', error);
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+}

--- a/src/app/api/feature/list-suspicious-replicas/route.ts
+++ b/src/app/api/feature/list-suspicious-replicas/route.ts
@@ -1,0 +1,40 @@
+import 'reflect-metadata';
+import { NextRequest, NextResponse } from 'next/server';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import { BaseController } from '@/lib/sdk/controller';
+import { ListSuspiciousReplicasControllerParameters } from '@/lib/infrastructure/controller/list-suspicious-replicas-controller';
+import { executeAuthenticatedController, parseQueryParams } from '@/lib/infrastructure/adapters/app-router-controller-adapter';
+
+/**
+ * GET /api/feature/list-suspicious-replicas
+ * Query params (all optional): rse_expression, younger_than, nattempts
+ * Returns a streamed NDJSON response of SuspiciousReplicaViewModel items.
+ */
+export async function GET(request: NextRequest) {
+    try {
+        const params = parseQueryParams(request);
+
+        const rseExpression = params.rse_expression as string | undefined;
+        const youngerThan = params.younger_than as string | undefined;
+        const nattemptsRaw = params.nattempts as string | undefined;
+        const nattempts = nattemptsRaw !== undefined ? parseInt(nattemptsRaw, 10) : undefined;
+
+        const controller = appContainer.get<BaseController<ListSuspiciousReplicasControllerParameters, void>>(
+            CONTROLLERS.LIST_SUSPICIOUS_REPLICAS,
+        );
+
+        return executeAuthenticatedController(
+            controller,
+            {
+                rseExpression,
+                youngerThan,
+                nattempts: !isNaN(nattempts as number) ? nattempts : undefined,
+            },
+            true,
+        );
+    } catch (error) {
+        console.error('Error in list-suspicious-replicas:', error);
+        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    }
+}

--- a/src/component-library/features/layout/HeaderClient.tsx
+++ b/src/component-library/features/layout/HeaderClient.tsx
@@ -31,7 +31,7 @@ type TFullMenuItem = TMenuItem & {
 
 const MenuItem = ({ item, pathname, onClick }: { item: TMenuItem; pathname: string | null; onClick?: () => void }) => {
     const isActive = item.path === pathname;
-    const classes = `hover:text-brand-500 transition-colors duration-150 ${isActive && 'text-brand-500 font-semibold'}`;
+    const classes = `hover:text-brand-500 transition-colors duration-150 whitespace-nowrap ${isActive && 'text-brand-500 font-semibold'}`;
     return (
         <Link href={item.path ?? '/'} className={cn(classes, 'relative')} onClick={onClick}>
             {item.title}
@@ -125,7 +125,7 @@ const MobileNavigationBar = ({ menuItems }: { menuItems: TFullMenuItem[] }) => {
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
     return (
-        <div className="flex md:hidden">
+        <div className="flex lg:hidden">
             <button
                 className="rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 px-2 items-center"
                 onClick={() => setIsMenuOpen(prevState => !prevState)}
@@ -295,9 +295,17 @@ export const HeaderClient = ({ siteHeader, siteHeaderError, isSiteHeaderFetching
         ...(canViewApprovalQueue ? [{ title: 'Approve Rules', path: '/rules/approve?autoSearch=true' }] : []),
     ];
 
+    const didsChildren: TMenuItem[] = [
+        { title: 'List DIDs', path: '/dids' },
+        { title: 'Suspicious Replicas', path: '/suspicious-replicas' },
+    ];
+
     const menuItems: TFullMenuItem[] = [
         { title: 'Dashboard', path: '/dashboard' },
-        { title: 'DIDs', path: '/dids' },
+        {
+            title: 'DIDs',
+            children: didsChildren,
+        },
         { title: 'RSEs', path: '/rses' },
         { title: 'Subscriptions', path: subscriptionUrl },
         {
@@ -330,14 +338,7 @@ export const HeaderClient = ({ siteHeader, siteHeaderError, isSiteHeaderFetching
                 <>
                     <div className="flex items-center">
                         <Link className="w-12 h-full stroke-white fill-white" href="/dashboard">
-                            <Image
-                                src={logoPath}
-                                alt="Rucio Logo"
-                                width={logoSize}
-                                height={logoSize}
-                                className="h-auto"
-                                suppressHydrationWarning
-                            />
+                            <Image src={logoPath} alt="Rucio Logo" width={logoSize} height={logoSize} className="h-auto" suppressHydrationWarning />
                         </Link>
                         <a className="w-12 h-full" href={siteHeader.projectUrl}>
                             <Image src="/experiment-logo.png" alt="Experiment Logo" width={logoSize} height={logoSize} className="h-auto" />

--- a/src/component-library/features/mutations/DeclareBadReplicaDialog.tsx
+++ b/src/component-library/features/mutations/DeclareBadReplicaDialog.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import * as React from 'react';
+import { MutationDialog } from '@/component-library/features/mutations/MutationDialog';
+import { Input } from '@/component-library/atoms/form/input';
+import { DateInput } from '@/component-library/atoms/legacy/input/DateInput/DateInput';
+import { HiExclamationCircle } from 'react-icons/hi';
+
+export interface DeclareBadReplicaTarget {
+    scope: string;
+    name: string;
+    rse: string;
+}
+
+export interface DeclareBadReplicaDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /**
+     * Replicas to be declared bad. Empty array means no selection (dialog closed
+     * caller-side). Length 1 renders the single-row layout; length > 1 renders
+     * the bulk summary grouped by RSE.
+     */
+    targets: DeclareBadReplicaTarget[];
+    onConfirm: (reason: string, expiresAt: string | null) => void;
+    loading?: boolean;
+}
+
+/**
+ * Confirmation dialog for declaring one or more suspicious replicas as bad.
+ * Reason is required; expires_at is optional (null = no expiry).
+ *
+ * For bulk selections spanning multiple RSEs the caller is expected to send
+ * one POST per RSE group (Rucio's `/replicas/bad/dids` takes a single RSE
+ * per call); the dialog itself just collects the shared reason + expiry.
+ */
+export const DeclareBadReplicaDialog: React.FC<DeclareBadReplicaDialogProps> = ({
+    open,
+    onOpenChange,
+    targets,
+    onConfirm,
+    loading = false,
+}) => {
+    const [reason, setReason] = React.useState('');
+    const [expiresAt, setExpiresAt] = React.useState<Date | null>(null);
+
+    // Reset form whenever the dialog opens for a new selection. Keyed on the
+    // sorted target list so re-opening the same selection doesn't clobber input.
+    const selectionKey = React.useMemo(
+        () =>
+            targets
+                .map(t => `${t.rse}::${t.scope}:${t.name}`)
+                .sort()
+                .join('|'),
+        [targets],
+    );
+    React.useEffect(() => {
+        if (open) {
+            setReason('');
+            setExpiresAt(null);
+        }
+    }, [open, selectionKey]);
+
+    const trimmedReason = reason.trim();
+    const isValid = trimmedReason.length > 0 && targets.length > 0;
+
+    const handleSubmit = () => {
+        if (!isValid) return;
+        // Rucio's parser expects %Y-%m-%dT%H:%M:%S without fractional seconds.
+        const expiresAtStr = expiresAt ? expiresAt.toISOString().replace(/\.\d{3}Z$/, '') : null;
+        onConfirm(trimmedReason, expiresAtStr);
+    };
+
+    const byRse = React.useMemo(() => {
+        const map = new Map<string, DeclareBadReplicaTarget[]>();
+        for (const t of targets) {
+            const arr = map.get(t.rse) ?? [];
+            arr.push(t);
+            map.set(t.rse, arr);
+        }
+        return Array.from(map.entries()).sort((a, b) => b[1].length - a[1].length);
+    }, [targets]);
+
+    const isBulk = targets.length > 1;
+    const single = targets.length === 1 ? targets[0] : null;
+
+    return (
+        <MutationDialog
+            open={open}
+            onOpenChange={onOpenChange}
+            title={isBulk ? 'Declare Replicas Bad' : 'Declare Replica Bad'}
+            description={
+                isBulk
+                    ? `Mark ${targets.length} replicas across ${byRse.length} RSE${byRse.length !== 1 ? 's' : ''} as bad.`
+                    : 'Mark this replica as bad on its RSE. Rucio will schedule re-transfer or removal.'
+            }
+            onSubmit={handleSubmit}
+            submitLabel={isBulk ? `Declare ${targets.length} Bad` : 'Declare Bad'}
+            submitVariant="error"
+            loading={loading}
+            disabled={!isValid}
+        >
+            <div className="space-y-4">
+                <div className="flex items-start gap-3 rounded-md bg-base-error-50 dark:bg-base-error-950 border border-base-error-200 dark:border-base-error-800 p-3">
+                    <HiExclamationCircle
+                        className="h-5 w-5 shrink-0 text-base-error-600 dark:text-base-error-400 mt-0.5"
+                        aria-hidden="true"
+                    />
+                    <p className="text-sm text-base-error-900 dark:text-base-error-100">
+                        {isBulk
+                            ? 'Each replica will be marked bad on its RSE. Rucio will treat them as unavailable and may schedule re-transfer or deletion. This cannot be undone from the UI.'
+                            : 'This marks the replica as bad on its RSE. Rucio will treat it as unavailable and may schedule re-transfer or deletion. This cannot be undone from the UI.'}
+                    </p>
+                </div>
+
+                {single && (
+                    <div className="rounded-md bg-neutral-100 dark:bg-neutral-800 p-3 space-y-2">
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-sm text-neutral-600 dark:text-neutral-400">Scope</span>
+                            <span className="font-mono text-sm font-medium text-neutral-900 dark:text-neutral-100 break-all text-right">
+                                {single.scope}
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-sm text-neutral-600 dark:text-neutral-400">Name</span>
+                            <span className="font-mono text-sm font-medium text-neutral-900 dark:text-neutral-100 break-all text-right max-w-[70%]">
+                                {single.name}
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-3">
+                            <span className="text-sm text-neutral-600 dark:text-neutral-400">RSE</span>
+                            <span className="font-mono text-sm font-medium text-neutral-900 dark:text-neutral-100 break-all text-right">
+                                {single.rse}
+                            </span>
+                        </div>
+                    </div>
+                )}
+
+                {isBulk && (
+                    <div className="rounded-md bg-neutral-100 dark:bg-neutral-800 p-3 space-y-2 max-h-48 overflow-y-auto">
+                        <p className="text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">By RSE</p>
+                        <ul className="space-y-1">
+                            {byRse.map(([rse, replicas]) => (
+                                <li key={rse} className="flex items-center justify-between gap-3">
+                                    <span className="font-mono text-sm text-neutral-900 dark:text-neutral-100 break-all">{rse}</span>
+                                    <span className="text-sm text-neutral-600 dark:text-neutral-400 shrink-0">
+                                        {replicas.length} replica{replicas.length !== 1 ? 's' : ''}
+                                    </span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+
+                <div>
+                    <label
+                        htmlFor="declare-bad-reason"
+                        className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block"
+                    >
+                        Reason <span className="text-base-error-600">*</span>
+                    </label>
+                    <Input
+                        id="declare-bad-reason"
+                        className="w-full"
+                        value={reason}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setReason(e.target.value)}
+                        placeholder="e.g. lost, source unreachable"
+                        aria-required
+                        aria-invalid={!isValid && reason.length > 0}
+                    />
+                </div>
+
+                <div>
+                    <div className="flex items-center justify-between mb-2">
+                        <label
+                            htmlFor="declare-bad-expires-at"
+                            className="text-sm font-medium text-neutral-700 dark:text-neutral-300"
+                        >
+                            Expires at <span className="text-neutral-500">(optional)</span>
+                        </label>
+                        {expiresAt && (
+                            <button
+                                type="button"
+                                onClick={() => setExpiresAt(null)}
+                                className="text-xs font-medium text-brand-600 dark:text-brand-400 hover:underline focus:outline-none focus:ring-2 focus:ring-brand-500 rounded"
+                            >
+                                Clear
+                            </button>
+                        )}
+                    </div>
+                    <DateInput
+                        id="declare-bad-expires-at"
+                        onchange={(date: Date) => setExpiresAt(date)}
+                        initialdate={expiresAt ?? undefined}
+                        placeholder="No expiry"
+                    />
+                </div>
+            </div>
+        </MutationDialog>
+    );
+};

--- a/src/component-library/pages/Dashboard/widgets/HotBarCard.tsx
+++ b/src/component-library/pages/Dashboard/widgets/HotBarCard.tsx
@@ -26,6 +26,8 @@ function getTypeBadgeStyles(type: CardTypeEnum): string {
         case CardTypeEnum.RSE:
         case CardTypeEnum.RSE_LIST:
             return 'bg-base-warning-100 text-base-warning-900 dark:bg-base-warning-900/20 dark:text-base-warning-100';
+        case CardTypeEnum.SUSPICIOUS_REPLICA_LIST:
+            return 'bg-base-error-100 text-base-error-900 dark:bg-base-error-900/20 dark:text-base-error-100';
         default:
             return 'bg-neutral-100 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100';
     }

--- a/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.stories.tsx
+++ b/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.stories.tsx
@@ -1,0 +1,28 @@
+import { StoryFn, Meta } from '@storybook/nextjs';
+import { fixtureSuspiciousReplicaViewModel } from '@/test/fixtures/table-fixtures';
+import { ListSuspiciousReplicas } from '@/component-library/pages/Replica/suspicious/ListSuspiciousReplicas';
+import { ToastedTemplate } from '@/component-library/templates/ToastedTemplate/ToastedTemplate';
+
+export default {
+    title: 'Components/Pages/Replica/ListSuspiciousReplicas',
+    component: ListSuspiciousReplicas,
+    parameters: {
+        docs: { disable: true },
+    },
+} as Meta<typeof ListSuspiciousReplicas>;
+
+const Template: StoryFn<typeof ListSuspiciousReplicas> = args => (
+    <ToastedTemplate>
+        <ListSuspiciousReplicas {...args} />
+    </ToastedTemplate>
+);
+
+/** Empty grid — no initial data and no streaming endpoint. */
+export const Empty = Template.bind({});
+Empty.args = {};
+
+/** Grid pre-populated with static mock data (no network calls). */
+export const WithData = Template.bind({});
+WithData.args = {
+    initialData: Array.from({ length: 30 }, () => fixtureSuspiciousReplicaViewModel()),
+};

--- a/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.tsx
+++ b/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+import React, { ChangeEvent, useCallback, useRef, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { HiOutlineBan, HiInformationCircle } from 'react-icons/hi';
+import { HiChevronDown } from 'react-icons/hi2';
+import { cn } from '@/component-library/utils';
+import { SuspiciousReplicaViewModel, DeclareBadReplicasViewModel } from '@/lib/infrastructure/data/view-model/replica';
+import { StreamingStatus } from '@/lib/infrastructure/hooks/useStreamReader';
+import useTableStreaming from '@/lib/infrastructure/hooks/useTableStreaming';
+import { Button } from '@/component-library/atoms/form/button';
+import { Input } from '@/component-library/atoms/form/input';
+import { DateInput } from '@/component-library/atoms/legacy/input/DateInput/DateInput';
+import { SearchButton } from '@/component-library/features/search/SearchButton';
+import { SuspiciousReplicasTable } from '@/component-library/pages/Replica/suspicious/SuspiciousReplicasTable';
+import { DeclareBadReplicaDialog, DeclareBadReplicaTarget } from '@/component-library/features/mutations/DeclareBadReplicaDialog';
+import { useToast } from '@/lib/infrastructure/hooks/useToast';
+
+type SearchFilters = {
+    rseExpression: string;
+    youngerThan?: Date;
+    nattempts: string;
+};
+
+type ListSuspiciousReplicasProps = {
+    initialData?: SuspiciousReplicaViewModel[];
+};
+
+function FilterField({ children, label, htmlFor }: { children: React.ReactNode; label: string; htmlFor: string }) {
+    return (
+        <div className="grow flex-1">
+            <label htmlFor={htmlFor} className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">
+                {label}
+            </label>
+            {children}
+        </div>
+    );
+}
+
+const getDefaultYoungerThan = (): Date => {
+    const d = new Date();
+    d.setDate(d.getDate() - 6);
+    return d;
+};
+
+const toTarget = (r: SuspiciousReplicaViewModel): DeclareBadReplicaTarget => ({
+    scope: r.scope,
+    name: r.name,
+    rse: r.rse,
+});
+
+export const ListSuspiciousReplicas = (props: ListSuspiciousReplicasProps) => {
+    const [filters, setFilters] = useState<SearchFilters>({
+        rseExpression: '',
+        youngerThan: getDefaultYoungerThan(),
+        nattempts: '10',
+    });
+
+    const { onGridReady, streamingHook, startStreaming, stopStreaming } = useTableStreaming<SuspiciousReplicaViewModel>(props.initialData);
+    const { toast } = useToast();
+
+    // Selection: rows currently checked in the table.
+    const [selectedReplicas, setSelectedReplicas] = useState<DeclareBadReplicaTarget[]>([]);
+    // Dialog state: targets is non-empty when the dialog is open.
+    const [declareBadTargets, setDeclareBadTargets] = useState<DeclareBadReplicaTarget[]>([]);
+    const declareBadOpen = declareBadTargets.length > 0;
+
+    // Stable refs so the polling interval / mutation callbacks always read the latest values.
+    const filtersRef = useRef(filters);
+    filtersRef.current = filters;
+    const startStreamingRef = useRef(startStreaming);
+    startStreamingRef.current = startStreaming;
+
+    const handleFiltersChange = (newFilters: Partial<SearchFilters>) => {
+        setFilters(prev => ({ ...prev, ...newFilters }));
+    };
+
+    const buildSearchUrl = useCallback((searchFilters: SearchFilters): string => {
+        const params = new URLSearchParams();
+        if (searchFilters.rseExpression) {
+            params.append('rse_expression', searchFilters.rseExpression);
+        }
+        if (searchFilters.youngerThan) {
+            // Rucio's parser uses datetime.strptime with `%Y-%m-%dT%H:%M:%S` — toISOString()
+            // adds `.000Z` which Rucio rejects with HTTP 500, so we strip it.
+            params.append('younger_than', searchFilters.youngerThan.toISOString().replace(/\.\d{3}Z$/, ''));
+        }
+        const nattempts = parseInt(searchFilters.nattempts, 10);
+        // Rucio's filter is exclusive (`cnt > nattempts`), so 0 is meaningful
+        // (matches every replica with at least one recorded suspicion).
+        if (!isNaN(nattempts) && nattempts >= 0) {
+            params.append('nattempts', nattempts.toString());
+        }
+        return `/api/feature/list-suspicious-replicas?${params.toString()}`;
+    }, []);
+
+    const onSearch = (event: React.SyntheticEvent) => {
+        event.preventDefault();
+        startStreaming(buildSearchUrl(filters));
+    };
+
+    const onStop = (event: React.SyntheticEvent) => {
+        event.preventDefault();
+        stopStreaming();
+    };
+
+    /**
+     * Bulk-friendly mutation: groups the supplied targets by RSE (Rucio's
+     * `/replicas/bad/dids` takes one RSE per call) and fires one POST per
+     * group. Returns aggregated success/notDeclared counts so the toast
+     * summary stays accurate for both single-row and bulk submissions.
+     */
+    const declareBadMutation = useMutation({
+        mutationFn: async (input: { targets: DeclareBadReplicaTarget[]; reason: string; expiresAt: string | null }) => {
+            const groups = new Map<string, DeclareBadReplicaTarget[]>();
+            for (const t of input.targets) {
+                const arr = groups.get(t.rse) ?? [];
+                arr.push(t);
+                groups.set(t.rse, arr);
+            }
+            const results = await Promise.all(
+                Array.from(groups.entries()).map(async ([rse, replicas]) => {
+                    const res = await fetch('/api/feature/declare-bad-replicas', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            dids: replicas.map(r => ({ scope: r.scope, name: r.name })),
+                            rse,
+                            reason: input.reason,
+                            expiresAt: input.expiresAt,
+                        }),
+                    });
+                    const vm: DeclareBadReplicasViewModel = await res.json();
+                    if (!res.ok || vm.status !== 'success') {
+                        throw vm;
+                    }
+                    return { rse, requested: replicas.length, vm };
+                }),
+            );
+            return results;
+        },
+        onSuccess: results => {
+            setDeclareBadTargets([]);
+            setSelectedReplicas([]);
+            const requested = results.reduce((acc, r) => acc + r.requested, 0);
+            const refused = results.reduce((acc, r) => acc + (r.vm.notDeclared?.length ?? 0), 0);
+            const accepted = requested - refused;
+            const rseCount = results.length;
+
+            if (refused === 0) {
+                toast({
+                    variant: 'success',
+                    title: requested === 1 ? 'Replica declared bad' : `${accepted} replicas declared bad`,
+                    description:
+                        rseCount > 1
+                            ? `Across ${rseCount} RSEs.`
+                            : results[0]
+                              ? `On ${results[0].rse}.`
+                              : undefined,
+                });
+            } else {
+                toast({
+                    variant: 'warning',
+                    title: `${accepted} of ${requested} declared bad`,
+                    description: `${refused} replica${refused !== 1 ? 's were' : ' was'} refused by Rucio.`,
+                });
+            }
+            // Refresh so newly-bad replicas drop out of the suspicious list.
+            startStreamingRef.current(buildSearchUrl(filtersRef.current));
+        },
+        onError: (error: DeclareBadReplicasViewModel) => {
+            toast({
+                variant: 'error',
+                title: 'Failed to declare replicas bad',
+                description: error?.message || 'The Rucio server rejected the request.',
+            });
+        },
+    });
+
+    const onDeclareBad = useCallback((replica: SuspiciousReplicaViewModel) => {
+        setDeclareBadTargets([toTarget(replica)]);
+    }, []);
+
+    const onBulkDeclareBad = () => {
+        if (selectedReplicas.length === 0) return;
+        setDeclareBadTargets(selectedReplicas);
+    };
+
+    const onDeclareBadConfirm = (reason: string, expiresAt: string | null) => {
+        if (declareBadTargets.length === 0) return;
+        declareBadMutation.mutate({ targets: declareBadTargets, reason, expiresAt });
+    };
+
+    const onSelectionChanged = useCallback((rows: SuspiciousReplicaViewModel[]) => {
+        setSelectedReplicas(rows.filter(r => r.status === 'success').map(toTarget));
+    }, []);
+
+    const isRunning = streamingHook.status === StreamingStatus.RUNNING;
+    const selectedCount = selectedReplicas.length;
+
+    const [isTipsOpen, setIsTipsOpen] = useState(false);
+
+    return (
+        <div className="flex flex-col space-y-6 w-full">
+            {/* Tips & suggestions — collapsible info banner. Page-local so the
+                content stays specific to suspicious-replicas workflows. */}
+            <div className="rounded-md bg-base-info-50 dark:bg-base-info-900 text-sm text-base-info-700 dark:text-base-info-200">
+                <button
+                    type="button"
+                    className="flex w-full items-center gap-2 p-3 text-left"
+                    onClick={() => setIsTipsOpen(prev => !prev)}
+                    aria-expanded={isTipsOpen}
+                    aria-controls="suspicious-replicas-tips"
+                >
+                    <HiInformationCircle className="h-5 w-5 shrink-0" aria-hidden="true" />
+                    <span className="font-medium flex-1">Tips & suggestions</span>
+                    <HiChevronDown
+                        className={cn('h-4 w-4 shrink-0 transition-transform duration-200', isTipsOpen && 'rotate-180')}
+                        aria-hidden="true"
+                    />
+                </button>
+                {isTipsOpen && (
+                    <ul id="suspicious-replicas-tips" className="list-disc list-inside space-y-1 px-3 pb-3 pl-10">
+                        <li>
+                            <span className="font-medium">Suspicious vs. bad:</span>  A replica is &quot;suspicious&quot; when Rucio has
+                            recorded one or more failed access attempts against it. Declaring it bad transitions Rucio to schedule
+                            re-transfer or removal.
+                        </li>
+                        <li>
+                            <span className="font-medium">Min Attempts Threshold:</span> Rucio applies this filter strictly. A replica
+                            with <code className="font-mono">cnt = 3</code> is returned only when the threshold is{' '}
+                            <code className="font-mono">0</code>, <code className="font-mono">1</code>, or{' '}
+                            <code className="font-mono">2</code>. Set the threshold to <code className="font-mono">0</code> to see every
+                            recorded suspicion.
+                        </li>
+                        <li>
+                            <span className="font-medium">RSE Expression:</span> accepts Rucio expressions such as{' '}
+                            <code className="font-mono">tier=1</code> or a literal RSE name to narrow results.
+                        </li>
+                        <li>
+                            <span className="font-medium">Bulk Declare Bad:</span>  Tick checkboxes on multiple rows to enable the bulk
+                            toolbar.
+                        </li>
+                        <li>
+                            <span className="font-medium">Irreversible from the UI:</span> declaring a replica bad cannot be undone here;
+                            it can only be reverted server-side by an administrator.
+                        </li>
+                        <li>
+                            <span className="font-medium">Navigation:</span> click an <span className="font-medium">RSE</span> cell to
+                            open its detail page, or a <span className="font-medium">Name</span> cell to open the DID.
+                        </li>
+                        <li>
+                            <span className="font-medium">Refresh:</span> the page re-fetches automatically after each successful
+                            declare-bad. To pick up new server-side suspicions, click the search button.
+                        </li>
+                    </ul>
+                )}
+            </div>
+
+            {/* Filter Panel */}
+            <div className="rounded-lg bg-neutral-0 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 shadow-sm p-6">
+                <div className="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4 items-end">
+                    <div className="flex flex-col w-full space-y-4">
+                        <div className="flex flex-col sm:flex-row w-full gap-4">
+                            <FilterField label="RSE Expression" htmlFor="suspicious-rse-expression">
+                                <Input
+                                    id="suspicious-rse-expression"
+                                    className="w-full"
+                                    value={filters.rseExpression}
+                                    onChange={(e: ChangeEvent<HTMLInputElement>) => handleFiltersChange({ rseExpression: e.target.value })}
+                                    onEnterKey={onSearch}
+                                    placeholder="e.g. tier=1&type=DATADISK"
+                                />
+                            </FilterField>
+                            <FilterField label="Younger Than" htmlFor="suspicious-younger-than">
+                                <DateInput
+                                    id="suspicious-younger-than"
+                                    onchange={(date: Date) => handleFiltersChange({ youngerThan: date })}
+                                    initialdate={filters.youngerThan}
+                                    placeholder="Select date"
+                                />
+                            </FilterField>
+                            <FilterField label="Min Attempts Threshold" htmlFor="suspicious-nattempts">
+                                <Input
+                                    id="suspicious-nattempts"
+                                    className="w-full"
+                                    type="number"
+                                    value={filters.nattempts}
+                                    onChange={(e: ChangeEvent<HTMLInputElement>) => handleFiltersChange({ nattempts: e.target.value })}
+                                    onEnterKey={onSearch}
+                                    placeholder="0"
+                                    min={0}
+                                    max={400}
+                                />
+                            </FilterField>
+                        </div>
+                    </div>
+                    <SearchButton className="sm:w-48 shrink-0" isRunning={isRunning} onStop={onStop} onSearch={onSearch} />
+                </div>
+            </div>
+
+            {/* Bulk actions toolbar — visible only when rows are selected */}
+            {selectedCount > 0 && (
+                <div className="flex items-center gap-3 rounded-lg bg-neutral-100 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 px-4 py-3">
+                    <span className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                        {selectedCount} replica{selectedCount !== 1 ? 's' : ''} selected
+                    </span>
+                    <div className="flex gap-2 ml-auto">
+                        <Button variant="error" size="sm" onClick={onBulkDeclareBad}>
+                            <HiOutlineBan className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                            Declare Bad Selected
+                        </Button>
+                    </div>
+                </div>
+            )}
+
+            {/* Results Table */}
+            <div className="rounded-lg bg-neutral-0 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 shadow-sm overflow-hidden h-[calc(100vh-24rem)]">
+                <SuspiciousReplicasTable
+                    streamingHook={streamingHook}
+                    onGridReady={onGridReady}
+                    onDeclareBad={onDeclareBad}
+                    onSelectionChanged={onSelectionChanged}
+                />
+            </div>
+
+            <DeclareBadReplicaDialog
+                open={declareBadOpen}
+                onOpenChange={open => {
+                    if (!open) setDeclareBadTargets([]);
+                }}
+                targets={declareBadTargets}
+                onConfirm={onDeclareBadConfirm}
+                loading={declareBadMutation.isPending}
+            />
+        </div>
+    );
+};

--- a/src/component-library/pages/Replica/suspicious/SuspiciousReplicasTable.tsx
+++ b/src/component-library/pages/Replica/suspicious/SuspiciousReplicasTable.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useMemo, useRef } from 'react';
+import { AgGridReact } from 'ag-grid-react';
+import { GridReadyEvent, SelectionChangedEvent, ValueGetterParams } from 'ag-grid-community';
+import { UseStreamReader } from '@/lib/infrastructure/hooks/useStreamReader';
+import { StreamedTable } from '@/component-library/features/table/StreamedTable/StreamedTable';
+import { DefaultTextFilterParams, DefaultDateFilterParams } from '@/component-library/features/utils/filter-parameters';
+import { DateCellRenderer } from '@/component-library/features/utils/DateWithTooltip';
+import { ClickableCell } from '@/component-library/features/table/cells/ClickableCell';
+import { Button } from '@/component-library/atoms/form/button';
+import { HiOutlineBan, HiOutlineExternalLink } from 'react-icons/hi';
+import { SuspiciousReplicaViewModel } from '@/lib/infrastructure/data/view-model/replica';
+
+type SuspiciousReplicasTableProps = {
+    streamingHook: UseStreamReader<SuspiciousReplicaViewModel>;
+    onGridReady: (event: GridReadyEvent) => void;
+    /** Per-row "Declare bad" action — opens the dialog for a single replica. */
+    onDeclareBad: (replica: SuspiciousReplicaViewModel) => void;
+    /** Notifies the parent of the current selection (multi-row checkboxes). */
+    onSelectionChanged: (selected: SuspiciousReplicaViewModel[]) => void;
+};
+
+interface ActionsCellParams {
+    data: SuspiciousReplicaViewModel | undefined;
+    onDeclareBad: (replica: SuspiciousReplicaViewModel) => void;
+}
+
+const ActionsCell = ({ data, onDeclareBad }: ActionsCellParams) => {
+    if (!data || data.status !== 'success') return null;
+    return (
+        <div className="flex items-center gap-1 h-full">
+            <Button
+                size="sm"
+                variant="error"
+                className="h-7 px-2 text-xs"
+                onClick={e => {
+                    e.stopPropagation();
+                    onDeclareBad(data);
+                }}
+            >
+                <HiOutlineBan className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                Declare bad
+            </Button>
+            <Button
+                size="sm"
+                variant="neutral"
+                className="h-7 px-2 text-xs"
+                onClick={e => {
+                    e.stopPropagation();
+                    window.open(`/did/${encodeURIComponent(data.scope)}/${encodeURIComponent(data.name)}`, '_blank');
+                }}
+            >
+                <HiOutlineExternalLink className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+                View
+            </Button>
+        </div>
+    );
+};
+
+const ClickableDIDName = (props: { data: SuspiciousReplicaViewModel | undefined }) => {
+    if (!props.data) return null;
+    const { scope, name } = props.data;
+    return <ClickableCell href={`/did/${encodeURIComponent(scope)}/${encodeURIComponent(name)}`}>{name}</ClickableCell>;
+};
+
+const ClickableRSE = (props: { value: string }) => {
+    if (!props.value) return null;
+    return <ClickableCell href={`/rse/${encodeURIComponent(props.value)}`}>{props.value}</ClickableCell>;
+};
+
+export const SuspiciousReplicasTable = (props: SuspiciousReplicasTableProps) => {
+    const { onDeclareBad, onSelectionChanged, ...tableProps } = props;
+    const tableRef = useRef<AgGridReact<SuspiciousReplicaViewModel>>(null);
+
+    const columnDefs = useMemo(
+        () => [
+            {
+                headerCheckboxSelection: true,
+                checkboxSelection: true,
+                width: 48,
+                minWidth: 48,
+                maxWidth: 48,
+                suppressMenu: true,
+                sortable: false,
+                filter: false,
+                resizable: false,
+            },
+            {
+                headerName: 'Scope',
+                field: 'scope',
+                flex: 1,
+                minWidth: 140,
+                filter: true,
+                filterParams: DefaultTextFilterParams,
+                sortable: true,
+            },
+            {
+                headerName: 'Name',
+                field: 'name',
+                flex: 2,
+                minWidth: 260,
+                filter: true,
+                filterParams: DefaultTextFilterParams,
+                sortable: true,
+                cellRenderer: ClickableDIDName,
+            },
+            {
+                headerName: 'RSE',
+                field: 'rse',
+                flex: 1,
+                minWidth: 180,
+                filter: true,
+                filterParams: DefaultTextFilterParams,
+                sortable: true,
+                cellRenderer: ClickableRSE,
+            },
+            {
+                headerName: 'Created At',
+                field: 'createdAt',
+                flex: 1,
+                minWidth: 180,
+                cellRenderer: DateCellRenderer,
+                filter: 'agDateColumnFilter',
+                filterParams: DefaultDateFilterParams,
+                sortable: true,
+            },
+            {
+                headerName: 'Count',
+                field: 'cnt',
+                width: 100,
+                minWidth: 100,
+                filter: 'agNumberColumnFilter',
+                sortable: true,
+                sort: 'desc' as const,
+            },
+            {
+                headerName: 'Actions',
+                colId: 'actions',
+                width: 200,
+                minWidth: 200,
+                sortable: false,
+                filter: false,
+                resizable: false,
+                pinned: 'right' as const,
+                cellRenderer: ActionsCell,
+                cellRendererParams: { onDeclareBad },
+                valueGetter: (params: ValueGetterParams<SuspiciousReplicaViewModel>) => params.data?.name,
+            },
+        ],
+        [onDeclareBad],
+    );
+
+    const handleGridReady = (event: GridReadyEvent) => {
+        tableProps.onGridReady(event);
+        // Default sort: count descending (AC #5).
+        event.api.applyColumnState({
+            state: [{ colId: 'cnt', sort: 'desc' }],
+            defaultState: { sort: null },
+        });
+    };
+
+    const handleSelectionChanged = (event: SelectionChangedEvent<SuspiciousReplicaViewModel>) => {
+        onSelectionChanged(event.api.getSelectedRows());
+    };
+
+    return (
+        <StreamedTable
+            columnDefs={columnDefs}
+            tableRef={tableRef}
+            streamingHook={tableProps.streamingHook}
+            onGridReady={handleGridReady}
+            rowSelection="multiple"
+            suppressRowClickSelection={true}
+            onSelectionChanged={handleSelectionChanged}
+        />
+    );
+};

--- a/src/lib/core/dto/replica-dto.ts
+++ b/src/lib/core/dto/replica-dto.ts
@@ -50,3 +50,23 @@ export interface ListSuspiciousReplicasDTO extends BaseDTO {
 export interface DeclareBadPFNsDTO extends BaseDTO {
     created: boolean;
 }
+
+/**
+ * A single replica (scope, name, rse) that Rucio refused to mark bad on a
+ * `POST /replicas/bad/dids` call. Empty list on the wire == full success.
+ */
+export interface NotDeclaredReplicaDTO {
+    scope: string;
+    name: string;
+    rse: string;
+    reason?: string;
+}
+
+/**
+ * Data Transfer Object for the DeclareBadReplicas endpoint
+ * (`POST /replicas/bad/dids`). On success the body is a JSON array of replicas
+ * the server *refused* to mark bad (or an empty array on full success).
+ */
+export interface DeclareBadReplicasDTO extends BaseDTO {
+    notDeclared: NotDeclaredReplicaDTO[];
+}

--- a/src/lib/core/entity/hotbar.ts
+++ b/src/lib/core/entity/hotbar.ts
@@ -9,6 +9,7 @@ export enum HotBarCardType {
     RULE_LIST = 'RULE_LIST',
     RSE = 'RSE',
     RSE_LIST = 'RSE_LIST',
+    SUSPICIOUS_REPLICA_LIST = 'SUSPICIOUS_REPLICA_LIST',
 }
 
 export interface HotBarCard {

--- a/src/lib/core/port/primary/declare-bad-replicas-ports.ts
+++ b/src/lib/core/port/primary/declare-bad-replicas-ports.ts
@@ -1,0 +1,16 @@
+import { BaseAuthenticatedInputPort, BaseOutputPort } from '@/lib/sdk/primary-ports';
+import {
+    DeclareBadReplicasError,
+    DeclareBadReplicasRequest,
+    DeclareBadReplicasResponse,
+} from '@/lib/core/usecase-models/declare-bad-replicas-usecase-models';
+
+/**
+ * @interface DeclareBadReplicasInputPort representing the DeclareBadReplicas usecase.
+ */
+export interface DeclareBadReplicasInputPort extends BaseAuthenticatedInputPort<DeclareBadReplicasRequest> {}
+
+/**
+ * @interface DeclareBadReplicasOutputPort representing the DeclareBadReplicas presenter.
+ */
+export interface DeclareBadReplicasOutputPort extends BaseOutputPort<DeclareBadReplicasResponse, DeclareBadReplicasError> {}

--- a/src/lib/core/port/primary/list-suspicious-replicas-ports.ts
+++ b/src/lib/core/port/primary/list-suspicious-replicas-ports.ts
@@ -1,0 +1,18 @@
+import { BaseAuthenticatedInputPort, BaseStreamingOutputPort } from '@/lib/sdk/primary-ports';
+import { BaseViewModel } from '@/lib/sdk/view-models';
+import {
+    ListSuspiciousReplicasRequest,
+    ListSuspiciousReplicasResponse,
+    ListSuspiciousReplicasError,
+} from '@/lib/core/usecase-models/list-suspicious-replicas-usecase-models';
+
+/**
+ * @interface ListSuspiciousReplicasInputPort that abstracts the usecase.
+ */
+export interface ListSuspiciousReplicasInputPort extends BaseAuthenticatedInputPort<ListSuspiciousReplicasRequest> {}
+
+/**
+ * @interface ListSuspiciousReplicasOutputPort that abstracts the presenter.
+ */
+export interface ListSuspiciousReplicasOutputPort
+    extends BaseStreamingOutputPort<ListSuspiciousReplicasResponse, ListSuspiciousReplicasError, BaseViewModel> {}

--- a/src/lib/core/port/secondary/replica-gateway-output-port.ts
+++ b/src/lib/core/port/secondary/replica-gateway-output-port.ts
@@ -1,6 +1,6 @@
 import { ListReplicasDTO } from '@/lib/core/dto/replica-dto';
 import { DatasetReplicasDTO } from '@/lib/core/dto/replica-dto';
-import { DeclareBadPFNsDTO, ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
+import { DeclareBadPFNsDTO, DeclareBadReplicasDTO, ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
 
 /**
  * Output port for the Replica Gateway, responsible for defining the methods that the Gateway will use to interact with the Rucio Server.
@@ -49,4 +49,22 @@ export default interface ReplicaGatewayOutputPort {
      * @returns A Promise that resolves to a DeclareBadPFNsDTO object.
      */
     declareBadPFNs(rucioAuthToken: string, pfns: string[], reason: string, state: string, expiresAt?: string | null): Promise<DeclareBadPFNsDTO>;
+
+    /**
+     * Declares replicas as bad on a given RSE via `POST /replicas/bad/dids`.
+     * Returns a DTO whose `notDeclared` array lists replicas the server refused
+     * to mark bad (empty array on full success).
+     * @param rucioAuthToken - The Rucio auth token to use for authentication.
+     * @param dids - List of {scope, name} pairs to declare bad.
+     * @param rse - The RSE on which to mark the replicas bad.
+     * @param reason - The reason for declaring the replicas as bad.
+     * @param expiresAt - Optional expiry timestamp for the declaration.
+     */
+    declareBadReplicas(
+        rucioAuthToken: string,
+        dids: Array<{ scope: string; name: string }>,
+        rse: string,
+        reason: string,
+        expiresAt?: string | null,
+    ): Promise<DeclareBadReplicasDTO>;
 }

--- a/src/lib/core/use-case/declare-bad-replicas-usecase.ts
+++ b/src/lib/core/use-case/declare-bad-replicas-usecase.ts
@@ -1,0 +1,67 @@
+import { injectable } from 'inversify';
+import { BaseSingleEndpointUseCase } from '@/lib/sdk/usecase';
+import { AuthenticatedRequestModel } from '@/lib/sdk/usecase-models';
+
+import {
+    DeclareBadReplicasError,
+    DeclareBadReplicasRequest,
+    DeclareBadReplicasResponse,
+} from '@/lib/core/usecase-models/declare-bad-replicas-usecase-models';
+import { DeclareBadReplicasInputPort, type DeclareBadReplicasOutputPort } from '@/lib/core/port/primary/declare-bad-replicas-ports';
+import { DeclareBadReplicasDTO } from '@/lib/core/dto/replica-dto';
+import type ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+
+@injectable()
+export default class DeclareBadReplicasUseCase
+    extends BaseSingleEndpointUseCase<
+        AuthenticatedRequestModel<DeclareBadReplicasRequest>,
+        DeclareBadReplicasResponse,
+        DeclareBadReplicasError,
+        DeclareBadReplicasDTO
+    >
+    implements DeclareBadReplicasInputPort
+{
+    constructor(protected readonly presenter: DeclareBadReplicasOutputPort, private readonly gateway: ReplicaGatewayOutputPort) {
+        super(presenter);
+    }
+
+    validateRequestModel(requestModel: AuthenticatedRequestModel<DeclareBadReplicasRequest>): DeclareBadReplicasError | undefined {
+        if (!requestModel.dids || requestModel.dids.length === 0) {
+            return {
+                status: 'error',
+                name: 'ValidationError',
+                message: 'At least one DID must be supplied.',
+                code: 400,
+            } as DeclareBadReplicasError;
+        }
+        if (!requestModel.rse || requestModel.rse.trim().length === 0) {
+            return { status: 'error', name: 'ValidationError', message: 'RSE is required.', code: 400 } as DeclareBadReplicasError;
+        }
+        if (!requestModel.reason || requestModel.reason.trim().length === 0) {
+            return { status: 'error', name: 'ValidationError', message: 'A reason is required.', code: 400 } as DeclareBadReplicasError;
+        }
+        return undefined;
+    }
+
+    async makeGatewayRequest(requestModel: AuthenticatedRequestModel<DeclareBadReplicasRequest>): Promise<DeclareBadReplicasDTO> {
+        const { rucioAuthToken, dids, rse, reason, expiresAt } = requestModel;
+        return this.gateway.declareBadReplicas(rucioAuthToken, dids, rse, reason, expiresAt ?? null);
+    }
+
+    handleGatewayError(error: DeclareBadReplicasDTO): DeclareBadReplicasError {
+        return {
+            status: 'error',
+            message: error.errorMessage ?? 'Gateway Error',
+            name: error.errorName ?? 'Gateway Error',
+            code: error.errorCode ?? 500,
+        } as DeclareBadReplicasError;
+    }
+
+    processDTO(dto: DeclareBadReplicasDTO): { data: DeclareBadReplicasResponse | DeclareBadReplicasError; status: 'success' | 'error' } {
+        const responseModel: DeclareBadReplicasResponse = {
+            status: 'success',
+            notDeclared: dto.notDeclared,
+        };
+        return { status: 'success', data: responseModel };
+    }
+}

--- a/src/lib/core/use-case/list-suspicious-replicas-usecase.ts
+++ b/src/lib/core/use-case/list-suspicious-replicas-usecase.ts
@@ -1,0 +1,88 @@
+import { injectable } from 'inversify';
+import { Readable, PassThrough, Transform } from 'stream';
+import { BaseStreamingUseCase } from '@/lib/sdk/usecase';
+import { AuthenticatedRequestModel } from '@/lib/sdk/usecase-models';
+import { BaseViewModel } from '@/lib/sdk/view-models';
+
+import {
+    ListSuspiciousReplicasError,
+    ListSuspiciousReplicasRequest,
+    ListSuspiciousReplicasResponse,
+} from '@/lib/core/usecase-models/list-suspicious-replicas-usecase-models';
+import { ListSuspiciousReplicasInputPort, type ListSuspiciousReplicasOutputPort } from '@/lib/core/port/primary/list-suspicious-replicas-ports';
+
+import { SuspiciousReplicaDTO } from '@/lib/core/dto/replica-dto';
+import type ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+
+@injectable()
+export default class ListSuspiciousReplicasUseCase
+    extends BaseStreamingUseCase<
+        ListSuspiciousReplicasRequest,
+        ListSuspiciousReplicasResponse,
+        ListSuspiciousReplicasError,
+        SuspiciousReplicaDTO,
+        BaseViewModel
+    >
+    implements ListSuspiciousReplicasInputPort
+{
+    constructor(protected readonly presenter: ListSuspiciousReplicasOutputPort, private readonly gateway: ReplicaGatewayOutputPort) {
+        super(presenter);
+    }
+
+    validateRequestModel(requestModel: AuthenticatedRequestModel<ListSuspiciousReplicasRequest>): ListSuspiciousReplicasError | undefined {
+        return undefined;
+    }
+
+    async intializeRequest(requestModel: AuthenticatedRequestModel<ListSuspiciousReplicasRequest>): Promise<ListSuspiciousReplicasError | undefined> {
+        return Promise.resolve(undefined);
+    }
+
+    async generateSourceStream(requestModel: AuthenticatedRequestModel<ListSuspiciousReplicasRequest>): Promise<{
+        status: 'success' | 'error';
+        stream?: Transform | Readable | PassThrough | null;
+        error?: ListSuspiciousReplicasError;
+    }> {
+        const { rucioAuthToken, rseExpression, youngerThan, nattempts } = requestModel;
+        const dto = await this.gateway.listSuspiciousReplicas(rucioAuthToken, rseExpression, youngerThan, nattempts);
+
+        if (dto.status === 'error') {
+            const errorModel: ListSuspiciousReplicasError = {
+                status: 'error',
+                error: `Gateway returned with ${dto.errorCode}: ${dto.errorMessage}`,
+                message: dto.errorMessage ?? 'Gateway Error',
+                name: dto.errorName ?? 'Gateway Error',
+                code: dto.errorCode ?? 500,
+            } as ListSuspiciousReplicasError;
+            return { status: 'error', error: errorModel };
+        }
+
+        const stream = Readable.from(dto.replicas);
+        return { status: 'success', stream };
+    }
+
+    processStreamedData(dto: SuspiciousReplicaDTO): {
+        data: ListSuspiciousReplicasResponse | ListSuspiciousReplicasError;
+        status: 'success' | 'error';
+    } {
+        if (dto.status === 'error') {
+            const errorModel: ListSuspiciousReplicasError = {
+                status: 'error',
+                code: dto.errorCode ?? 500,
+                message: dto.errorMessage ?? 'Could not process the fetched data',
+                name: dto.errorName ?? 'Gateway Error',
+            } as ListSuspiciousReplicasError;
+            return { status: 'error', data: errorModel };
+        }
+
+        const responseModel: ListSuspiciousReplicasResponse = {
+            status: 'success',
+            scope: dto.scope,
+            name: dto.name,
+            rse: dto.rse,
+            rseId: dto.rseId,
+            cnt: dto.cnt,
+            createdAt: dto.createdAt,
+        };
+        return { status: 'success', data: responseModel };
+    }
+}

--- a/src/lib/core/usecase-models/declare-bad-replicas-usecase-models.ts
+++ b/src/lib/core/usecase-models/declare-bad-replicas-usecase-models.ts
@@ -1,0 +1,27 @@
+import { BaseErrorResponseModel, BaseResponseModel } from '@/lib/sdk/usecase-models';
+import { NotDeclaredReplicaDTO } from '@/lib/core/dto/replica-dto';
+
+/**
+ * @interface DeclareBadReplicasRequest represents the RequestModel for the
+ * declare_bad_replicas usecase (POST /replicas/bad/dids on the Rucio server).
+ */
+export interface DeclareBadReplicasRequest {
+    dids: Array<{ scope: string; name: string }>;
+    rse: string;
+    reason: string;
+    /** ISO-like timestamp accepted by Rucio (`%Y-%m-%dT%H:%M:%S`); null/undefined = no expiry. */
+    expiresAt?: string | null;
+}
+
+/**
+ * @interface DeclareBadReplicasResponse — replicas the server *refused* to mark bad.
+ * An empty `notDeclared` list means every supplied replica was accepted.
+ */
+export interface DeclareBadReplicasResponse extends BaseResponseModel {
+    notDeclared: NotDeclaredReplicaDTO[];
+}
+
+/**
+ * @interface DeclareBadReplicasError represents the ErrorModel for the usecase.
+ */
+export interface DeclareBadReplicasError extends BaseErrorResponseModel {}

--- a/src/lib/core/usecase-models/list-suspicious-replicas-usecase-models.ts
+++ b/src/lib/core/usecase-models/list-suspicious-replicas-usecase-models.ts
@@ -1,0 +1,28 @@
+import { BaseErrorResponseModel, BaseResponseModel } from '@/lib/sdk/usecase-models';
+
+/**
+ * @interface ListSuspiciousReplicasRequest represents the RequestModel for list_suspicious_replicas usecase
+ */
+export interface ListSuspiciousReplicasRequest {
+    rseExpression?: string;
+    youngerThan?: string;
+    nattempts?: number;
+}
+
+/**
+ * @interface ListSuspiciousReplicasResponse represents the ResponseModel for list_suspicious_replicas usecase.
+ * Each instance corresponds to a single suspicious replica entry from the Rucio server.
+ */
+export interface ListSuspiciousReplicasResponse extends BaseResponseModel {
+    scope: string;
+    name: string;
+    rse: string;
+    rseId: string;
+    cnt: number;
+    createdAt: string;
+}
+
+/**
+ * @interface ListSuspiciousReplicasError represents the ErrorModel for list_suspicious_replicas usecase
+ */
+export interface ListSuspiciousReplicasError extends BaseErrorResponseModel {}

--- a/src/lib/infrastructure/command-palette/command-registry.ts
+++ b/src/lib/infrastructure/command-palette/command-registry.ts
@@ -12,6 +12,7 @@ import {
     MagnifyingGlassIcon,
     PlusIcon,
     QuestionMarkCircleIcon,
+    ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
 import { CommandItem } from '@/lib/core/entity/command-palette';
 import { buildDIDSearchUrl, buildRSESearchUrl, buildRuleDetailUrl, buildSubscriptionSearchUrl, detectSearchType } from '@/lib/infrastructure/utils/navigation';
@@ -74,6 +75,15 @@ export function getNavigationCommands(account?: string, canViewApprovalQueue?: b
             icon: ServerIcon,
             url: '/rses',
             keywords: ['rse', 'storage', 'element', 'endpoint'],
+        },
+        {
+            id: 'nav-suspicious-replicas',
+            type: 'navigation',
+            title: 'Suspicious Replicas',
+            description: 'List suspicious file replicas and declare them bad',
+            icon: ExclamationTriangleIcon,
+            url: '/suspicious-replicas',
+            keywords: ['suspicious', 'bad', 'replica', 'file', 'corrupted', 'declare', 'rse'],
         },
         {
             id: 'nav-subscriptions',

--- a/src/lib/infrastructure/controller/declare-bad-replicas-controller.ts
+++ b/src/lib/infrastructure/controller/declare-bad-replicas-controller.ts
@@ -1,0 +1,40 @@
+import { injectable, inject } from 'inversify';
+import { Signal } from '@/lib/sdk/web';
+
+import { AuthenticatedRequestModel } from '@/lib/sdk/usecase-models';
+import { BaseController, TAuthenticatedControllerParameters } from '@/lib/sdk/controller';
+import { DeclareBadReplicasRequest } from '@/lib/core/usecase-models/declare-bad-replicas-usecase-models';
+import { DeclareBadReplicasInputPort } from '@/lib/core/port/primary/declare-bad-replicas-ports';
+import USECASE_FACTORY from '@/lib/infrastructure/ioc/ioc-symbols-usecase-factory';
+
+export type DeclareBadReplicasControllerParameters = TAuthenticatedControllerParameters & {
+    dids: Array<{ scope: string; name: string }>;
+    rse: string;
+    reason: string;
+    expiresAt?: string | null;
+};
+
+@injectable()
+class DeclareBadReplicasController extends BaseController<
+    DeclareBadReplicasControllerParameters,
+    AuthenticatedRequestModel<DeclareBadReplicasRequest>
+> {
+    constructor(
+        @inject(USECASE_FACTORY.DECLARE_BAD_REPLICAS)
+        declareBadReplicasUseCaseFactory: (response: Signal) => DeclareBadReplicasInputPort,
+    ) {
+        super(declareBadReplicasUseCaseFactory);
+    }
+
+    prepareRequestModel(parameters: DeclareBadReplicasControllerParameters): AuthenticatedRequestModel<DeclareBadReplicasRequest> {
+        return {
+            rucioAuthToken: parameters.rucioAuthToken,
+            dids: parameters.dids,
+            rse: parameters.rse,
+            reason: parameters.reason,
+            expiresAt: parameters.expiresAt,
+        } as AuthenticatedRequestModel<DeclareBadReplicasRequest>;
+    }
+}
+
+export default DeclareBadReplicasController;

--- a/src/lib/infrastructure/controller/list-suspicious-replicas-controller.ts
+++ b/src/lib/infrastructure/controller/list-suspicious-replicas-controller.ts
@@ -1,0 +1,41 @@
+import { injectable, inject } from 'inversify';
+import { Signal } from '@/lib/sdk/web';
+
+import { AuthenticatedRequestModel } from '@/lib/sdk/usecase-models';
+import { BaseController, TAuthenticatedControllerParameters } from '@/lib/sdk/controller';
+import { ListSuspiciousReplicasRequest } from '@/lib/core/usecase-models/list-suspicious-replicas-usecase-models';
+import { ListSuspiciousReplicasInputPort } from '@/lib/core/port/primary/list-suspicious-replicas-ports';
+import USECASE_FACTORY from '@/lib/infrastructure/ioc/ioc-symbols-usecase-factory';
+
+export type ListSuspiciousReplicasControllerParameters = TAuthenticatedControllerParameters & {
+    rucioAuthToken: string;
+    rseExpression?: string;
+    youngerThan?: string;
+    nattempts?: number;
+};
+
+@injectable()
+class ListSuspiciousReplicasController extends BaseController<
+    ListSuspiciousReplicasControllerParameters,
+    AuthenticatedRequestModel<ListSuspiciousReplicasRequest>
+> {
+    constructor(
+        @inject(USECASE_FACTORY.LIST_SUSPICIOUS_REPLICAS)
+        listSuspiciousReplicasUseCaseFactory: (response: Signal) => ListSuspiciousReplicasInputPort,
+    ) {
+        super(listSuspiciousReplicasUseCaseFactory);
+    }
+
+    prepareRequestModel(
+        parameters: ListSuspiciousReplicasControllerParameters,
+    ): AuthenticatedRequestModel<ListSuspiciousReplicasRequest> {
+        return {
+            rucioAuthToken: parameters.rucioAuthToken,
+            rseExpression: parameters.rseExpression,
+            youngerThan: parameters.youngerThan,
+            nattempts: parameters.nattempts,
+        } as AuthenticatedRequestModel<ListSuspiciousReplicasRequest>;
+    }
+}
+
+export default ListSuspiciousReplicasController;

--- a/src/lib/infrastructure/data/view-model/replica.ts
+++ b/src/lib/infrastructure/data/view-model/replica.ts
@@ -1,0 +1,46 @@
+import { BaseViewModel } from '@/lib/sdk/view-models';
+
+/**
+ * ViewModel for a single suspicious replica entry.
+ * Includes a typed error discriminator per project conventions.
+ */
+export interface SuspiciousReplicaViewModel extends BaseViewModel {
+    scope: string;
+    name: string;
+    rse: string;
+    rseId: string;
+    cnt: number;
+    createdAt: string;
+    /** Typed error discriminator — set when status === 'error' */
+    errorType?: 'gateway_error' | 'unknown';
+}
+
+export function generateEmptySuspiciousReplicaViewModel(): SuspiciousReplicaViewModel {
+    return {
+        status: 'error',
+        scope: '',
+        name: '',
+        rse: '',
+        rseId: '',
+        cnt: 0,
+        createdAt: '',
+    };
+}
+
+/**
+ * ViewModel returned from the declare-bad-replicas mutation.
+ * The Rucio endpoint POST /replicas/bad/dids returns a list of replicas that
+ * could not be marked bad; an empty list (the success case) means every
+ * supplied DID was accepted.
+ */
+export interface DeclareBadReplicasViewModel extends BaseViewModel {
+    /** Replicas the server refused to mark bad (empty array on full success). */
+    notDeclared: Array<{ scope: string; name: string; rse: string; reason?: string }>;
+    /** Typed error discriminator — set when status === 'error' */
+    errorType?: 'gateway_error' | 'validation_error' | 'unknown';
+}
+
+export const getEmptyDeclareBadReplicasViewModel = (): DeclareBadReplicasViewModel => ({
+    status: 'error',
+    notDeclared: [],
+});

--- a/src/lib/infrastructure/gateway/replica-gateway/endpoints/declare-bad-replicas-endpoint.ts
+++ b/src/lib/infrastructure/gateway/replica-gateway/endpoints/declare-bad-replicas-endpoint.ts
@@ -1,0 +1,88 @@
+import { DeclareBadReplicasDTO, NotDeclaredReplicaDTO } from '@/lib/core/dto/replica-dto';
+import { BaseEndpoint, extractErrorMessage } from '@/lib/sdk/gateway-endpoints';
+import { HTTPRequest } from '@/lib/sdk/http';
+
+/**
+ * Endpoint for `POST /replicas/bad/dids/`.
+ *
+ * Body shape: `{ dids: [{scope, name}], rse, reason, expires_at? }`.
+ * On success the server returns 201 with a JSON array body of replicas it
+ * refused to mark bad (typically empty == every supplied DID accepted).
+ */
+export default class DeclareBadReplicasEndpoint extends BaseEndpoint<DeclareBadReplicasDTO> {
+    constructor(
+        private readonly rucioAuthToken: string,
+        private readonly dids: Array<{ scope: string; name: string }>,
+        private readonly rse: string,
+        private readonly reason: string,
+        private readonly expiresAt?: string | null,
+    ) {
+        super();
+    }
+
+    async initialize(): Promise<void> {
+        await super.initialize();
+        this.url = `${this.rucioHost}/replicas/bad/dids/`;
+
+        const body: Record<string, unknown> = {
+            dids: this.dids,
+            rse: this.rse,
+            reason: this.reason,
+        };
+        if (this.expiresAt !== undefined) {
+            body.expires_at = this.expiresAt;
+        }
+
+        const request: HTTPRequest = {
+            method: 'POST',
+            url: this.url,
+            headers: {
+                'X-Rucio-Auth-Token': this.rucioAuthToken,
+                'Content-Type': 'application/json',
+            },
+            body: body,
+        };
+        this.request = request;
+        this.initialized = true;
+    }
+
+    async reportErrors(statusCode: number, response: Response): Promise<DeclareBadReplicasDTO | undefined> {
+        const error = await extractErrorMessage(response);
+        const dto: DeclareBadReplicasDTO = {
+            status: 'error',
+            notDeclared: [],
+            errorCode: statusCode,
+            errorName: 'Unknown Error',
+            errorType: 'gateway_endpoint_error',
+            errorMessage: `${error ?? 'No error details available from rucio'}`,
+        };
+        return Promise.resolve(dto);
+    }
+
+    createDTO(data: object | string): DeclareBadReplicasDTO {
+        // Rucio returns either a JSON array of "could not be declared" entries or
+        // an empty array. Defensive: tolerate object/string shapes from upstream.
+        let items: unknown[] = [];
+        if (Array.isArray(data)) {
+            items = data;
+        } else if (typeof data === 'string') {
+            try {
+                const parsed = JSON.parse(data);
+                if (Array.isArray(parsed)) items = parsed;
+            } catch {
+                items = [];
+            }
+        }
+
+        const notDeclared: NotDeclaredReplicaDTO[] = items
+            .filter((it): it is Record<string, unknown> => typeof it === 'object' && it !== null)
+            .map(it => ({
+                scope: String(it.scope ?? ''),
+                name: String(it.name ?? ''),
+                rse: String(it.rse ?? ''),
+                reason: it.reason !== undefined ? String(it.reason) : undefined,
+            }));
+
+        return { status: 'success', notDeclared };
+    }
+}

--- a/src/lib/infrastructure/gateway/replica-gateway/replica-gateway.ts
+++ b/src/lib/infrastructure/gateway/replica-gateway/replica-gateway.ts
@@ -1,10 +1,11 @@
-import { DeclareBadPFNsDTO, ListReplicasDTO, ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
+import { DeclareBadPFNsDTO, DeclareBadReplicasDTO, ListReplicasDTO, ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
 import ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
 import { injectable } from 'inversify';
 import ListDatasetReplicasEndpoint from './endpoints/list-dataset-replicas-endpoint';
 import ListFileReplicasEndpoint from './endpoints/list-file-replicas-endpoint';
 import ListSuspiciousReplicasEndpoint from './endpoints/list-suspicious-replicas-endpoint';
 import DeclareBadPFNsEndpoint from './endpoints/declare-bad-pfns-endpoint';
+import DeclareBadReplicasEndpoint from './endpoints/declare-bad-replicas-endpoint';
 
 @injectable()
 export default class ReplicaGateway implements ReplicaGatewayOutputPort {
@@ -90,6 +91,29 @@ export default class ReplicaGateway implements ReplicaGatewayOutputPort {
                 status: 'error',
                 created: false,
                 errorName: 'Exception occurred while declaring bad PFNs',
+                errorType: 'gateway_endpoint_error',
+                errorMessage: error?.toString(),
+            };
+            return Promise.resolve(errorDTO);
+        }
+    }
+
+    async declareBadReplicas(
+        rucioAuthToken: string,
+        dids: Array<{ scope: string; name: string }>,
+        rse: string,
+        reason: string,
+        expiresAt?: string | null,
+    ): Promise<DeclareBadReplicasDTO> {
+        try {
+            const endpoint = new DeclareBadReplicasEndpoint(rucioAuthToken, dids, rse, reason, expiresAt);
+            const dto: DeclareBadReplicasDTO = await endpoint.fetch();
+            return dto;
+        } catch (error) {
+            const errorDTO: DeclareBadReplicasDTO = {
+                status: 'error',
+                notDeclared: [],
+                errorName: 'Exception occurred while declaring bad replicas',
                 errorType: 'gateway_endpoint_error',
                 errorMessage: error?.toString(),
             };

--- a/src/lib/infrastructure/hooks/useTableStreaming.ts
+++ b/src/lib/infrastructure/hooks/useTableStreaming.ts
@@ -30,7 +30,8 @@ export default function useTableStreaming<T extends BaseViewModel>(initialData?:
 
     useEffect(() => {
         if (gridApi && initialData) {
-            onData(initialData);
+            const validData = initialData.filter(element => validator.isValid(element));
+            gridApi.setGridOption('rowData', validData);
         }
     }, [gridApi]);
 

--- a/src/lib/infrastructure/ioc/container-config.ts
+++ b/src/lib/infrastructure/ioc/container-config.ts
@@ -67,6 +67,8 @@ import RequestGatewayOutputPort from '@/lib/core/port/secondary/request-gateway-
 import GetFTSLinkFeature from './features/get-fts-link-feature';
 import GetDDMLinkFeature from './features/get-ddm-link-feature';
 import UpdateRuleFeature from '@/lib/infrastructure/ioc/features/update-rule-feature';
+import ListSuspiciousReplicasFeature from '@/lib/infrastructure/ioc/features/list-suspicious-replicas-feature';
+import DeclareBadReplicasFeature from '@/lib/infrastructure/ioc/features/declare-bad-replicas-feature';
 
 /**
  * IoC Container configuration for the application.
@@ -100,6 +102,8 @@ loadFeaturesSync(appContainer, [
     new ListDIDRulesFeature(appContainer),
     new ListDatasetReplicasFeature(appContainer),
     new ListFileReplicasFeature(appContainer),
+    new ListSuspiciousReplicasFeature(appContainer),
+    new DeclareBadReplicasFeature(appContainer),
     new ListSubscriptionsFeature(appContainer),
     new GetRuleFeature(appContainer),
     new GetFTSLinkFeature(appContainer),

--- a/src/lib/infrastructure/ioc/features/declare-bad-replicas-feature.ts
+++ b/src/lib/infrastructure/ioc/features/declare-bad-replicas-feature.ts
@@ -1,0 +1,46 @@
+import ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+import {
+    DeclareBadReplicasError,
+    DeclareBadReplicasRequest,
+    DeclareBadReplicasResponse,
+} from '@/lib/core/usecase-models/declare-bad-replicas-usecase-models';
+import { DeclareBadReplicasControllerParameters } from '@/lib/infrastructure/controller/declare-bad-replicas-controller';
+import DeclareBadReplicasController from '@/lib/infrastructure/controller/declare-bad-replicas-controller';
+import { DeclareBadReplicasViewModel } from '@/lib/infrastructure/data/view-model/replica';
+import { BaseFeature, IOCSymbols } from '@/lib/sdk/ioc-helpers';
+import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import INPUT_PORT from '@/lib/infrastructure/ioc/ioc-symbols-input-port';
+import USECASE_FACTORY from '@/lib/infrastructure/ioc/ioc-symbols-usecase-factory';
+import { Container } from 'inversify';
+
+import DeclareBadReplicasUseCase from '@/lib/core/use-case/declare-bad-replicas-usecase';
+import DeclareBadReplicasPresenter from '@/lib/infrastructure/presenter/declare-bad-replicas-presenter';
+
+export default class DeclareBadReplicasFeature extends BaseFeature<
+    DeclareBadReplicasControllerParameters,
+    DeclareBadReplicasRequest,
+    DeclareBadReplicasResponse,
+    DeclareBadReplicasError,
+    DeclareBadReplicasViewModel
+> {
+    constructor(appContainer: Container) {
+        const replicaGateway = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+
+        const symbols: IOCSymbols = {
+            CONTROLLER: CONTROLLERS.DECLARE_BAD_REPLICAS,
+            USECASE_FACTORY: USECASE_FACTORY.DECLARE_BAD_REPLICAS,
+            INPUT_PORT: INPUT_PORT.DECLARE_BAD_REPLICAS,
+        };
+        const useCaseConstructorArgs = [replicaGateway];
+        super(
+            'DeclareBadReplicas',
+            DeclareBadReplicasController,
+            DeclareBadReplicasUseCase,
+            useCaseConstructorArgs,
+            DeclareBadReplicasPresenter,
+            false,
+            symbols,
+        );
+    }
+}

--- a/src/lib/infrastructure/ioc/features/list-suspicious-replicas-feature.ts
+++ b/src/lib/infrastructure/ioc/features/list-suspicious-replicas-feature.ts
@@ -1,0 +1,46 @@
+import ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+import {
+    ListSuspiciousReplicasError,
+    ListSuspiciousReplicasRequest,
+    ListSuspiciousReplicasResponse,
+} from '@/lib/core/usecase-models/list-suspicious-replicas-usecase-models';
+import { ListSuspiciousReplicasControllerParameters } from '@/lib/infrastructure/controller/list-suspicious-replicas-controller';
+import ListSuspiciousReplicasController from '@/lib/infrastructure/controller/list-suspicious-replicas-controller';
+import { SuspiciousReplicaViewModel } from '@/lib/infrastructure/data/view-model/replica';
+import { BaseStreamableFeature, IOCSymbols } from '@/lib/sdk/ioc-helpers';
+import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import INPUT_PORT from '@/lib/infrastructure/ioc/ioc-symbols-input-port';
+import USECASE_FACTORY from '@/lib/infrastructure/ioc/ioc-symbols-usecase-factory';
+import { Container } from 'inversify';
+
+import ListSuspiciousReplicasUseCase from '@/lib/core/use-case/list-suspicious-replicas-usecase';
+import ListSuspiciousReplicasPresenter from '@/lib/infrastructure/presenter/list-suspicious-replicas-presenter';
+
+export default class ListSuspiciousReplicasFeature extends BaseStreamableFeature<
+    ListSuspiciousReplicasControllerParameters,
+    ListSuspiciousReplicasRequest,
+    ListSuspiciousReplicasResponse,
+    ListSuspiciousReplicasError,
+    SuspiciousReplicaViewModel
+> {
+    constructor(appContainer: Container) {
+        const replicaGateway = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+
+        const symbols: IOCSymbols = {
+            CONTROLLER: CONTROLLERS.LIST_SUSPICIOUS_REPLICAS,
+            USECASE_FACTORY: USECASE_FACTORY.LIST_SUSPICIOUS_REPLICAS,
+            INPUT_PORT: INPUT_PORT.LIST_SUSPICIOUS_REPLICAS,
+        };
+        const useCaseConstructorArgs = [replicaGateway];
+        super(
+            'ListSuspiciousReplicas',
+            ListSuspiciousReplicasController,
+            ListSuspiciousReplicasUseCase,
+            useCaseConstructorArgs,
+            ListSuspiciousReplicasPresenter,
+            false,
+            symbols,
+        );
+    }
+}

--- a/src/lib/infrastructure/ioc/ioc-symbols-controllers.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-controllers.ts
@@ -1,6 +1,5 @@
 /**
- * /**
- * @file ioc-symbols-input-port.ts
+ * @file ioc-symbols-controllers.ts
  * @description This file contains the symbols for the controllers. Controllers are used
  * to execute the use cases.
  */
@@ -40,6 +39,8 @@ const CONTROLLERS = {
     GET_FTS_LINK: Symbol.for('GetFTSLinkController'),
     GET_DDM_LINK: Symbol.for('GetDDMLinkController'),
     UPDATE_RULE: Symbol.for('UpdateRuleController'),
+    LIST_SUSPICIOUS_REPLICAS: Symbol.for('ListSuspiciousReplicasController'),
+    DECLARE_BAD_REPLICAS: Symbol.for('DeclareBadReplicasController'),
 };
 
 export default CONTROLLERS;

--- a/src/lib/infrastructure/ioc/ioc-symbols-input-port.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-input-port.ts
@@ -39,6 +39,8 @@ const INPUT_PORT = {
     GET_FTS_LINK: Symbol.for('GetFTSLinkInputPort'),
     GET_DDM_LINK: Symbol.for('GetDDMLinkInputPort'),
     UPDATE_RULE: Symbol.for('UpdateRuleInputPort'),
+    LIST_SUSPICIOUS_REPLICAS: Symbol.for('ListSuspiciousReplicasInputPort'),
+    DECLARE_BAD_REPLICAS: Symbol.for('DeclareBadReplicasInputPort'),
 };
 
 export default INPUT_PORT;

--- a/src/lib/infrastructure/ioc/ioc-symbols-usecase-factory.ts
+++ b/src/lib/infrastructure/ioc/ioc-symbols-usecase-factory.ts
@@ -40,6 +40,8 @@ const USECASE_FACTORY = {
     GET_FTS_LINK: Symbol.for('Factory<GetFTSLinkUseCase>'),
     GET_DDM_LINK: Symbol.for('Factory<GetDDMLinkUseCase>'),
     UPDATE_RULE: Symbol.for('Factory<UpdateRuleUseCase>'),
+    LIST_SUSPICIOUS_REPLICAS: Symbol.for('Factory<ListSuspiciousReplicasUseCase>'),
+    DECLARE_BAD_REPLICAS: Symbol.for('Factory<DeclareBadReplicasUseCase>'),
 };
 
 export default USECASE_FACTORY;

--- a/src/lib/infrastructure/presenter/declare-bad-replicas-presenter.ts
+++ b/src/lib/infrastructure/presenter/declare-bad-replicas-presenter.ts
@@ -1,0 +1,36 @@
+import { BasePresenter } from '@/lib/sdk/presenter';
+import {
+    DeclareBadReplicasError,
+    DeclareBadReplicasResponse,
+} from '@/lib/core/usecase-models/declare-bad-replicas-usecase-models';
+import { DeclareBadReplicasViewModel, getEmptyDeclareBadReplicasViewModel } from '@/lib/infrastructure/data/view-model/replica';
+
+export default class DeclareBadReplicasPresenter extends BasePresenter<
+    DeclareBadReplicasResponse,
+    DeclareBadReplicasError,
+    DeclareBadReplicasViewModel
+> {
+    convertResponseModelToViewModel(responseModel: DeclareBadReplicasResponse): { viewModel: DeclareBadReplicasViewModel; status: number } {
+        const viewModel: DeclareBadReplicasViewModel = {
+            status: 'success',
+            notDeclared: responseModel.notDeclared.map(r => ({
+                scope: r.scope,
+                name: r.name,
+                rse: r.rse,
+                reason: r.reason,
+            })),
+        };
+        return { status: 200, viewModel };
+    }
+
+    convertErrorModelToViewModel(errorModel: DeclareBadReplicasError): { viewModel: DeclareBadReplicasViewModel; status: number } {
+        const viewModel: DeclareBadReplicasViewModel = getEmptyDeclareBadReplicasViewModel();
+        viewModel.message = errorModel.message || errorModel.name;
+        viewModel.errorType =
+            (errorModel.code ?? 500) >= 400 && (errorModel.code ?? 500) < 500 && errorModel.name === 'ValidationError'
+                ? 'validation_error'
+                : 'gateway_error';
+        const errorCode = errorModel.code || 500;
+        return { status: errorCode, viewModel };
+    }
+}

--- a/src/lib/infrastructure/presenter/list-suspicious-replicas-presenter.ts
+++ b/src/lib/infrastructure/presenter/list-suspicious-replicas-presenter.ts
@@ -1,0 +1,45 @@
+import {
+    ListSuspiciousReplicasError,
+    ListSuspiciousReplicasResponse,
+} from '@/lib/core/usecase-models/list-suspicious-replicas-usecase-models';
+import { SuspiciousReplicaViewModel, generateEmptySuspiciousReplicaViewModel } from '@/lib/infrastructure/data/view-model/replica';
+import { BaseStreamingPresenter } from '@/lib/sdk/presenter';
+import { ListSuspiciousReplicasOutputPort } from '@/lib/core/port/primary/list-suspicious-replicas-ports';
+
+export default class ListSuspiciousReplicasPresenter
+    extends BaseStreamingPresenter<ListSuspiciousReplicasResponse, ListSuspiciousReplicasError, SuspiciousReplicaViewModel>
+    implements ListSuspiciousReplicasOutputPort
+{
+    streamResponseModelToViewModel(responseModel: ListSuspiciousReplicasResponse): SuspiciousReplicaViewModel {
+        const viewModel: SuspiciousReplicaViewModel = {
+            status: 'success',
+            scope: responseModel.scope,
+            name: responseModel.name,
+            rse: responseModel.rse,
+            rseId: responseModel.rseId,
+            cnt: responseModel.cnt,
+            createdAt: responseModel.createdAt,
+        };
+        return viewModel;
+    }
+
+    streamErrorModelToViewModel(error: ListSuspiciousReplicasError): SuspiciousReplicaViewModel {
+        const errorViewModel: SuspiciousReplicaViewModel = generateEmptySuspiciousReplicaViewModel();
+        errorViewModel.status = 'error';
+        errorViewModel.message = `${error.name}: ${error.message}`;
+        errorViewModel.errorType = 'gateway_error';
+        return errorViewModel;
+    }
+
+    convertErrorModelToViewModel(errorModel: ListSuspiciousReplicasError): { viewModel: SuspiciousReplicaViewModel; status: number } {
+        const viewModel: SuspiciousReplicaViewModel = generateEmptySuspiciousReplicaViewModel();
+        const message = errorModel.message ? errorModel.message.toString() : errorModel.name;
+        viewModel.message = message;
+        viewModel.errorType = 'gateway_error';
+        const errorCode = errorModel.code ? errorModel.code : 500;
+        return {
+            status: errorCode,
+            viewModel: viewModel,
+        };
+    }
+}

--- a/src/lib/utils/hotbar-storage.ts
+++ b/src/lib/utils/hotbar-storage.ts
@@ -16,6 +16,10 @@ export function inferCardType(url: string): HotBarCardType {
         const urlObj = new URL(url, window.location.origin);
         const pathname = urlObj.pathname;
 
+        // Suspicious-replicas is matched first because its URL contains no
+        // /did/rule/rse substrings and the default fallback below would
+        // otherwise mis-classify it as DID.
+        if (pathname.includes('/suspicious-replicas')) return HotBarCardType.SUSPICIOUS_REPLICA_LIST;
         if (pathname.includes('/dids')) return HotBarCardType.DID_LIST;
         if (pathname.includes('/did/')) return HotBarCardType.DID;
         if (pathname.includes('/rules')) return HotBarCardType.RULE_LIST;

--- a/test/api/replica/declare-bad-replicas.test.ts
+++ b/test/api/replica/declare-bad-replicas.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the declare-bad-replicas feature.
+ *
+ * Two layers:
+ *  - Controller-level: exercises the use case + presenter through the IoC
+ *    container against a mocked Rucio /replicas/bad/dids endpoint.
+ *  - Route-level: confirms `POST /api/feature/declare-bad-replicas` returns
+ *    200 + JSON on success and 400 on a malformed body, with the auth
+ *    wrapper stubbed.
+ */
+
+import { Writable } from 'stream';
+
+// jsdom doesn't ship Response.json, which NextResponse.json relies on for
+// short-circuit validation errors. Polyfill it before importing the route.
+if (typeof (global.Response as { json?: unknown }).json !== 'function') {
+    (global.Response as unknown as { json: (data: unknown, init?: ResponseInit) => Response }).json = function jsonPolyfill(
+        data: unknown,
+        init?: ResponseInit,
+    ): Response {
+        return new Response(JSON.stringify(data), {
+            ...init,
+            headers: {
+                'content-type': 'application/json',
+                ...(init?.headers instanceof Headers
+                    ? Object.fromEntries((init.headers as Headers).entries())
+                    : (init?.headers ?? {})),
+            },
+        });
+    };
+}
+
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import { BaseController } from '@/lib/sdk/controller';
+import DeclareBadReplicasController, {
+    DeclareBadReplicasControllerParameters,
+} from '@/lib/infrastructure/controller/declare-bad-replicas-controller';
+import { DeclareBadReplicasRequest } from '@/lib/core/usecase-models/declare-bad-replicas-usecase-models';
+import { MockHttpStreamableResponseFactory } from 'test/fixtures/http-fixtures';
+import { NextApiResponse } from 'next';
+import { DeclareBadReplicasViewModel } from '@/lib/infrastructure/data/view-model/replica';
+
+const makeEndpoint = (status: number, body: unknown): MockEndpoint => ({
+    url: `${MockRucioServerFactory.RUCIO_HOST}/replicas/bad/dids/`,
+    method: 'POST',
+    includes: 'replicas/bad/dids',
+    response: {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+    },
+});
+
+describe('Feature: DeclareBadReplicas (controller)', () => {
+    beforeEach(() => {
+        fetchMock.doMock();
+    });
+
+    afterEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('returns a success view model with an empty notDeclared list on full acceptance', async () => {
+        MockRucioServerFactory.createMockRucioServer(true, [makeEndpoint(201, [])]);
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: DeclareBadReplicasController = appContainer.get(CONTROLLERS.DECLARE_BAD_REPLICAS);
+
+        await controller.execute({
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            dids: [{ scope: 'test', name: 'susp_1.dat' }],
+            rse: 'MOCK_SUSPICIOUS',
+            reason: 'checksum mismatch',
+        });
+
+        expect(res.statusCode).toBe(200);
+        const viewModel = res._getJSONData() as DeclareBadReplicasViewModel;
+        expect(viewModel.status).toBe('success');
+        expect(viewModel.notDeclared).toEqual([]);
+    });
+
+    it('surfaces replicas the server refused via notDeclared', async () => {
+        MockRucioServerFactory.createMockRucioServer(true, [
+            makeEndpoint(201, [{ scope: 'test', name: 'missing.dat', rse: 'MOCK_SUSPICIOUS', reason: 'No such replica' }]),
+        ]);
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: BaseController<DeclareBadReplicasControllerParameters, DeclareBadReplicasRequest> = appContainer.get(
+            CONTROLLERS.DECLARE_BAD_REPLICAS,
+        );
+
+        await controller.execute({
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            dids: [{ scope: 'test', name: 'missing.dat' }],
+            rse: 'MOCK_SUSPICIOUS',
+            reason: 'checksum mismatch',
+        });
+
+        const viewModel = res._getJSONData() as DeclareBadReplicasViewModel;
+        expect(viewModel.status).toBe('success');
+        expect(viewModel.notDeclared).toHaveLength(1);
+        expect(viewModel.notDeclared[0].name).toBe('missing.dat');
+        expect(viewModel.notDeclared[0].reason).toBe('No such replica');
+    });
+
+    it('propagates a gateway 500 as an error view model', async () => {
+        MockRucioServerFactory.createMockRucioServer(true, [makeEndpoint(500, { error: 'boom' })]);
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: BaseController<DeclareBadReplicasControllerParameters, DeclareBadReplicasRequest> = appContainer.get(
+            CONTROLLERS.DECLARE_BAD_REPLICAS,
+        );
+
+        await controller.execute({
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            dids: [{ scope: 'test', name: 'x' }],
+            rse: 'MOCK_SUSPICIOUS',
+            reason: 'r',
+        });
+
+        expect(res.statusCode).toBeGreaterThanOrEqual(400);
+        const viewModel = res._getJSONData() as DeclareBadReplicasViewModel;
+        expect(viewModel.status).toBe('error');
+        expect(viewModel.errorType).toBe('gateway_error');
+    });
+
+    it('rejects requests with missing reason via the use case validator', async () => {
+        // No endpoint mock — the validator should short-circuit before hitting Rucio.
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: BaseController<DeclareBadReplicasControllerParameters, DeclareBadReplicasRequest> = appContainer.get(
+            CONTROLLERS.DECLARE_BAD_REPLICAS,
+        );
+
+        await controller.execute({
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            dids: [{ scope: 'test', name: 'x' }],
+            rse: 'MOCK_SUSPICIOUS',
+            reason: '   ',
+        });
+
+        const viewModel = res._getJSONData() as DeclareBadReplicasViewModel;
+        expect(viewModel.status).toBe('error');
+        expect(viewModel.errorType).toBe('validation_error');
+        expect(res.statusCode).toBe(400);
+    });
+});
+
+describe('Route: POST /api/feature/declare-bad-replicas', () => {
+    // Stub the auth-gated controller adapter so the route bypasses session
+    // checks and the controller executes against the mocked gateway.
+    let POST: typeof import('@/app/api/feature/declare-bad-replicas/route').POST;
+    let NextRequest: typeof import('next/server').NextRequest;
+
+    beforeAll(() => {
+        jest.doMock('@/lib/infrastructure/adapters/app-router-controller-adapter', () => {
+            const actual = jest.requireActual('@/lib/infrastructure/adapters/app-router-controller-adapter');
+
+            class FakeBufferingResponseAdapter extends Writable {
+                private _statusCode = 200;
+                private _headers: Record<string, string> = { 'Content-Type': 'application/json' };
+                private _data: unknown = null;
+                constructor() {
+                    super({ objectMode: true });
+                }
+                status(code: number) {
+                    this._statusCode = code;
+                    return this;
+                }
+                json(data: unknown) {
+                    this._data = data;
+                    return this;
+                }
+                setHeader(name: string, value: string) {
+                    this._headers[name] = value;
+                    return this;
+                }
+                _write(_chunk: unknown, _enc: BufferEncoding, cb: (e?: Error | null) => void) {
+                    cb();
+                }
+                getStatusCode() {
+                    return this._statusCode;
+                }
+                getData() {
+                    return this._data;
+                }
+                getHeaders() {
+                    return this._headers;
+                }
+            }
+
+            return {
+                __esModule: true,
+                ...actual,
+                executeAuthenticatedController: jest.fn(async (controller: any, parameters: any) => {
+                    const responseAdapter = new FakeBufferingResponseAdapter();
+                    await controller.execute({
+                        ...parameters,
+                        response: responseAdapter,
+                        rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+                    });
+                    const body = responseAdapter.getData();
+                    return new Response(body !== null ? JSON.stringify(body) : '{}', {
+                        status: responseAdapter.getStatusCode(),
+                        headers: responseAdapter.getHeaders(),
+                    });
+                }),
+            };
+        });
+
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        POST = require('@/app/api/feature/declare-bad-replicas/route').POST;
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        NextRequest = require('next/server').NextRequest;
+    });
+
+    beforeEach(() => {
+        fetchMock.doMock();
+        MockRucioServerFactory.createMockRucioServer(true, [makeEndpoint(201, [])]);
+    });
+
+    afterEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('returns 200 + application/json for a valid body', async () => {
+        const request = new NextRequest('http://localhost/api/feature/declare-bad-replicas', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                dids: [{ scope: 'test', name: 'susp_1.dat' }],
+                rse: 'MOCK_SUSPICIOUS',
+                reason: 'checksum mismatch',
+            }),
+        });
+        const response = (await POST(request)) as Response;
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')?.toLowerCase()).toContain('application/json');
+    });
+
+    it('returns 400 when the body fails Zod validation', async () => {
+        const request = new NextRequest('http://localhost/api/feature/declare-bad-replicas', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ rse: 'MOCK_SUSPICIOUS', reason: 'missing-dids' }),
+        });
+        const response = (await POST(request)) as Response;
+        expect(response.status).toBe(400);
+    });
+});

--- a/test/api/replica/list-suspicious-replicas-route.test.ts
+++ b/test/api/replica/list-suspicious-replicas-route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Route handler test for `GET /api/feature/list-suspicious-replicas`.
+ *
+ * Verifies the route returns HTTP 200 and the streaming Content-Type for a
+ * mocked gateway response, covering AC #12 (route returns the correct HTTP
+ * status and content-type).
+ *
+ * The auth-gated controller adapter is stubbed so the route bypasses session
+ * checks and the controller is exercised against the mocked Rucio gateway.
+ * The returned `Response` is constructed using the same `StreamingResponseAdapter`
+ * the production adapter uses, so the Content-Type assertion reflects real
+ * behavior.
+ */
+
+import { Writable } from 'stream';
+
+const FAKE_TOKEN = '3a4d6e9a73fb46bd9e5dc4cbaab1c8af';
+
+// Replace `executeAuthenticatedController` with a stub that mirrors the
+// streaming branch of the production adapter but skips the auth wrapper.
+jest.mock('@/lib/infrastructure/adapters/app-router-controller-adapter', () => {
+    const actual = jest.requireActual('@/lib/infrastructure/adapters/app-router-controller-adapter');
+
+    class FakeStreamingResponseAdapter extends Writable {
+        private _statusCode = 200;
+        private _headers: Record<string, string> = {
+            'Content-Type': 'text/event-stream;charset=utf-8',
+            'Cache-Control': 'no-cache, no-transform',
+            Connection: 'keep-alive',
+        };
+        private _controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+        private _encoder = new TextEncoder();
+        constructor() {
+            super({ objectMode: true });
+        }
+        status(code: number) {
+            this._statusCode = code;
+            return this;
+        }
+        setHeader(name: string, value: string) {
+            this._headers[name] = value;
+            return this;
+        }
+        json(_data: unknown) {
+            return this;
+        }
+        _write(chunk: unknown, _enc: BufferEncoding, cb: (err?: Error | null) => void) {
+            const s = typeof chunk === 'string' ? chunk : Buffer.isBuffer(chunk) ? chunk.toString() : JSON.stringify(chunk) + '\n';
+            this._controller?.enqueue(this._encoder.encode(s));
+            cb();
+        }
+        _final(cb: (err?: Error | null) => void) {
+            try {
+                this._controller?.close();
+            } catch (_e) {
+                // already closed
+            }
+            cb();
+        }
+        createReadableStream(): ReadableStream<Uint8Array> {
+            const self = this;
+            return new ReadableStream<Uint8Array>({
+                start(controller) {
+                    self._controller = controller;
+                },
+            });
+        }
+        getStatusCode() {
+            return this._statusCode;
+        }
+        getHeaders() {
+            return this._headers;
+        }
+    }
+
+    return {
+        __esModule: true,
+        ...actual,
+        executeAuthenticatedController: jest.fn(async (controller: any, parameters: any) => {
+            const responseAdapter = new FakeStreamingResponseAdapter();
+            const stream = responseAdapter.createReadableStream();
+            const params = {
+                ...parameters,
+                response: responseAdapter,
+                session: { user: { rucioAuthToken: FAKE_TOKEN } },
+                rucioAuthToken: FAKE_TOKEN,
+            };
+            // Kick off the controller; chunks are enqueued into the ReadableStream
+            // via the adapter's _write/_final. Return immediately so the response
+            // streams as the controller writes.
+            controller.execute(params);
+            return new Response(stream, {
+                status: responseAdapter.getStatusCode(),
+                headers: responseAdapter.getHeaders(),
+            });
+        }),
+    };
+});
+
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+import { NextRequest } from 'next/server';
+import { GET } from '@/app/api/feature/list-suspicious-replicas/route';
+
+const mockReplicas = [
+    {
+        scope: 'test',
+        name: 'suspicious_test_file_1.dat',
+        rse: 'MOCK_SUSPICIOUS',
+        rse_id: '6762d2e939bd41a89a012f40d038843e',
+        cnt: 3,
+        created_at: 'Wed, 18 Mar 2026 09:08:23 UTC',
+    },
+];
+
+describe('Route: GET /api/feature/list-suspicious-replicas', () => {
+    beforeEach(() => {
+        fetchMock.doMock();
+        const endpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/replicas/suspicious/`,
+            method: 'GET',
+            includes: 'replicas/suspicious',
+            response: {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(mockReplicas),
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [endpoint]);
+    });
+
+    afterEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('returns 200 and a streaming Content-Type for a mocked gateway response', async () => {
+        const request = new NextRequest('http://localhost/api/feature/list-suspicious-replicas');
+        const response = (await GET(request)) as Response;
+
+        expect(response.status).toBe(200);
+        const contentType = response.headers.get('content-type') ?? '';
+        // Streaming endpoints set Content-Type via StreamingResponseAdapter
+        // (`text/event-stream;charset=utf-8`), shared with other feature streams.
+        expect(contentType.toLowerCase()).toContain('text/event-stream');
+    });
+});

--- a/test/api/replica/list-suspicious-replicas-usecase.test.ts
+++ b/test/api/replica/list-suspicious-replicas-usecase.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Unit tests for {@link ListSuspiciousReplicasUseCase}.
+ *
+ * The gateway and presenter are mocked so each scenario exercises a single
+ * code-path through the use case without going through the IoC container.
+ *
+ * Scenarios:
+ *  - happy path: gateway returns a non-empty list → presenter receives one
+ *    success response per DTO via the streaming pipeline.
+ *  - empty result: gateway returns an empty list → presenter receives no
+ *    stream items but the pipeline finishes cleanly.
+ *  - error propagation: gateway returns a status='error' DTO → presenter
+ *    receives a single error model via `presentError`.
+ */
+
+import { Readable, Writable } from 'stream';
+import ListSuspiciousReplicasUseCase from '@/lib/core/use-case/list-suspicious-replicas-usecase';
+import { SuspiciousReplicaDTO, ListSuspiciousReplicasDTO } from '@/lib/core/dto/replica-dto';
+import { AuthenticatedRequestModel } from '@/lib/sdk/usecase-models';
+import {
+    ListSuspiciousReplicasError,
+    ListSuspiciousReplicasRequest,
+    ListSuspiciousReplicasResponse,
+} from '@/lib/core/usecase-models/list-suspicious-replicas-usecase-models';
+import type ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+import { ListSuspiciousReplicasOutputPort } from '@/lib/core/port/primary/list-suspicious-replicas-ports';
+
+type Captured = {
+    responses: ListSuspiciousReplicasResponse[];
+    errors: ListSuspiciousReplicasError[];
+    finished: boolean;
+};
+
+function makeCapturingPresenter(): { presenter: ListSuspiciousReplicasOutputPort; captured: Captured; sink: Writable } {
+    const captured: Captured = { responses: [], errors: [], finished: false };
+
+    const sink = new Writable({
+        objectMode: true,
+        write(chunk, _enc, cb) {
+            if (chunk && chunk.status === 'error') {
+                captured.errors.push(chunk as ListSuspiciousReplicasError);
+            } else if (chunk && chunk.status === 'success') {
+                captured.responses.push(chunk as ListSuspiciousReplicasResponse);
+            }
+            cb();
+        },
+    });
+    sink.on('finish', () => {
+        captured.finished = true;
+    });
+
+    const presenter = {
+        setupStream(transform: NodeJS.ReadWriteStream) {
+            transform.pipe(sink);
+        },
+        presentError(error: ListSuspiciousReplicasError) {
+            captured.errors.push(error);
+        },
+    } as unknown as ListSuspiciousReplicasOutputPort;
+
+    return { presenter, captured, sink };
+}
+
+function makeGatewayReturning(dto: ListSuspiciousReplicasDTO): ReplicaGatewayOutputPort {
+    return { listSuspiciousReplicas: jest.fn().mockResolvedValue(dto) } as unknown as ReplicaGatewayOutputPort;
+}
+
+function makeRequest(): AuthenticatedRequestModel<ListSuspiciousReplicasRequest> {
+    return {
+        rucioAuthToken: 'token',
+        rseExpression: undefined,
+        youngerThan: undefined,
+        nattempts: undefined,
+    } as AuthenticatedRequestModel<ListSuspiciousReplicasRequest>;
+}
+
+const successDTO = (replicas: SuspiciousReplicaDTO[]): ListSuspiciousReplicasDTO => ({
+    status: 'success',
+    replicas,
+});
+
+const sampleReplica: SuspiciousReplicaDTO = {
+    status: 'success',
+    scope: 'test',
+    name: 'file.dat',
+    rse: 'MOCK',
+    rseId: '00000000000000000000000000000001',
+    cnt: 3,
+    createdAt: 'Wed, 18 Mar 2026 09:08:23 UTC',
+};
+
+async function waitForSinkFinish(sink: Writable): Promise<void> {
+    if ((sink as any).writableFinished) return;
+    await new Promise<void>(resolve => sink.once('finish', () => resolve()));
+}
+
+describe('ListSuspiciousReplicasUseCase', () => {
+    it('happy path — streams one response per replica returned by the gateway', async () => {
+        const gateway = makeGatewayReturning(successDTO([sampleReplica, { ...sampleReplica, name: 'other.dat', cnt: 7 }]));
+        const { presenter, captured, sink } = makeCapturingPresenter();
+        const useCase = new ListSuspiciousReplicasUseCase(presenter, gateway);
+
+        await useCase.execute(makeRequest());
+        await waitForSinkFinish(sink);
+
+        expect(gateway.listSuspiciousReplicas).toHaveBeenCalledTimes(1);
+        expect(captured.errors).toHaveLength(0);
+        expect(captured.responses).toHaveLength(2);
+        expect(captured.responses[0]).toMatchObject({ status: 'success', rse: 'MOCK', name: 'file.dat', cnt: 3 });
+        expect(captured.responses[1]).toMatchObject({ name: 'other.dat', cnt: 7 });
+    });
+
+    it('empty result — gateway returns no replicas; pipeline finishes with no items', async () => {
+        const gateway = makeGatewayReturning(successDTO([]));
+        const { presenter, captured, sink } = makeCapturingPresenter();
+        const useCase = new ListSuspiciousReplicasUseCase(presenter, gateway);
+
+        await useCase.execute(makeRequest());
+        await waitForSinkFinish(sink);
+
+        expect(captured.responses).toHaveLength(0);
+        expect(captured.errors).toHaveLength(0);
+        expect(captured.finished).toBe(true);
+    });
+
+    it('error propagation — gateway returns an error DTO; presenter receives a single error model', async () => {
+        const gateway = makeGatewayReturning({
+            status: 'error',
+            replicas: [],
+            errorCode: 503,
+            errorName: 'GatewayUnavailable',
+            errorMessage: 'upstream is down',
+            errorType: 'gateway_endpoint_error',
+        } as ListSuspiciousReplicasDTO);
+        const { presenter, captured } = makeCapturingPresenter();
+        const useCase = new ListSuspiciousReplicasUseCase(presenter, gateway);
+
+        await useCase.execute(makeRequest());
+
+        expect(captured.errors).toHaveLength(1);
+        expect(captured.errors[0]).toMatchObject({ status: 'error', code: 503, name: 'GatewayUnavailable' });
+        expect(captured.responses).toHaveLength(0);
+    });
+
+    it('processStreamedData converts a DTO into a success response model', () => {
+        const gateway = makeGatewayReturning(successDTO([]));
+        const { presenter } = makeCapturingPresenter();
+        const useCase = new ListSuspiciousReplicasUseCase(presenter, gateway);
+
+        const result = useCase.processStreamedData(sampleReplica);
+        expect(result.status).toBe('success');
+        expect(result.data).toMatchObject({ status: 'success', rse: 'MOCK', cnt: 3 });
+    });
+
+    it('processStreamedData converts an error DTO into an error model', () => {
+        const gateway = makeGatewayReturning(successDTO([]));
+        const { presenter } = makeCapturingPresenter();
+        const useCase = new ListSuspiciousReplicasUseCase(presenter, gateway);
+
+        const result = useCase.processStreamedData({
+            status: 'error',
+            scope: '',
+            name: '',
+            rse: '',
+            rseId: '',
+            cnt: 0,
+            createdAt: '',
+            errorCode: 502,
+            errorName: 'BadGateway',
+            errorMessage: 'oops',
+        } as unknown as SuspiciousReplicaDTO);
+
+        expect(result.status).toBe('error');
+        expect(result.data).toMatchObject({ status: 'error', code: 502, name: 'BadGateway' });
+    });
+
+    // Ensure the Readable.from(...) used as the source stream emits to the pipeline.
+    it('streams arrays via Readable.from when the gateway returns multiple items', async () => {
+        const items: SuspiciousReplicaDTO[] = Array.from({ length: 5 }, (_, i) => ({
+            ...sampleReplica,
+            name: `file_${i}.dat`,
+            cnt: i,
+        }));
+        const gateway = makeGatewayReturning(successDTO(items));
+        const { presenter, captured, sink } = makeCapturingPresenter();
+        const useCase = new ListSuspiciousReplicasUseCase(presenter, gateway);
+
+        await useCase.execute(makeRequest());
+        await waitForSinkFinish(sink);
+
+        expect(captured.responses.map(r => r.cnt)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('does not error if Readable.from is called with an empty array', async () => {
+        const gateway = makeGatewayReturning(successDTO([]));
+        const { presenter, sink } = makeCapturingPresenter();
+        const useCase = new ListSuspiciousReplicasUseCase(presenter, gateway);
+
+        const src = Readable.from([]);
+        await new Promise<void>(resolve => {
+            src.on('end', resolve);
+            src.resume();
+        });
+
+        await useCase.execute(makeRequest());
+        await waitForSinkFinish(sink);
+    });
+});

--- a/test/api/replica/list-suspicious-replicas.test.ts
+++ b/test/api/replica/list-suspicious-replicas.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the list-suspicious-replicas feature.
+ *
+ * Coverage:
+ *  - Controller-level: happy path streams view models, empty result, gateway error
+ *    (mirrors the pattern used by other replica feature tests in this directory).
+ *  - Route-level: `GET /api/feature/list-suspicious-replicas` returns 200 with the
+ *    streaming Content-Type for a mocked gateway response.
+ */
+
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
+import { BaseController } from '@/lib/sdk/controller';
+import ListSuspiciousReplicasController, {
+    ListSuspiciousReplicasControllerParameters,
+} from '@/lib/infrastructure/controller/list-suspicious-replicas-controller';
+import { MockHttpStreamableResponseFactory } from 'test/fixtures/http-fixtures';
+import { NextApiResponse } from 'next';
+import { SuspiciousReplicaViewModel } from '@/lib/infrastructure/data/view-model/replica';
+import { collectStreamedData } from 'test/fixtures/stream-test-utils';
+
+const mockReplicas = [
+    {
+        scope: 'test',
+        name: 'suspicious_test_file_1.dat',
+        rse: 'MOCK_SUSPICIOUS',
+        rse_id: '6762d2e939bd41a89a012f40d038843e',
+        cnt: 3,
+        created_at: 'Wed, 18 Mar 2026 09:08:23 UTC',
+    },
+    {
+        scope: 'test',
+        name: 'suspicious_test_file_2.dat',
+        rse: 'MOCK_SUSPICIOUS_OTHER',
+        rse_id: 'aaaabbbbccccddddeeeeffff00001111',
+        cnt: 5,
+        created_at: 'Wed, 18 Mar 2026 10:08:23 UTC',
+    },
+];
+
+const makeEndpoint = (status: number, body: unknown): MockEndpoint => ({
+    url: `${MockRucioServerFactory.RUCIO_HOST}/replicas/suspicious/`,
+    method: 'GET',
+    includes: 'replicas/suspicious',
+    response: {
+        status,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+    },
+});
+
+describe('Feature: ListSuspiciousReplicas (controller)', () => {
+    beforeEach(() => {
+        fetchMock.doMock();
+    });
+
+    afterEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('streams view models for a successful gateway response', async () => {
+        MockRucioServerFactory.createMockRucioServer(true, [makeEndpoint(200, mockReplicas)]);
+
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: ListSuspiciousReplicasController = appContainer.get(CONTROLLERS.LIST_SUSPICIOUS_REPLICAS);
+
+        const params: ListSuspiciousReplicasControllerParameters = {
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+        };
+        await controller.execute(params);
+
+        const received = await collectStreamedData<string>(res);
+        const parsed = received.map(d => JSON.parse(d)) as SuspiciousReplicaViewModel[];
+
+        expect(parsed.length).toBe(2);
+        expect(parsed[0].status).toBe('success');
+        expect(parsed[0].rse).toBe('MOCK_SUSPICIOUS');
+        expect(parsed[0].name).toBe('suspicious_test_file_1.dat');
+        expect(parsed[1].cnt).toBe(5);
+    });
+
+    it('produces an empty stream when the gateway returns no replicas', async () => {
+        MockRucioServerFactory.createMockRucioServer(true, [makeEndpoint(200, [])]);
+
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: BaseController<ListSuspiciousReplicasControllerParameters, unknown> = appContainer.get(
+            CONTROLLERS.LIST_SUSPICIOUS_REPLICAS,
+        );
+
+        await controller.execute({
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+        });
+
+        const received = await collectStreamedData<string>(res);
+        expect(received.length).toBe(0);
+    });
+
+    it('propagates a gateway error as an error view model', async () => {
+        MockRucioServerFactory.createMockRucioServer(true, [makeEndpoint(500, { error: 'boom' })]);
+
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: BaseController<ListSuspiciousReplicasControllerParameters, unknown> = appContainer.get(
+            CONTROLLERS.LIST_SUSPICIOUS_REPLICAS,
+        );
+
+        await controller.execute({
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+        });
+
+        // The streaming presenter writes a JSON error body to the response on gateway failure.
+        expect(res.statusCode).toBeGreaterThanOrEqual(400);
+        const errBody = res._getJSONData();
+        expect(errBody).toBeDefined();
+        expect(errBody.errorType ?? errBody.status).toBeTruthy();
+    });
+
+    it('forwards query parameters to the gateway request', async () => {
+        const endpoint: MockEndpoint = {
+            ...makeEndpoint(200, mockReplicas),
+            requestValidator: async request => {
+                const url = request.url;
+                if (!url.includes('rse_expression=tier%3D1')) return false;
+                if (!url.includes('nattempts=5')) return false;
+                if (!url.includes('younger_than=')) return false;
+                return true;
+            },
+        };
+        MockRucioServerFactory.createMockRucioServer(true, [endpoint]);
+
+        const res = MockHttpStreamableResponseFactory.getMockResponse();
+        const controller: BaseController<ListSuspiciousReplicasControllerParameters, unknown> = appContainer.get(
+            CONTROLLERS.LIST_SUSPICIOUS_REPLICAS,
+        );
+
+        await controller.execute({
+            response: res as unknown as NextApiResponse,
+            rucioAuthToken: MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            rseExpression: 'tier=1',
+            youngerThan: '2026-01-01T00:00:00.000Z',
+            nattempts: 5,
+        });
+
+        const received = await collectStreamedData<string>(res);
+        const parsed = received.map(d => JSON.parse(d)) as SuspiciousReplicaViewModel[];
+        expect(parsed.length).toBe(2);
+    });
+});
+

--- a/test/fixtures/table-fixtures.ts
+++ b/test/fixtures/table-fixtures.ts
@@ -36,6 +36,7 @@ import {
 } from '@/lib/infrastructure/data/view-model/did';
 import { ApproveRuleViewModel, RuleMetaViewModel, RulePageLockEntryViewModel, RuleViewModel } from '@/lib/infrastructure/data/view-model/rule';
 import { ListDIDsViewModel } from '@/lib/infrastructure/data/view-model/list-did';
+import { SuspiciousReplicaViewModel } from '@/lib/infrastructure/data/view-model/replica';
 import useStreamReader, { StreamingSettings, StreamingStatus } from '@/lib/infrastructure/hooks/useStreamReader';
 
 export function mockUseComDOM<T extends BaseViewModel>(data: T[]): UseComDOM<T> {
@@ -466,4 +467,16 @@ export function generateSequenceArray(length: number, generator: () => any): any
         result.push(generator());
     }
     return result;
+}
+
+export function fixtureSuspiciousReplicaViewModel(): SuspiciousReplicaViewModel {
+    return {
+        ...mockBaseVM(),
+        scope: createRandomScope(),
+        name: faker.lorem.words(3).replace(/\s/g, '.'),
+        rse: createRSEName(),
+        rseId: faker.string.uuid().replace(/-/g, ''),
+        cnt: faker.number.int({ min: 1, max: 100 }),
+        createdAt: faker.date.past().toISOString(),
+    };
 }

--- a/test/gateway/replica/replica-gateway-declare-bad-replicas.test.ts
+++ b/test/gateway/replica/replica-gateway-declare-bad-replicas.test.ts
@@ -1,0 +1,70 @@
+import MockRucioServerFactory, { MockEndpoint } from 'test/fixtures/rucio-server';
+import ReplicaGatewayOutputPort from '@/lib/core/port/secondary/replica-gateway-output-port';
+import appContainer from '@/lib/infrastructure/ioc/container-config';
+import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
+import { DeclareBadReplicasDTO } from '@/lib/core/dto/replica-dto';
+
+const endpointBuilder = (status: number, body: unknown): MockEndpoint => ({
+    url: `${MockRucioServerFactory.RUCIO_HOST}/replicas/bad/dids/`,
+    method: 'POST',
+    includes: 'replicas/bad/dids',
+    response: {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+    },
+});
+
+describe('Replica Gateway: Declare Bad Replicas', () => {
+    afterEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    it('returns success with an empty notDeclared list when Rucio accepts every DID', async () => {
+        fetchMock.doMock();
+        MockRucioServerFactory.createMockRucioServer(true, [endpointBuilder(201, [])]);
+
+        const gateway: ReplicaGatewayOutputPort = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+        const dto: DeclareBadReplicasDTO = await gateway.declareBadReplicas(
+            MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            [{ scope: 'test', name: 'susp_1.dat' }],
+            'MOCK_SUSPICIOUS',
+            'checksum mismatch',
+        );
+        expect(dto.status).toBe('success');
+        expect(dto.notDeclared).toEqual([]);
+    });
+
+    it('surfaces replicas that Rucio refused to mark bad', async () => {
+        fetchMock.doMock();
+        MockRucioServerFactory.createMockRucioServer(true, [
+            endpointBuilder(201, [{ scope: 'test', name: 'susp_2.dat', rse: 'MOCK_SUSPICIOUS', reason: 'No such replica' }]),
+        ]);
+
+        const gateway: ReplicaGatewayOutputPort = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+        const dto: DeclareBadReplicasDTO = await gateway.declareBadReplicas(
+            MockRucioServerFactory.VALID_RUCIO_TOKEN,
+            [{ scope: 'test', name: 'susp_2.dat' }],
+            'MOCK_SUSPICIOUS',
+            'checksum mismatch',
+        );
+        expect(dto.status).toBe('success');
+        expect(dto.notDeclared).toHaveLength(1);
+        expect(dto.notDeclared[0]).toEqual({
+            scope: 'test',
+            name: 'susp_2.dat',
+            rse: 'MOCK_SUSPICIOUS',
+            reason: 'No such replica',
+        });
+    });
+
+    it('returns an error DTO on auth failure', async () => {
+        fetchMock.doMock();
+        MockRucioServerFactory.createMockRucioServer(true, [endpointBuilder(201, [])]);
+
+        const gateway: ReplicaGatewayOutputPort = appContainer.get<ReplicaGatewayOutputPort>(GATEWAYS.REPLICA);
+        const dto: DeclareBadReplicasDTO = await gateway.declareBadReplicas('invalid-token', [{ scope: 'test', name: 'x' }], 'MOCK', 'r');
+        expect(dto.status).toBe('error');
+        expect(dto.errorCode).toBe(401);
+    });
+});


### PR DESCRIPTION
## Summary
Adds `/suspicious-replicas`, a page that streams suspicious file replicas from Rucio's `GET /replicas/suspicious/` and exposes per-row + multi-row **Declare bad** actions backed by `POST /replicas/bad/dids`. Closes #710.

## Highlights
- ag-Grid table with filter panel (RSE expression, younger-than, min attempts threshold) and a per-row View link to the DID page.
- Multi-select checkboxes + bulk toolbar; bulk submissions are grouped by RSE client-side and dispatched as one POST per RSE (Rucio's endpoint takes a single RSE per call).
- DeclareBadReplicaDialog handles single + bulk targets with required reason and optional `expires_at` (with Clear).
- Full hexagonal stack: ports, use cases, controllers, presenters, IoC features, and new replica-gateway endpoint for declare-bad-replicas.
- Discoverability: nav entry under a new DIDs dropdown, command palette entry, dashboard bookmark widget integration.
- Tips & suggestions banner documenting threshold semantics (`cnt > N`), bulk behavior, and irreversibility.
