### PR TITLE
FIx env variable set with SERVER_CA_BUNDLE

### DIFF
--- a/src/lib/sdk/http.ts
+++ b/src/lib/sdk/http.ts
@@ -47,9 +47,9 @@ export function prepareRequestArgs(request: HTTPRequest): {
     }
     if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '1') {
         try {
-            const caPath = process.env.NODE_EXTRA_TLS_CERTS ?? '';
+            const caPath = process.env.NODE_EXTRA_CA_CERTS ?? '';
             if (caPath === '') {
-                throw new Error('NODE_EXTRA_TLS_CERTS is not set');
+                throw new Error('NODE_EXTRA_CA_CERTS is not set');
             }
             const ca = fs.readFileSync(caPath);
             const rucioHost = extractHostname(request.url as string);

--- a/tools/env-generator/src/api/base.ts
+++ b/tools/env-generator/src/api/base.ts
@@ -168,7 +168,7 @@ export class WebUIEnvTemplateCompiler {
 
     const requiredVariables: string[] = ["rucio_host", "rucio_auth_host", "hostname", "project_url", "vo_default", "vo_list", "nextauth_url"]
 
-    // check if NODE_TLS_REJECT_UNAUTHORIZED is set to 1, then NODE_EXTRA_TLS_CERTS should be set
+    // check if NODE_TLS_REJECT_UNAUTHORIZED is set to 1, then NODE_EXTRA_CA_CERTS should be set
     if(env['NODE_TLS_REJECT_UNAUTHORIZED'] === '1') {
       requiredVariables.push('SERVER_CA_BUNDLE')
     }

--- a/tools/env-generator/src/templates/.env.liquid
+++ b/tools/env-generator/src/templates/.env.liquid
@@ -22,7 +22,7 @@ NEXTAUTH_URL={{ context.NEXTAUTH_URL }}
 [fetch]
 NODE_TLS_REJECT_UNAUTHORIZED={{ context.NODE_TLS_REJECT_UNAUTHORIZED }}
 {% if enable_ssl == 'true' %}
-NODE_EXTRA_TLS_CERTS={{ context.SERVER_CA_BUNDLE }}
+NODE_EXTRA_CA_CERTS={{ context.SERVER_CA_BUNDLE }}
 {% endif %}
 
 [gateway]


### PR DESCRIPTION
Fix the env variable set with `RUCIO_WEBUI_SERVER_CA_BUNDLE` from `NODE_EXTRA_TLS_CERTS` to `NODE_EXTRA_CA_CERTS`. This solves https://github.com/rucio/webui/issues/802.