### PR TITLE
fix: Suspicious Replicas page - better styling, error management and access control

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rucio-webui",
-  "version": "39.3.5",
+  "version": "40.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rucio-webui",
-      "version": "39.3.5",
+      "version": "40.1.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@preact/signals": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rucio-webui",
-  "version": "39.3.5",
+  "version": "40.1.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .next .swc build",

--- a/src/app/(rucio)/suspicious-replicas/page.tsx
+++ b/src/app/(rucio)/suspicious-replicas/page.tsx
@@ -1,6 +1,19 @@
+import { getSessionUser } from '@/lib/infrastructure/auth/nextauth-session-utils';
+import { Role } from '@/lib/core/entity/auth-models';
+import { redirect } from 'next/navigation';
 import { ListSuspiciousReplicas } from '@/component-library/pages/Replica/suspicious/ListSuspiciousReplicas';
 
 export default async function Page() {
+    const user = await getSessionUser();
+
+    if (!user || !user.isLoggedIn) {
+        redirect('/');
+    }
+
+    if (user.role !== Role.ADMIN) {
+        redirect('/');
+    }
+
     return (
         <main className="min-h-screen bg-neutral-0 dark:bg-neutral-900 transition-colors duration-200">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 lg:py-10">

--- a/src/component-library/atoms/legacy/input/DateInput/DateInput.tsx
+++ b/src/component-library/atoms/legacy/input/DateInput/DateInput.tsx
@@ -53,6 +53,7 @@ export const DateInput: React.FC<DateInputProps> = ({
                     'disabled:cursor-not-allowed disabled:opacity-50',
                     className ?? '',
                 )}
+                wrapperClassName="w-full block"
                 dateFormat={'yyyy-MM-dd'}
                 placeholderText={placeholder}
                 disabled={disabled}

--- a/src/component-library/features/command-palette/CommandPalette.tsx
+++ b/src/component-library/features/command-palette/CommandPalette.tsx
@@ -22,6 +22,8 @@ import { ClockIcon, BookmarkIcon } from '@heroicons/react/24/outline';
 import { useQuery } from '@tanstack/react-query';
 import { SiteHeaderViewModel } from '@/lib/infrastructure/data/view-model/site-header';
 import { usePermissions } from '@/lib/infrastructure/hooks/usePermissions';
+import { useSession } from 'next-auth/react';
+import { Role } from '@/lib/core/entity/auth-models';
 
 export interface CommandPaletteProps {
     /** Whether the palette is open */
@@ -53,6 +55,8 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChan
 
     const { check, isReady } = usePermissions();
     const canViewApprovalQueue = isReady ? check('rule', 'viewApprovalQueue') : false;
+    const { data: session } = useSession();
+    const isAdmin = session?.user?.role === Role.ADMIN;
 
     // Build all sections with filtering
     const sections = useMemo<CommandSection[]>(() => {
@@ -102,7 +106,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChan
         }
 
         // Navigation Section
-        const navigationItems = getNavigationCommands(account, canViewApprovalQueue);
+        const navigationItems = getNavigationCommands(account, canViewApprovalQueue, isAdmin);
         allSections.push({
             id: 'navigation',
             title: 'Navigation',
@@ -144,7 +148,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ open, onOpenChan
         }
 
         return allSections;
-    }, [searchQuery, account, canViewApprovalQueue]);
+    }, [searchQuery, account, canViewApprovalQueue, isAdmin]);
 
     // Calculate total items count for keyboard navigation
     const totalItems = useMemo(() => {

--- a/src/component-library/features/layout/HeaderClient.tsx
+++ b/src/component-library/features/layout/HeaderClient.tsx
@@ -18,6 +18,7 @@ import { buildSubscriptionSearchUrl } from '@/lib/infrastructure/utils/navigatio
 import { usePermissions } from '@/lib/infrastructure/hooks/usePermissions';
 import { useSessionMonitor } from '@/lib/infrastructure/auth/session-monitor';
 import { useSession } from 'next-auth/react';
+import { Role } from '@/lib/core/entity/auth-models';
 import { useCommandPalette } from '@/lib/infrastructure/hooks/useCommandPalette';
 
 type TMenuItem = {
@@ -272,7 +273,8 @@ export const HeaderClient = ({ siteHeader, siteHeaderError, isSiteHeaderFetching
     const subscriptionUrl = buildSubscriptionSearchUrl(siteHeader?.activeAccount?.rucioAccount);
 
     const { manualSignOut } = useSessionMonitor();
-    const { update } = useSession();
+    const { data: session, update } = useSession();
+    const isAdmin = session?.user?.role === Role.ADMIN;
     const { check, isReady } = usePermissions();
 
     const handleSwitchAccount = async (account: string) => {
@@ -295,17 +297,22 @@ export const HeaderClient = ({ siteHeader, siteHeaderError, isSiteHeaderFetching
         ...(canViewApprovalQueue ? [{ title: 'Approve Rules', path: '/rules/approve?autoSearch=true' }] : []),
     ];
 
-    const didsChildren: TMenuItem[] = [
-        { title: 'List DIDs', path: '/dids' },
-        { title: 'Suspicious Replicas', path: '/suspicious-replicas' },
-    ];
+    // Suspicious Replicas is an admin-only surface (the page itself redirects
+    // non-admins). For non-admins the DIDs entry has no submenu and links
+    // straight to /dids instead of rendering an empty dropdown.
+    const didsItem: TFullMenuItem = isAdmin
+        ? {
+              title: 'DIDs',
+              children: [
+                  { title: 'List DIDs', path: '/dids' },
+                  { title: 'Suspicious Replicas', path: '/suspicious-replicas' },
+              ],
+          }
+        : { title: 'DIDs', path: '/dids' };
 
     const menuItems: TFullMenuItem[] = [
         { title: 'Dashboard', path: '/dashboard' },
-        {
-            title: 'DIDs',
-            children: didsChildren,
-        },
+        didsItem,
         { title: 'RSEs', path: '/rses' },
         { title: 'Subscriptions', path: subscriptionUrl },
         {

--- a/src/component-library/features/table/overlays/NoLoadedRowsOverlay.tsx
+++ b/src/component-library/features/table/overlays/NoLoadedRowsOverlay.tsx
@@ -12,10 +12,22 @@ export const NoLoadedRowsOverlay = (props: { error?: StreamingError; status: Str
                 </p>
             );
         } else if (props.error.type !== StreamingErrorType.BAD_METHOD_CALL) {
+            // Prefer the server-supplied message (e.g. "Problem with parentheses."
+            // from an invalid RSE expression). Rucio status codes are not always
+            // a clean 400 for input-validation errors, so we don't gate this on
+            // error.type — the streaming pipeline only ever populates `message`
+            // with actionable text. Fall back to generic copy when absent (e.g.
+            // raw network failures with no body).
+            const serverMessage = props.error.message?.trim();
+            const hasServerMessage = !!serverMessage;
+            const primary = hasServerMessage ? serverMessage : 'Something went wrong while loading data.';
+            const secondary = hasServerMessage
+                ? 'Adjust your filters and search again.'
+                : 'Check your network connection and try searching again.';
             return (
                 <div className="flex flex-col items-center gap-1 text-center px-4">
-                    <p className="text-sm font-medium text-neutral-700 dark:text-neutral-100">Something went wrong while loading data.</p>
-                    <p className="text-xs text-neutral-500 dark:text-neutral-400">Check your network connection and try searching again.</p>
+                    <p className="text-sm font-medium text-neutral-700 dark:text-neutral-100">{primary}</p>
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400">{secondary}</p>
                 </div>
             );
         }

--- a/src/component-library/features/table/overlays/NoLoadedRowsOverlay.tsx
+++ b/src/component-library/features/table/overlays/NoLoadedRowsOverlay.tsx
@@ -4,14 +4,18 @@ import React from 'react';
 import { NoDataYetOverlay } from '@/component-library/features/table/overlays/NoDataYetOverlay';
 
 export const NoLoadedRowsOverlay = (props: { error?: StreamingError; status: StreamingStatus }) => {
-    // TODO: add icons
     if (props.error) {
         if (props.error.type === StreamingErrorType.NOT_FOUND) {
-            return <div className="text-neutral-700 dark:text-neutral-100">Nothing found</div>;
+            return (
+                <p className="text-sm text-neutral-700 dark:text-neutral-100 text-center px-4">
+                    No results found. Try adjusting your filters and searching again.
+                </p>
+            );
         } else if (props.error.type !== StreamingErrorType.BAD_METHOD_CALL) {
             return (
-                <div className="text-neutral-700 dark:text-neutral-100">
-                    An <b>error</b> has occurred
+                <div className="flex flex-col items-center gap-1 text-center px-4">
+                    <p className="text-sm font-medium text-neutral-700 dark:text-neutral-100">Something went wrong while loading data.</p>
+                    <p className="text-xs text-neutral-500 dark:text-neutral-400">Check your network connection and try searching again.</p>
                 </div>
             );
         }

--- a/src/component-library/features/utils/BaseViewModelValidator.ts
+++ b/src/component-library/features/utils/BaseViewModelValidator.ts
@@ -16,7 +16,7 @@ export class BaseViewModelValidator {
         this.toast({
             variant: 'error',
             title: `Failed to resolve ${this.invalidCount} element${plural}`,
-            description: 'Please see the console for details.',
+            description: model.message || 'Please see the console for details.',
         });
         console.error(`Invalid element\nStatus: ${model.status}\nMessage: ${model.message}`);
         return false;

--- a/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.stories.tsx
+++ b/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.stories.tsx
@@ -2,6 +2,7 @@ import { StoryFn, Meta } from '@storybook/nextjs';
 import { fixtureSuspiciousReplicaViewModel } from '@/test/fixtures/table-fixtures';
 import { ListSuspiciousReplicas } from '@/component-library/pages/Replica/suspicious/ListSuspiciousReplicas';
 import { ToastedTemplate } from '@/component-library/templates/ToastedTemplate/ToastedTemplate';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 export default {
     title: 'Components/Pages/Replica/ListSuspiciousReplicas',
@@ -11,11 +12,16 @@ export default {
     },
 } as Meta<typeof ListSuspiciousReplicas>;
 
-const Template: StoryFn<typeof ListSuspiciousReplicas> = args => (
-    <ToastedTemplate>
-        <ListSuspiciousReplicas {...args} />
-    </ToastedTemplate>
-);
+const Template: StoryFn<typeof ListSuspiciousReplicas> = args => {
+    const queryClient = new QueryClient();
+    return (
+        <QueryClientProvider client={queryClient}>
+            <ToastedTemplate>
+                <ListSuspiciousReplicas {...args} />
+            </ToastedTemplate>
+        </QueryClientProvider>
+    );
+};
 
 /** Empty grid — no initial data and no streaming endpoint. */
 export const Empty = Template.bind({});

--- a/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.tsx
+++ b/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.tsx
@@ -26,9 +26,19 @@ type ListSuspiciousReplicasProps = {
     initialData?: SuspiciousReplicaViewModel[];
 };
 
-function FilterField({ children, label, htmlFor }: { children: React.ReactNode; label: string; htmlFor: string }) {
+function FilterField({
+    children,
+    label,
+    htmlFor,
+    className,
+}: {
+    children: React.ReactNode;
+    label: string;
+    htmlFor: string;
+    className?: string;
+}) {
     return (
-        <div className="grow flex-1">
+        <div className={cn('flex-1', className)}>
             <label htmlFor={htmlFor} className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">
                 {label}
             </label>
@@ -204,7 +214,7 @@ export const ListSuspiciousReplicas = (props: ListSuspiciousReplicasProps) => {
         <div className="flex flex-col space-y-6 w-full">
             {/* Tips & suggestions — collapsible info banner. Page-local so the
                 content stays specific to suspicious-replicas workflows. */}
-            <div className="rounded-md bg-base-info-50 dark:bg-base-info-900 text-sm text-base-info-700 dark:text-base-info-200">
+            <div className="rounded-md bg-base-info-100 dark:bg-base-info-900 text-sm text-base-info-700 dark:text-base-info-200">
                 <button
                     type="button"
                     className="flex w-full items-center gap-2 p-3 text-left"
@@ -257,11 +267,23 @@ export const ListSuspiciousReplicas = (props: ListSuspiciousReplicasProps) => {
                 )}
             </div>
 
+            {/* Streaming status strip — visible only while a stream is in progress */}
+            {isRunning && (
+                <div
+                    role="status"
+                    aria-live="polite"
+                    className="flex items-center gap-2 rounded-md bg-base-info-100 dark:bg-base-info-900 text-base-info-700 dark:text-base-info-200 px-3 py-2 text-sm"
+                >
+                    <HiInformationCircle className="h-5 w-5 shrink-0" aria-hidden="true" />
+                    <span>Loading results - data streams progressively and may take a moment to complete.</span>
+                </div>
+            )}
+
             {/* Filter Panel */}
             <div className="rounded-lg bg-neutral-0 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 shadow-sm p-6">
-                <div className="flex flex-col space-y-4 sm:flex-row sm:space-y-0 sm:space-x-4 items-end">
+                <div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-4 items-end">
                     <div className="flex flex-col w-full space-y-4">
-                        <div className="flex flex-col sm:flex-row w-full gap-4">
+                        <div className="flex flex-col md:flex-row w-full gap-4">
                             <FilterField label="RSE Expression" htmlFor="suspicious-rse-expression">
                                 <Input
                                     id="suspicious-rse-expression"
@@ -280,7 +302,7 @@ export const ListSuspiciousReplicas = (props: ListSuspiciousReplicasProps) => {
                                     placeholder="Select date"
                                 />
                             </FilterField>
-                            <FilterField label="Min Attempts Threshold" htmlFor="suspicious-nattempts">
+                            <FilterField label="Min Attempts Threshold" htmlFor="suspicious-nattempts" className="sm:max-w-[160px]">
                                 <Input
                                     id="suspicious-nattempts"
                                     className="w-full"

--- a/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.tsx
+++ b/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.tsx
@@ -39,7 +39,7 @@ function FilterField({
 }) {
     return (
         <div className={cn('flex-1', className)}>
-            <label htmlFor={htmlFor} className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block">
+            <label htmlFor={htmlFor} className="text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2 block whitespace-nowrap">
                 {label}
             </label>
             {children}
@@ -302,7 +302,7 @@ export const ListSuspiciousReplicas = (props: ListSuspiciousReplicasProps) => {
                                     placeholder="Select date"
                                 />
                             </FilterField>
-                            <FilterField label="Min Attempts Threshold" htmlFor="suspicious-nattempts" className="sm:max-w-[160px]">
+                            <FilterField label="Min Attempts Threshold" htmlFor="suspicious-nattempts" className="md:max-w-[200px]">
                                 <Input
                                     id="suspicious-nattempts"
                                     className="w-full"

--- a/src/lib/infrastructure/adapters/app-router-controller-adapter.ts
+++ b/src/lib/infrastructure/adapters/app-router-controller-adapter.ts
@@ -67,6 +67,10 @@ class StreamingResponseAdapter extends Writable implements Signal {
     private _encoder = new TextEncoder();
     private _finished = false;
     private _chunkCount = 0;
+    // Chunks produced before createReadableStream() is called (e.g. when the
+    // use case's error path runs synchronously inside controller.execute() and
+    // resolves before the route can attach the readable). Flushed in start().
+    private _pendingChunks: Uint8Array[] = [];
 
     constructor() {
         super({ objectMode: true });
@@ -78,11 +82,26 @@ class StreamingResponseAdapter extends Writable implements Signal {
     }
 
     json(data: any): void {
-        // For non-streaming presenters that call json()
-        const jsonStr = JSON.stringify(data);
+        // Terminal call from streaming presenters' presentError() path: emit the
+        // JSON body and close the ReadableStream so the HTTP response completes.
+        // Without the close() the client's response.json() hangs (request shows
+        // up as "pending" in DevTools forever).
+        const encoded = this._encoder.encode(JSON.stringify(data));
         if (this._controller) {
-            this._controller.enqueue(this._encoder.encode(jsonStr));
+            try {
+                this._controller.enqueue(encoded);
+                this._controller.close();
+            } catch (error) {
+                console.error('[StreamingResponseAdapter] Error finalizing json response:', error);
+            }
+            this._controller = null;
+        } else {
+            // No controller yet (route hasn't called createReadableStream).
+            // Buffer the body; start() will flush it and then close immediately
+            // because _finished is true.
+            this._pendingChunks.push(encoded);
         }
+        this._finished = true;
     }
 
     setHeader(name: string, value: string): this {
@@ -102,14 +121,17 @@ class StreamingResponseAdapter extends Writable implements Signal {
         }
 
         this._chunkCount++;
+        const encoded = this._encoder.encode(chunkStr);
 
-        // Immediately enqueue to ReadableStream if controller is available
         if (this._controller) {
             try {
-                this._controller.enqueue(this._encoder.encode(chunkStr));
+                this._controller.enqueue(encoded);
             } catch (error) {
                 console.error('[StreamingResponseAdapter] Error enqueueing chunk:', error);
             }
+        } else {
+            // Buffer until createReadableStream() runs.
+            this._pendingChunks.push(encoded);
         }
 
         callback();
@@ -144,12 +166,27 @@ class StreamingResponseAdapter extends Writable implements Signal {
     createReadableStream(): ReadableStream<Uint8Array> {
         return new ReadableStream<Uint8Array>({
             start: controller => {
-                // Store the controller so _write() can enqueue chunks directly
                 this._controller = controller;
 
-                // If stream already finished before we created ReadableStream, close it
+                // Flush anything written before the stream was attached
+                // (most commonly the JSON body from presentError()).
+                for (const chunk of this._pendingChunks) {
+                    try {
+                        controller.enqueue(chunk);
+                    } catch (error) {
+                        console.error('[StreamingResponseAdapter] Error flushing pending chunk:', error);
+                    }
+                }
+                this._pendingChunks = [];
+
+                // If the producer already finished, close immediately.
                 if (this._finished) {
-                    controller.close();
+                    try {
+                        controller.close();
+                    } catch (error) {
+                        console.error('[StreamingResponseAdapter] Error closing controller on start:', error);
+                    }
+                    this._controller = null;
                 }
             },
 

--- a/src/lib/infrastructure/command-palette/command-registry.ts
+++ b/src/lib/infrastructure/command-palette/command-registry.ts
@@ -24,9 +24,11 @@ import { buildDIDSearchUrl, buildRSESearchUrl, buildRuleDetailUrl, buildSubscrip
  * @param canViewApprovalQueue - Whether the current user can access the approve rules page.
  *   Must be resolved by the caller (e.g. via `usePermissions().check`) so this function
  *   remains pure and works before PermixProvider has run setup().
+ * @param isAdmin - Whether the current user has the admin role. Gates the
+ *   suspicious-replicas entry (admin-only surface).
  */
-export function getNavigationCommands(account?: string, canViewApprovalQueue?: boolean): CommandItem[] {
-    return [
+export function getNavigationCommands(account?: string, canViewApprovalQueue?: boolean, isAdmin?: boolean): CommandItem[] {
+    const commands: CommandItem[] = [
         {
             id: 'nav-dashboard',
             type: 'navigation',
@@ -77,15 +79,6 @@ export function getNavigationCommands(account?: string, canViewApprovalQueue?: b
             keywords: ['rse', 'storage', 'element', 'endpoint'],
         },
         {
-            id: 'nav-suspicious-replicas',
-            type: 'navigation',
-            title: 'Suspicious Replicas',
-            description: 'List suspicious file replicas and declare them bad',
-            icon: ExclamationTriangleIcon,
-            url: '/suspicious-replicas',
-            keywords: ['suspicious', 'bad', 'replica', 'file', 'corrupted', 'declare', 'rse'],
-        },
-        {
             id: 'nav-subscriptions',
             type: 'navigation',
             title: 'Subscriptions',
@@ -95,6 +88,21 @@ export function getNavigationCommands(account?: string, canViewApprovalQueue?: b
             keywords: ['subscription', 'subscribe', 'data'],
         },
     ];
+
+    // Admin-only navigation surfaces
+    if (isAdmin) {
+        commands.push({
+            id: 'nav-suspicious-replicas',
+            type: 'navigation',
+            title: 'Suspicious Replicas',
+            description: 'List suspicious file replicas and declare them bad',
+            icon: ExclamationTriangleIcon,
+            url: '/suspicious-replicas',
+            keywords: ['suspicious', 'bad', 'replica', 'file', 'corrupted', 'declare', 'rse'],
+        });
+    }
+
+    return commands;
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #782

- Restrict the suspicious-replicas page to admin users with a server-side role guard (non-admins and unauthenticated users are redirected to root)
- Fix responsive filter layout: use `md` breakpoint for filter row stacking to prevent label/input misalignment on narrow viewports; add per-field `className` prop for width constraints
- Add a streaming status banner (accessible `role=status`, `aria-live=polite`) shown while results are loading to communicate the progressive-streaming behaviour
- Improve `NoLoadedRowsOverlay` empty-state and error copy with actionable, descriptive messages replacing the previous terse placeholders

## Changes

**Access control** (`src/app/(rucio)/suspicious-replicas/page.tsx`): Server component now calls `getSessionUser()` and redirects anyone without `Role.ADMIN`.

**Responsive layout + streaming indicator** (`ListSuspiciousReplicas.tsx`, `.stories.tsx`): Filter rows wrap at `md` rather than `sm`, eliminating the misaligned "Min Attempts Threshold" input on small screens. A dismissible status strip is displayed while the stream is in progress. Storybook story now wraps in `QueryClientProvider`.

**Overlay copy** (`NoLoadedRowsOverlay.tsx`): "Nothing found" becomes "No results found. Try adjusting your filters and searching again." Error state renders a two-line centred block: primary message + a network/retry hint.