### PR TITLE
fix: FEATURE_DDM_DASHBOARD env var parsing is case-sensitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rucio-webui",
-  "version": "39.3.5",
+  "version": "40.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rucio-webui",
-      "version": "39.3.5",
+      "version": "40.1.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@preact/signals": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rucio-webui",
-  "version": "39.3.5",
+  "version": "40.1.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .next .swc build",

--- a/src/app/(rucio)/rule/[id]/page.tsx
+++ b/src/app/(rucio)/rule/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { DetailsRule } from '@/component-library/pages/Rule/details/DetailsRule';
+import { parseBoolEnv } from '@/lib/core/utils/env-utils';
 
 export const metadata = {
     title: 'Rule - Rucio',
@@ -6,7 +7,7 @@ export const metadata = {
 
 export default async function PageRule({ params }: { params: Promise<{ id: string }> }) {
     const { id } = await params;
-    const featureDDMDashboard = process.env.FEATURE_DDM_DASHBOARD === 'true';
+    const featureDDMDashboard = parseBoolEnv(process.env.FEATURE_DDM_DASHBOARD);
 
     return (
         <main className="min-h-screen bg-neutral-0 dark:bg-neutral-900 transition-colors duration-200">

--- a/src/lib/core/use-case/get-ddm-link-usecase.ts
+++ b/src/lib/core/use-case/get-ddm-link-usecase.ts
@@ -5,6 +5,7 @@ import { GetDDMLinkRequest, GetDDMLinkResponse } from '@/lib/core/usecase-models
 import { GetDDMLinkInputPort, type GetDDMLinkOutputPort } from '@/lib/core/port/primary/get-ddm-link-ports';
 import type EnvConfigGatewayOutputPort from '@/lib/core/port/secondary/env-config-gateway-output-port';
 import { createDDMDashboardUrl } from '@/lib/core/utils/ddm-link-utils';
+import { parseBoolEnv } from '@/lib/core/utils/env-utils';
 
 @injectable()
 export default class GetDDMLinkUseCase implements GetDDMLinkInputPort {
@@ -17,7 +18,7 @@ export default class GetDDMLinkUseCase implements GetDDMLinkInputPort {
         const { scope, name, rse } = requestModel;
 
         const featureFlag = await this.envConfigGateway.get('FEATURE_DDM_DASHBOARD');
-        if (!featureFlag || featureFlag.toLowerCase() !== 'true') {
+        if (!parseBoolEnv(featureFlag)) {
             await this.presenter.presentError({
                 status: 'error',
                 message: 'DDM Dashboard feature is disabled',

--- a/src/lib/core/utils/env-utils.ts
+++ b/src/lib/core/utils/env-utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Parses a boolean-like environment variable string.
+ * Accepts 'true', '1', 'yes', 'on' (case-insensitive, trimmed) as truthy.
+ */
+export function parseBoolEnv(value: string | undefined): boolean {
+    if (!value) return false;
+    const normalised = value.trim().toLowerCase();
+    return normalised === 'true' || normalised === '1' || normalised === 'yes' || normalised === 'on';
+}

--- a/test/api/request/get-ddm-link.test.ts
+++ b/test/api/request/get-ddm-link.test.ts
@@ -1,4 +1,5 @@
 import GetDDMLinkUseCase from '@/lib/core/use-case/get-ddm-link-usecase';
+import { parseBoolEnv } from '@/lib/core/utils/env-utils';
 import { GetDDMLinkOutputPort } from '@/lib/core/port/primary/get-ddm-link-ports';
 import {
     ConfigNotFoundError,
@@ -64,6 +65,23 @@ const BASE_REQUEST: AuthenticatedRequestModel<GetDDMLinkRequest> = {
     name: 'file1',
     rse: 'XRD1',
 };
+
+// ---------------------------------------------------------------------------
+// parseBoolEnv unit tests
+// ---------------------------------------------------------------------------
+
+describe('parseBoolEnv', () => {
+    const truthyValues: Array<string | undefined> = ['true', 'True', 'TRUE', '1', 'yes', 'YES', 'on', 'ON', ' true '];
+    const falsyValues: Array<string | undefined> = ['false', '0', 'no', 'off', '', undefined];
+
+    it.each(truthyValues)('should return true for %p', (value) => {
+        expect(parseBoolEnv(value)).toBe(true);
+    });
+
+    it.each(falsyValues)('should return false for %p', (value) => {
+        expect(parseBoolEnv(value)).toBe(false);
+    });
+});
 
 // ---------------------------------------------------------------------------
 // createDDMDashboardUrl unit tests
@@ -142,6 +160,38 @@ describe('GetDDMLinkUseCase', () => {
         expect(presenter.lastError).toBeUndefined();
         expect(presenter.lastSuccess).toBeDefined();
     });
+
+    const additionalTruthyFlags = ['1', 'yes', 'YES', 'on', 'ON', ' true '];
+    it.each(additionalTruthyFlags)(
+        'should treat feature flag value %p as truthy and present success',
+        async (flagValue) => {
+            const presenter = makePresenter();
+            const envConfig = makeEnvConfig({ FEATURE_DDM_DASHBOARD: flagValue });
+            const useCase = new GetDDMLinkUseCase(presenter, envConfig);
+
+            await useCase.execute(BASE_REQUEST);
+
+            expect(presenter.lastError).toBeUndefined();
+            expect(presenter.lastSuccess).toBeDefined();
+        },
+    );
+
+    const additionalFalsyFlags = ['0', 'no', 'off', 'NO', 'OFF'];
+    it.each(additionalFalsyFlags)(
+        'should treat feature flag value %p as falsy and present FeatureDisabledError',
+        async (flagValue) => {
+            const presenter = makePresenter();
+            const envConfig = makeEnvConfig({ FEATURE_DDM_DASHBOARD: flagValue });
+            const useCase = new GetDDMLinkUseCase(presenter, envConfig);
+
+            await useCase.execute(BASE_REQUEST);
+
+            expect(presenter.lastError).toBeDefined();
+            expect((presenter.lastError as FeatureDisabledError).type).toBe('FeatureDisabledError');
+            expect(presenter.lastError!.code).toBe(403);
+            expect(presenter.lastSuccess).toBeUndefined();
+        },
+    );
 
     it('should call presentError with ConfigNotFoundError (code 500) when base URL is undefined', async () => {
         const presenter = makePresenter();

--- a/tools/env-generator/src/api/base.ts
+++ b/tools/env-generator/src/api/base.ts
@@ -3,6 +3,16 @@ import { Liquid } from "liquidjs";
 import { readFileSync, writeFileSync } from "fs";
 import crypto from "crypto";
 
+/**
+ * Parses a boolean-like environment variable string.
+ * Accepts 'true', '1', 'yes', 'on' (case-insensitive, trimmed) as truthy.
+ */
+function parseBoolEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalised = value.trim().toLowerCase();
+  return normalised === 'true' || normalised === '1' || normalised === 'yes' || normalised === 'on';
+}
+
 
 export type TTemplateGeneratorOutput = {
   status: boolean,
@@ -185,7 +195,7 @@ export class WebUIEnvTemplateCompiler {
     })
 
     // check if DDM Dashboard feature is enabled, the base URL must be set
-    if (env['FEATURE_DDM_DASHBOARD'] === 'true') {
+    if (parseBoolEnv(env['FEATURE_DDM_DASHBOARD'])) {
       const ddmBaseUrl = env['DDM_DASHBOARD_BASE_URL']
       if (!ddmBaseUrl || ddmBaseUrl.trim() === '') {
         errors.push({


### PR DESCRIPTION
## Summary

Closes #783

- Introduces a `parseBoolEnv` utility that accepts `true`, `1`, `yes`, `on` (case-insensitive, trimmed) as truthy values
- Replaces all hardcoded `=== 'true'` checks for `FEATURE_DDM_DASHBOARD` with `parseBoolEnv`
- Adds `parseBoolEnv` locally in the env-generator tool for the same fix

## Changes

The `FEATURE_DDM_DASHBOARD` env var was previously checked with a strict `=== 'true'` comparison, causing the feature to remain disabled when users set the value as `True`, `TRUE`, `1`, `yes`, or `on`. The new `parseBoolEnv` helper normalises the value (trim + lowercase) before comparison, making the check consistent with common Unix/Docker conventions. Tests cover all truthy and falsy variants.