### PR TITLE
fix(ui): scope Select All to filtered rows on Suspicious Replicas and Approve Rules

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { withThemeByClassName } from '@storybook/addon-themes';
+import { ThemeProvider } from 'next-themes';
 import '../src/app/globals.css';
+// Register AG Grid community modules (AG Grid v33+ renders nothing without this).
+// The app does this in src/app/layout.tsx via <AgGridSetup />; Storybook has no
+// root layout, so we import the same side-effect module here so grid stories render.
+import '../src/lib/ag-grid-setup';
 
 /**
  * Storybook Preview Configuration
@@ -9,50 +14,62 @@ import '../src/app/globals.css';
 
 // Decorator to ensure proper background color based on theme
 const withBackground = (Story, context) => {
-  const theme = context.globals.theme || 'light';
-  return (
-      <Story />
-  );
+    const theme = context.globals.theme || 'light';
+    return <Story />;
+};
+
+// Provide a next-themes context. RegularTable only mounts AG Grid once
+// `useTheme().resolvedTheme` is defined; without this provider the grid (and
+// therefore every table story) renders blank. The app supplies this in
+// src/app/layout.tsx.
+const withNextThemes = (Story, context) => {
+    const theme = context.globals.theme || 'light';
+    return (
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false} forcedTheme={theme}>
+            <Story />
+        </ThemeProvider>
+    );
 };
 
 export const decorators = [
-  withThemeByClassName({
-    themes: {
-      light: 'light',
-      dark: 'dark',
-    },
-    defaultTheme: 'light',
-  }),
-  withBackground,
+    withThemeByClassName({
+        themes: {
+            light: 'light',
+            dark: 'dark',
+        },
+        defaultTheme: 'light',
+    }),
+    withNextThemes,
+    withBackground,
 ];
 
 export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+        matchers: {
+            color: /(background|color)$/i,
+            date: /Date$/,
+        },
     },
-  },
-  backgrounds: {
-    options: {
-      light: {
-        name: 'light',
-        value: '#FFFFFF',
-      },
+    backgrounds: {
+        options: {
+            light: {
+                name: 'light',
+                value: '#FFFFFF',
+            },
 
-      dark: {
-        name: 'dark',
-        value: '#0F172A',
-      }
-    }
-  },
+            dark: {
+                name: 'dark',
+                value: '#0F172A',
+            },
+        },
+    },
 };
 
 export const tags = ['autodocs'];
 
 export const initialGlobals = {
-  backgrounds: {
-    value: 'light'
-  }
+    backgrounds: {
+        value: 'light',
+    },
 };

--- a/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.stories.tsx
+++ b/src/component-library/pages/Replica/suspicious/ListSuspiciousReplicas.stories.tsx
@@ -32,3 +32,29 @@ export const WithData = Template.bind({});
 WithData.args = {
     initialData: Array.from({ length: 30 }, () => fixtureSuspiciousReplicaViewModel()),
 };
+
+/**
+ * Multi-select filter test (for #789): 30 rows split evenly across three RSEs
+ * (10 each). Each row keeps a faker-random scope/name/count so the grid looks
+ * realistic, but the RSE column has only three distinct, repeated values so you
+ * can filter to an exact, countable subset.
+ *
+ * How to verify the "Select All scopes to filtered rows" fix:
+ *   1. Open the RSE column filter and type "DESY-ZN_DATADISK" so only those 10
+ *      rows remain visible.
+ *   2. Click the header checkbox (top-left of the grid).
+ *   3. The bulk toolbar should read "10 replicas selected", not 30. Before the
+ *      fix it selected all 30 rows, including the filtered-out ones.
+ *   4. Clear the filter: the 20 previously-hidden rows reappear unselected,
+ *      confirming the action only ever targeted the visible subset.
+ */
+const RSE_GROUPS = ['DESY-ZN_DATADISK', 'CERN-PROD_DATADISK', 'BNL-OSG2_DATADISK'];
+export const MultiSelectFilterTest = Template.bind({});
+MultiSelectFilterTest.args = {
+    initialData: RSE_GROUPS.flatMap(rse =>
+        Array.from({ length: 10 }, () => ({
+            ...fixtureSuspiciousReplicaViewModel(),
+            rse,
+        })),
+    ),
+};

--- a/src/component-library/pages/Replica/suspicious/SuspiciousReplicasTable.tsx
+++ b/src/component-library/pages/Replica/suspicious/SuspiciousReplicasTable.tsx
@@ -77,6 +77,7 @@ export const SuspiciousReplicasTable = (props: SuspiciousReplicasTableProps) => 
         () => [
             {
                 headerCheckboxSelection: true,
+                headerCheckboxSelectionFilteredOnly: true,
                 checkboxSelection: true,
                 width: 48,
                 minWidth: 48,

--- a/src/component-library/pages/Rule/approve/ApproveRule.stories.tsx
+++ b/src/component-library/pages/Rule/approve/ApproveRule.stories.tsx
@@ -39,13 +39,7 @@ const ApproveRuleStoryWrapper = ({ initialData, autoSearch, ...approveRuleProps 
     };
 
     return (
-        <ApproveRule
-            streamingHook={streamingHook}
-            onGridReady={onGridReady}
-            onSearch={handleSearch}
-            onStop={stopStreaming}
-            {...approveRuleProps}
-        />
+        <ApproveRule streamingHook={streamingHook} onGridReady={onGridReady} onSearch={handleSearch} onStop={stopStreaming} {...approveRuleProps} />
     );
 };
 
@@ -85,6 +79,36 @@ export const Default: Story = {
     args: {
         initialData: Array.from({ length: 12 }, () => ({
             ...fixtureApproveRuleViewModel(),
+            state: RuleState.WAITING_APPROVAL,
+        })),
+    },
+};
+
+/**
+ * Multi-select filter test (for #789): 12 rules in WAITING_APPROVAL state,
+ * split across three accounts (5 + 4 + 3). Every other field stays faker-random
+ * so the grid looks realistic, but the Account column has only three distinct,
+ * repeated values so you can filter to an exact, countable subset.
+ *
+ * How to verify the "Select All scopes to filtered rows" fix:
+ *   1. Open the Account column filter and type "prod-transfers" so only those 5
+ *      rows remain visible.
+ *   2. Click the header checkbox (top-left of the grid).
+ *   3. The bulk toolbar should read "5 rules selected", not 12. Before the fix
+ *      the header checkbox selected every row in the dataset, including the
+ *      filtered-out ones.
+ *   4. Clear the filter: the 7 previously-hidden rows reappear unselected,
+ *      confirming Approve/Deny would only target the visible subset.
+ */
+export const MultiSelectFilterTest: Story = {
+    args: {
+        initialData: [
+            ...Array.from({ length: 5 }, () => 'prod-transfers'),
+            ...Array.from({ length: 4 }, () => 'analysis-ops'),
+            ...Array.from({ length: 3 }, () => 'data-mgmt'),
+        ].map(account => ({
+            ...fixtureApproveRuleViewModel(),
+            account,
             state: RuleState.WAITING_APPROVAL,
         })),
     },

--- a/src/component-library/pages/Rule/approve/ApproveRuleTable.tsx
+++ b/src/component-library/pages/Rule/approve/ApproveRuleTable.tsx
@@ -134,6 +134,7 @@ const ApproveRuleTable = (props: ApproveRuleTableProps) => {
     const [columnDefs] = useState([
         {
             headerCheckboxSelection: true,
+            headerCheckboxSelectionFilteredOnly: true,
             checkboxSelection: true,
             width: 48,
             minWidth: 48,


### PR DESCRIPTION
## Summary

Closes #789.

On the Suspicious Replicas and Approve Rules pages, the AG Grid header "Select All" checkbox selected every row in the underlying dataset, including rows hidden by active client-side column filters. For admin bulk actions (declare-bad, approve, reject) this was a safety hazard: an operator could filter the grid, click Select All, and unknowingly act on rows they had filtered out.

## Changes

- **Fix:** add `headerCheckboxSelectionFilteredOnly: true` to the checkbox column in both `SuspiciousReplicasTable` and `ApproveRuleTable`, so the header checkbox only selects rows passing the active filters. The bulk action is driven by the grid selection, so it now targets the filtered subset only.
- **Tests:** add a `MultiSelectFilterTest` Storybook story to each page. Each uses controlled, repeated values in one filterable column (RSE for suspicious replicas, Account for approve rules) so a column filter isolates an exact, countable subset that makes the behaviour easy to check by hand.
- **Storybook infra:** grid stories previously rendered blank because the Storybook manager has no root layout. AG Grid v33+ needs explicit module registration (the app does this via `AgGridSetup` in `src/app/layout.tsx`), and `RegularTable` only mounts the grid once next-themes' `resolvedTheme` is defined. We import the `ag-grid-setup` side-effect module and wrap stories in a next-themes `ThemeProvider` in `.storybook/preview.jsx`, which fixes every table story, not just the new ones.

## Verification

Verified both pages in Storybook:

- **Suspicious Replicas:** filtered RSE to a single value (10 of 30 rows) → Select All reported "10 replicas selected", not 30. Clearing the filter brought back all 30 rows with only the 10 filtered rows still selected.
- **Approve Rules:** filtered Account to `prod-transfers` (5 of 12 rows) → Select All reported "5 rules selected". Clearing the filter left only those 5 selected, and clicking "Approve Selected" fired exactly 5 `onApprove` calls carrying only the filtered rule IDs, confirming only the filtered subset reaches the server-side bulk action.
