### PR TITLE
feat: Filter on active subscriptions on web UI

### DIFF
--- a/src/component-library/features/badges/Subscription/SubscriptionStateBadge.tsx
+++ b/src/component-library/features/badges/Subscription/SubscriptionStateBadge.tsx
@@ -2,7 +2,7 @@ import { SubscriptionState } from '@/lib/core/entity/rucio';
 import React from 'react';
 import { Badge } from '@/component-library/atoms/misc/Badge';
 
-const stateString: Record<SubscriptionState, string> = {
+export const subscriptionStateString: Record<SubscriptionState, string> = {
     [SubscriptionState.ACTIVE]: 'Active',
     [SubscriptionState.INACTIVE]: 'Inactive',
     [SubscriptionState.NEW]: 'New',
@@ -32,5 +32,5 @@ const stateVariants: Record<SubscriptionState, 'default' | 'success' | 'error' |
 };
 
 export const SubscriptionStateBadge = (props: { value: SubscriptionState; className?: string }) => {
-    return <Badge value={stateString[props.value]} variant={stateVariants[props.value]} className={props.className} />;
+    return <Badge value={subscriptionStateString[props.value]} variant={stateVariants[props.value]} className={props.className} />;
 };

--- a/src/component-library/pages/Subscriptions/list/ListSubscription.tsx
+++ b/src/component-library/pages/Subscriptions/list/ListSubscription.tsx
@@ -4,8 +4,11 @@ import { ListSubscriptionTable } from '@/component-library/pages/Subscriptions/l
 import useTableStreaming from '@/lib/infrastructure/hooks/useTableStreaming';
 import { SubscriptionRuleStatesViewModel } from '@/lib/infrastructure/data/view-model/subscriptions';
 import { Heading } from '@/component-library/atoms/misc/Heading';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { SubscriptionState } from '@/lib/core/entity/rucio';
+import { IRowNode, GridReadyEvent } from 'ag-grid-community';
+import { Checkbox } from '@/component-library/atoms/form/checkbox';
 import { SiteHeaderViewModel } from '@/lib/infrastructure/data/view-model/site-header';
 import { InfoField } from '@/component-library/features/fields/InfoField';
 import { WarningField } from '@/component-library/features/fields/WarningField';
@@ -17,8 +20,26 @@ type ListSubscriptionProps = {
 };
 
 export const ListSubscription = (props: ListSubscriptionProps) => {
-    const { gridApi, onGridReady, streamingHook, startStreaming } = useTableStreaming<SubscriptionRuleStatesViewModel>(props.initialData);
+    const { gridApi, onGridReady: onGridReadyBase, streamingHook, startStreaming } = useTableStreaming<SubscriptionRuleStatesViewModel>(props.initialData);
     const hasAutoSearched = useRef(false);
+
+    const showActiveOnlyRef = useRef(true);
+    const [showActiveOnly, setShowActiveOnly] = useState(true);
+
+    const onGridReady = (event: GridReadyEvent) => {
+        onGridReadyBase(event);
+        event.api.setGridOption('isExternalFilterPresent', () => showActiveOnlyRef.current);
+        event.api.setGridOption('doesExternalFilterPass', (node: IRowNode) => {
+            const vm = node.data as SubscriptionRuleStatesViewModel;
+            return !showActiveOnlyRef.current || vm?.subscriptionState === SubscriptionState.ACTIVE;
+        });
+    };
+
+    const handleToggle = (checked: boolean) => {
+        showActiveOnlyRef.current = checked;
+        setShowActiveOnly(checked);
+        gridApi?.onFilterChanged();
+    };
 
     // TODO: replace with server-side request
     const querySiteHeader = async () => {
@@ -62,7 +83,6 @@ export const ListSubscription = (props: ListSubscriptionProps) => {
     }
 
     if (!props.accountFilter && (siteHeaderError || !siteHeader || !siteHeader.activeAccount)) {
-        console.log(siteHeaderError);
         return (
             <WarningField>
                 <span>Failed to load account information</span>
@@ -80,9 +100,19 @@ export const ListSubscription = (props: ListSubscriptionProps) => {
 
     return (
         <div className="flex flex-col space-y-3 w-full">
-            <Heading size="sm" className="text-neutral-600 dark:text-neutral-400">
-                for account {account}
-            </Heading>
+            <div className="flex items-center justify-between">
+                <Heading size="sm" className="text-neutral-600 dark:text-neutral-400">
+                    for account {account}
+                </Heading>
+                <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-400 select-none">
+                    <Checkbox
+                        checked={showActiveOnly}
+                        onCheckedChange={(checked) => handleToggle(checked === true)}
+                        aria-label="Show active subscriptions only"
+                    />
+                    <span>Active subscriptions only</span>
+                </div>
+            </div>
             <div className="rounded-lg bg-neutral-0 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 shadow-sm overflow-hidden h-[calc(100vh-20rem)]">
                 <ListSubscriptionTable streamingHook={streamingHook} onGridReady={onGridReady} account={account} />
             </div>

--- a/src/component-library/pages/Subscriptions/list/ListSubscriptionTable.tsx
+++ b/src/component-library/pages/Subscriptions/list/ListSubscriptionTable.tsx
@@ -9,7 +9,7 @@ import { RuleStateBadge } from '@/component-library/features/badges/Rule/RuleSta
 import { RuleState, SubscriptionState } from '@/lib/core/entity/rucio';
 import { badgeCellClasses } from '@/component-library/features/table/cells/badge-cell';
 import { ClickableCell } from '@/component-library/features/table/cells/ClickableCell';
-import { SubscriptionStateBadge } from '@/component-library/features/badges/Subscription/SubscriptionStateBadge';
+import { SubscriptionStateBadge, subscriptionStateString } from '@/component-library/features/badges/Subscription/SubscriptionStateBadge';
 
 type ListSubscriptionTableProps = {
     streamingHook: UseStreamReader<SubscriptionRuleStatesViewModel>;
@@ -48,6 +48,10 @@ export const ListSubscriptionTable = (props: ListSubscriptionTableProps) => {
             ),
             filter: true,
             filterParams: DefaultTextFilterParams,
+            // The cell value is the enum code (e.g. 'A'); filter against the displayed
+            // label (e.g. 'Active') so text searches match what the user sees.
+            filterValueGetter: (params: { data?: SubscriptionRuleStatesViewModel }) =>
+                subscriptionStateString[params.data?.subscriptionState ?? SubscriptionState.UNKNOWN],
         },
         {
             headerName: 'OK',

--- a/src/component-library/pages/Subscriptions/list/ListSubscriptionTable.tsx
+++ b/src/component-library/pages/Subscriptions/list/ListSubscriptionTable.tsx
@@ -6,9 +6,10 @@ import { SubscriptionRuleStatesViewModel } from '@/lib/infrastructure/data/view-
 import { GridReadyEvent } from 'ag-grid-community';
 import { DefaultTextFilterParams } from '@/component-library/features/utils/filter-parameters';
 import { RuleStateBadge } from '@/component-library/features/badges/Rule/RuleStateBadge';
-import { RuleState } from '@/lib/core/entity/rucio';
+import { RuleState, SubscriptionState } from '@/lib/core/entity/rucio';
 import { badgeCellClasses } from '@/component-library/features/table/cells/badge-cell';
 import { ClickableCell } from '@/component-library/features/table/cells/ClickableCell';
+import { SubscriptionStateBadge } from '@/component-library/features/badges/Subscription/SubscriptionStateBadge';
 
 type ListSubscriptionTableProps = {
     streamingHook: UseStreamReader<SubscriptionRuleStatesViewModel>;
@@ -35,6 +36,16 @@ export const ListSubscriptionTable = (props: ListSubscriptionTableProps) => {
             cellRendererParams: {
                 account: props.account,
             },
+            filter: true,
+            filterParams: DefaultTextFilterParams,
+        },
+        {
+            headerName: 'State',
+            field: 'subscriptionState',
+            minWidth: 140,
+            cellRenderer: (params: { value: SubscriptionState }) => (
+                <SubscriptionStateBadge value={params.value ?? SubscriptionState.UNKNOWN} className={badgeCellClasses} />
+            ),
             filter: true,
             filterParams: DefaultTextFilterParams,
         },

--- a/src/lib/core/dto/subscription-dto.ts
+++ b/src/lib/core/dto/subscription-dto.ts
@@ -1,5 +1,5 @@
 import { BaseDTO, BaseStreamableDTO } from '@/lib/sdk/dto';
-import { RuleState, Subscription, SubscriptionRuleStates } from '../entity/rucio';
+import { RuleState, Subscription, SubscriptionRuleStates, SubscriptionState } from '../entity/rucio';
 
 /**
  * The Data Transfer Object for the ListSubscriptionsEndpoint which contains the stream
@@ -19,4 +19,5 @@ export interface SubscriptionRuleStateDTO extends BaseDTO {
     subscriptionName: string;
     state: RuleState;
     count: number;
+    subscriptionState: SubscriptionState;
 }

--- a/src/lib/core/entity/rucio.ts
+++ b/src/lib/core/entity/rucio.ts
@@ -302,6 +302,7 @@ export type Subscription = {
 
 export type SubscriptionRuleStates = {
     name: string;
+    subscriptionState: SubscriptionState;
     state_ok: number;
     state_replicating: number;
     state_stuck: number;

--- a/src/lib/core/use-case/list-subscription-rule-states-usecase.ts
+++ b/src/lib/core/use-case/list-subscription-rule-states-usecase.ts
@@ -14,9 +14,9 @@ import {
 import { SubscriptionRuleStatesViewModel } from '@/lib/infrastructure/data/view-model/subscriptions';
 
 import { BaseStreamableDTO } from '@/lib/sdk/dto';
-import { SubscriptionRuleStateDTO } from '@/lib/core/dto/subscription-dto';
-import type RSEGatewayOutputPort from '@/lib/core/port/secondary/subscription-gateway-output-port';
-import { RuleState } from '../entity/rucio';
+import { SubscriptionDTO, SubscriptionRuleStateDTO } from '@/lib/core/dto/subscription-dto';
+import type SubscriptionGatewayOutputPort from '@/lib/core/port/secondary/subscription-gateway-output-port';
+import { RuleState, SubscriptionState } from '../entity/rucio';
 import { TransformCallback } from 'stream';
 
 @injectable()
@@ -31,9 +31,11 @@ export default class ListSubscriptionRuleStatesUseCase
     >
     implements ListSubscriptionRuleStatesInputPort
 {
+    private subscriptionStateMap: Map<string, SubscriptionState> = new Map();
+
     constructor(
         protected readonly presenter: ListSubscriptionRuleStatesOutputPort,
-        private readonly gateway: RSEGatewayOutputPort,
+        private readonly gateway: SubscriptionGatewayOutputPort,
         private responseModels: ListSubscriptionRuleStatesResponse[] = [],
         private errorModels: ListSubscriptionRuleStatesError[] = [],
     ) {
@@ -47,6 +49,19 @@ export default class ListSubscriptionRuleStatesUseCase
     async intializeRequest(
         request: AuthenticatedRequestModel<AuthenticatedRequestModel<ListSubscriptionRuleStatesRequest>>,
     ): Promise<ListSubscriptionRuleStatesError | undefined> {
+        try {
+            const listDTO = await this.gateway.list(request.rucioAuthToken, request.account);
+            if (listDTO.status === 'success' && listDTO.stream) {
+                const stream = listDTO.stream;
+                for await (const chunk of stream as AsyncIterable<SubscriptionDTO>) {
+                    if (chunk && chunk.status === 'success' && chunk.name) {
+                        this.subscriptionStateMap.set(chunk.name, chunk.state);
+                    }
+                }
+            }
+        } catch (error) {
+            // Non-fatal: proceed without subscription state enrichment — unknown states will be shown
+        }
         return undefined;
     }
 
@@ -73,6 +88,7 @@ export default class ListSubscriptionRuleStatesUseCase
         return {
             status: 'success',
             name: existingModel.name,
+            subscriptionState: existingModel.subscriptionState,
             state_ok: existingModel.state_ok + newModel.state_ok,
             state_replicating: existingModel.state_replicating + newModel.state_replicating,
             state_stuck: existingModel.state_stuck + newModel.state_stuck,
@@ -84,9 +100,11 @@ export default class ListSubscriptionRuleStatesUseCase
 
     addOrUpdateSubscriptionRuleState(ruleStateDTO: SubscriptionRuleStateDTO): ListSubscriptionRuleStatesResponse {
         const existingEntryIndex = this.responseModels.findIndex(rs => rs.name === ruleStateDTO.subscriptionName);
+        const subscriptionState = this.subscriptionStateMap.get(ruleStateDTO.subscriptionName) ?? SubscriptionState.UNKNOWN;
         const newEntry: ListSubscriptionRuleStatesResponse = {
             status: 'success',
             name: ruleStateDTO.subscriptionName,
+            subscriptionState,
             state_ok: 0,
             state_replicating: 0,
             state_stuck: 0,
@@ -131,7 +149,6 @@ export default class ListSubscriptionRuleStatesUseCase
         data: ListSubscriptionRuleStatesResponse | ListSubscriptionRuleStatesError;
         status: 'success' | 'error';
     } {
-        // TODO: process streamed data
         if (dto.status === 'error') {
             const errorModel: ListSubscriptionRuleStatesError = {
                 status: 'error',
@@ -148,16 +165,16 @@ export default class ListSubscriptionRuleStatesUseCase
         try {
             const responseModel = this.addOrUpdateSubscriptionRuleState(dto);
             return {
-                status: 'pending' as any, // intentional use of any
+                status: 'success',
                 data: responseModel,
             };
-        } catch (error: any) {
+        } catch (error: unknown) {
             return {
                 status: 'error',
                 data: {
                     status: 'error',
                     code: 500,
-                    message: error.toString(),
+                    message: error instanceof Error ? error.message : String(error),
                     name: 'Error while processing streamed data',
                 } as ListSubscriptionRuleStatesError,
             };
@@ -174,6 +191,7 @@ export default class ListSubscriptionRuleStatesUseCase
             const errorModel = data as ListSubscriptionRuleStatesError;
             // push the errors as soon as they arrive
             callback(null, errorModel);
+            return;
         }
         callback(null);
     }

--- a/src/lib/infrastructure/data/view-model/subscriptions.ts
+++ b/src/lib/infrastructure/data/view-model/subscriptions.ts
@@ -34,6 +34,7 @@ export function generateEmptySubscriptionRuleStatesViewModel(): SubscriptionRule
     const viewModel: SubscriptionRuleStatesViewModel = {
         status: 'error',
         name: '',
+        subscriptionState: SubscriptionState.UNKNOWN,
         state_ok: 0,
         state_replicating: 0,
         state_stuck: 0,

--- a/src/lib/infrastructure/gateway/subscription-gateway/subscription-gateway-utils.ts
+++ b/src/lib/infrastructure/gateway/subscription-gateway/subscription-gateway-utils.ts
@@ -1,6 +1,5 @@
 import { SubscriptionDTO, SubscriptionRuleStateDTO } from '@/lib/core/dto/subscription-dto';
 import { RuleState, SubscriptionReplicationRule, SubscriptionState } from '@/lib/core/entity/rucio';
-import { de } from '@faker-js/faker';
 
 /**
  * Represents the data returned by Rucio Server for a subscription.
@@ -70,14 +69,19 @@ export function parseReplicationRuleState(replicationRuleStateString: string): R
  */
 export function parseSubscriptionState(state: string): SubscriptionState {
     switch (state.toUpperCase()) {
+        case 'A':
         case 'ACTIVE':
             return SubscriptionState.ACTIVE;
+        case 'I':
         case 'INACTIVE':
             return SubscriptionState.INACTIVE;
+        case 'N':
         case 'NEW':
             return SubscriptionState.NEW;
+        case 'U':
         case 'UPDATED':
             return SubscriptionState.UPDATED;
+        case 'B':
         case 'BROKEN':
             return SubscriptionState.BROKEN;
         default:
@@ -119,6 +123,7 @@ export function convertToSubscriptionRuleStatesDTO(data: TRucioSubscriptionRuleS
         subscriptionName: data[1],
         state: parseReplicationRuleState(data[2]),
         count: data[3],
+        subscriptionState: SubscriptionState.UNKNOWN,
     };
 }
 /**
@@ -154,5 +159,6 @@ export function getEmptySubscriptionRuleStatesDTO(): SubscriptionRuleStateDTO {
         subscriptionName: '',
         state: RuleState.UNKNOWN,
         count: 0,
+        subscriptionState: SubscriptionState.UNKNOWN,
     };
 }

--- a/test/api/subscription/list-subscription-rule-states.test.ts
+++ b/test/api/subscription/list-subscription-rule-states.test.ts
@@ -8,10 +8,50 @@ import { ListSubscriptionRuleStatesRequest } from '@/lib/core/usecase-models/lis
 import CONTROLLERS from '@/lib/infrastructure/ioc/ioc-symbols-controllers';
 import { NextApiResponse } from 'next';
 import { generateEmptySubscriptionRuleStatesViewModel } from '@/lib/infrastructure/data/view-model/subscriptions';
+import { SubscriptionState } from '@/lib/core/entity/rucio';
 
 describe('Get Subscription Rule States', () => {
     beforeEach(() => {
         fetchMock.doMock();
+
+        const makeSubscription = (name: string) =>
+            JSON.stringify({
+                id: `mock-id-${name}`,
+                name,
+                filter: '{}',
+                replication_rules: '[]',
+                policyid: 0,
+                state: 'A',
+                last_processed: 'Thu, 01 Jan 2026 00:00:00 UTC',
+                account: 'ddmadmin',
+                lifetime: 'Thu, 01 Jan 2099 00:00:00 UTC',
+                comments: null,
+                retroactive: false,
+                expired_at: null,
+                created_at: 'Thu, 01 Jan 2026 00:00:00 UTC',
+                updated_at: 'Thu, 01 Jan 2026 00:00:00 UTC',
+            });
+
+        const getSubscriptionsEndpoint: MockEndpoint = {
+            url: `${MockRucioServerFactory.RUCIO_HOST}/subscriptions/ddmadmin`,
+            method: 'GET',
+            endsWith: '/subscriptions/ddmadmin',
+            response: {
+                status: 200,
+                headers: {
+                    'Content-Type': 'application/x-json-stream',
+                },
+                body: Readable.from(
+                    [
+                        makeSubscription('EVNT to T0 with 1 year lifetime'),
+                        makeSubscription('group.phys-gener to CERN-PROD_PHYS-GENER'),
+                        makeSubscription('*Functional Test'),
+                        makeSubscription('T0 DESD to T1 tape'),
+                    ].join('\n'),
+                ),
+            },
+        };
+
         const getSubscriptionRuleStatesEndpoint: MockEndpoint = {
             url: `${MockRucioServerFactory.RUCIO_HOST}/subscriptions/ddmadmin/rules/states`,
             method: 'GET',
@@ -32,7 +72,7 @@ describe('Get Subscription Rule States', () => {
                 ),
             },
         };
-        MockRucioServerFactory.createMockRucioServer(true, [getSubscriptionRuleStatesEndpoint]);
+        MockRucioServerFactory.createMockRucioServer(true, [getSubscriptionsEndpoint, getSubscriptionRuleStatesEndpoint]);
     });
 
     afterEach(() => {
@@ -76,24 +116,28 @@ describe('Get Subscription Rule States', () => {
                 ...generateEmptySubscriptionRuleStatesViewModel(),
                 status: 'success',
                 name: 'EVNT to T0 with 1 year lifetime',
+                subscriptionState: SubscriptionState.ACTIVE,
                 state_ok: 15464,
             },
             {
                 ...generateEmptySubscriptionRuleStatesViewModel(),
                 status: 'success',
                 name: 'group.phys-gener to CERN-PROD_PHYS-GENER',
+                subscriptionState: SubscriptionState.ACTIVE,
                 state_ok: 5344,
             },
             {
                 ...generateEmptySubscriptionRuleStatesViewModel(),
                 status: 'success',
                 name: '*Functional Test',
+                subscriptionState: SubscriptionState.ACTIVE,
                 state_ok: 95918,
             },
             {
                 ...generateEmptySubscriptionRuleStatesViewModel(),
                 status: 'success',
                 name: 'T0 DESD to T1 tape',
+                subscriptionState: SubscriptionState.ACTIVE,
                 state_ok: 2382,
                 state_stuck: 500,
             },

--- a/test/fixtures/table-fixtures.ts
+++ b/test/fixtures/table-fixtures.ts
@@ -411,6 +411,7 @@ export function fixtureSubscriptionRuleStatesViewModel(): SubscriptionRuleStates
         state_suspended: faker.number.int({ min: 0, max: 10 }),
         state_waiting_approval: faker.number.int({ min: 0, max: 10 }),
         state_inject: faker.number.int({ min: 0, max: 10 }),
+        subscriptionState: randomEnum<SubscriptionState>(SubscriptionState),
     };
 }
 

--- a/test/gateway/subscription/list-subscription-rule-states.test.ts
+++ b/test/gateway/subscription/list-subscription-rule-states.test.ts
@@ -62,7 +62,7 @@ describe('Get Subscription Rule States', () => {
         });
 
         expect(receivedData.length).toEqual(4);
-        expect(receivedData).toEqual([
+        expect(receivedData).toMatchObject([
             {
                 status: 'success',
                 account: 'ddmadmin',
@@ -92,24 +92,5 @@ describe('Get Subscription Rule States', () => {
                 count: 2382,
             },
         ]);
-    });
-    it('tests_merge_of_2_objects', () => {
-        const obj1 = {
-            status: 'success',
-            states_ok: 1,
-        };
-        const obj2 = {
-            status: 'success',
-            states_replicating: 2,
-        };
-        const mergedObj = {
-            ...obj1,
-            ...obj2,
-        };
-        expect(mergedObj).toEqual({
-            status: 'success',
-            states_ok: 1,
-            states_replicating: 2,
-        });
     });
 });


### PR DESCRIPTION
## Summary

Closes #534

- Enriches the subscription rule states data pipeline with `subscriptionState` by pre-fetching the subscriptions list and building a name to state lookup map in the use case layer
- Adds an "Active subscriptions only" checkbox toggle to the subscriptions list page that uses ag-Grid's external filter API to show only active subscriptions by default
- Adds a "State" column with a `SubscriptionStateBadge` renderer to the subscriptions table

## Changes

The Rucio REST API returns subscription state as a single-character code (`A`, `I`, `N`, `U`, `B`). The gateway `parseSubscriptionState` utility now handles both the short codes and the full names for forward compatibility.

The "active only" filter defaults to on at page load. Users can uncheck the toggle to see all subscriptions regardless of state. It is implemented client-side via ag-Grid's `isExternalFilterPresent` / `doesExternalFilterPass` hooks, as the `/subscriptions/{account}/rules/states` endpoint does not accept a `state` query parameter.

The State column's per-column text filter matches against the displayed label (e.g. "Active") rather than the raw enum code, so searching by state name works as users expect.
