### PR TITLE
fix(login): honour x509Enabled and iconUrl on the login page

### DIFF
--- a/src/component-library/demos/01_1_Login_OIDC.stories.ts
+++ b/src/component-library/demos/01_1_Login_OIDC.stories.ts
@@ -18,9 +18,10 @@ const cernOIDCProvider: OIDCProvider = {
     redirectUrl: 'https://login.cern.ch/adfs/oauth2/authorize',
 };
 
-// Carries an iconUrl, so the CMS tab below shows a branded button next to CERN's
-// fallback icon. Served from ../public via staticDirs, to keep the published
-// Storybook independent of any remote host.
+// Carries an iconUrl pointing at a local public/ asset, mirroring how the container
+// serves downloaded provider icons through next/image. The CMS tab below shows this
+// branded button next to CERN's fallback icon; served via staticDirs so the published
+// Storybook stays independent of any remote host.
 const IndigoIAMProvider: OIDCProvider = {
     name: 'Indigo IAM',
     url: 'https://accounts.google.com/o/oauth2/v2/auth',

--- a/src/component-library/demos/01_1_Login_OIDC.stories.ts
+++ b/src/component-library/demos/01_1_Login_OIDC.stories.ts
@@ -18,9 +18,13 @@ const cernOIDCProvider: OIDCProvider = {
     redirectUrl: 'https://login.cern.ch/adfs/oauth2/authorize',
 };
 
+// Carries an iconUrl, so the CMS tab below shows a branded button next to CERN's
+// fallback icon. Served from ../public via staticDirs, to keep the published
+// Storybook independent of any remote host.
 const IndigoIAMProvider: OIDCProvider = {
     name: 'Indigo IAM',
     url: 'https://accounts.google.com/o/oauth2/v2/auth',
+    iconUrl: '/experiment-logo.png',
     clientId: '1234567890',
     clientSecret: '1234567890',
     authorizationUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
@@ -85,5 +89,39 @@ export const AMultiVOOIDCEnabledLogin: Story = {
         voAtlas.oidcEnabled = true;
         voCMS.oidcEnabled = true;
         voLHCb.oidcEnabled = true;
+    },
+};
+
+/**
+ * A deployment that authenticates purely through OIDC: userpass and x509 are both
+ * off, so the only login options are the configured providers. Indigo IAM renders
+ * its configured iconUrl, CERN falls back to the default icon.
+ */
+export const BOIDCOnlyLogin: Story = {
+    args: {
+        loginViewModel: {
+            status: 'success',
+            userpassEnabled: false,
+            x509Enabled: false,
+            oidcEnabled: true,
+            oidcProviders: [cernOIDCProvider, IndigoIAMProvider],
+            multiVOEnabled: false,
+            voList: [voCMS],
+            isLoggedIn: false,
+            accountActive: undefined,
+            accountsAvailable: undefined,
+            rucioAuthHost: 'https://rucio.cern.ch',
+        },
+        authViewModel: {
+            status: 'success',
+            message: '',
+            rucioAccount: '',
+            rucioMultiAccount: '',
+            rucioAuthType: '',
+            rucioAuthToken: '',
+            rucioIdentity: '',
+            rucioAuthTokenExpires: '',
+            role: undefined,
+        },
     },
 };

--- a/src/component-library/pages/Login/Login.tsx
+++ b/src/component-library/pages/Login/Login.tsx
@@ -13,6 +13,7 @@ import { AuthViewModel } from '@/lib/infrastructure/data/auth/auth';
 import { MdAccountCircle } from 'react-icons/md';
 import { HiArrowRight, HiArrowLeft } from 'react-icons/hi';
 import Link from 'next/link';
+import Image from 'next/image';
 import { motion, AnimatePresence } from 'motion/react';
 import Modal from 'react-modal';
 import { cn } from '@/component-library/utils';
@@ -345,11 +346,9 @@ export const Login = ({
                                         onClick={() => handleOIDCSubmit(provider, loginViewModel.voList[selectedVOTab], inputAccount)}
                                     >
                                         {provider.iconUrl ? (
-                                            // next/image is not usable here: the icon URL is supplied by the
-                                            // operator at deploy time, so its host cannot be allow-listed in
-                                            // next.config's images.remotePatterns.
-                                            // eslint-disable-next-line @next/next/no-img-element
-                                            <img src={provider.iconUrl} alt="" className="mr-2 h-5 w-5 object-contain" />
+                                            // Icons are downloaded locally by the container entrypoint and served
+                                            // from public/oidc-icons via next/image (see the login-config spec).
+                                            <Image src={provider.iconUrl} alt="" width={20} height={20} className="mr-2 h-5 w-5 object-contain" />
                                         ) : (
                                             <MdAccountCircle className="mr-2 h-5 w-5" />
                                         )}

--- a/src/component-library/pages/Login/Login.tsx
+++ b/src/component-library/pages/Login/Login.tsx
@@ -344,7 +344,15 @@ export const Login = ({
                                         variant="neutral"
                                         onClick={() => handleOIDCSubmit(provider, loginViewModel.voList[selectedVOTab], inputAccount)}
                                     >
-                                        <MdAccountCircle className="mr-2 h-5 w-5" />
+                                        {provider.iconUrl ? (
+                                            // next/image is not usable here: the icon URL is supplied by the
+                                            // operator at deploy time, so its host cannot be allow-listed in
+                                            // next.config's images.remotePatterns.
+                                            // eslint-disable-next-line @next/next/no-img-element
+                                            <img src={provider.iconUrl} alt="" className="mr-2 h-5 w-5 object-contain" />
+                                        ) : (
+                                            <MdAccountCircle className="mr-2 h-5 w-5" />
+                                        )}
                                         {provider.name}
                                     </Button>
                                 );

--- a/src/component-library/pages/Login/Login.tsx
+++ b/src/component-library/pages/Login/Login.tsx
@@ -352,7 +352,7 @@ export const Login = ({
                         </div>
                     )}
 
-                    <Button onClick={() => submitX509(inputAccount)}>x509</Button>
+                    {loginViewModel.x509Enabled && <Button onClick={() => submitX509(inputAccount)}>x509</Button>}
 
                     {loginViewModel.userpassEnabled && (
                         <Button

--- a/src/lib/infrastructure/gateway/env-config-gateway.ts
+++ b/src/lib/infrastructure/gateway/env-config-gateway.ts
@@ -2,6 +2,8 @@ import { ConfigNotFound, InvalidConfig } from '@/lib/core/exceptions/env-config-
 import { OIDCProvider, VO } from '@/lib/core/entity/auth-models';
 import EnvConfigGatewayOutputPort from '@/lib/core/port/secondary/env-config-gateway-output-port';
 import { injectable } from 'inversify';
+import fs from 'fs';
+import path from 'path';
 
 @injectable()
 class EnvConfigGateway implements EnvConfigGatewayOutputPort {
@@ -73,7 +75,7 @@ class EnvConfigGateway implements EnvConfigGatewayOutputPort {
             const provider: OIDCProvider = {
                 name: providerName,
                 url: (await this.get(`OIDC_PROVIDER_${providerName}_URL`)) as string,
-                iconUrl: (await this.get(`OIDC_PROVIDER_${providerName}_ICON_URL`)) as string,
+                iconUrl: await this.resolveIconUrl(providerName),
                 clientId: (await this.get(`OIDC_PROVIDER_${providerName}_CLIENT_ID`)) as string,
                 clientSecret: (await this.get(`OIDC_PROVIDER_${providerName}_CLIENT_SECRET`)) as string,
                 authorizationUrl: (await this.get(`OIDC_PROVIDER_${providerName}_AUTHORIZATION_URL`)) as string,
@@ -87,6 +89,22 @@ class EnvConfigGateway implements EnvConfigGatewayOutputPort {
             providers.push(provider);
         }
         return Promise.resolve(providers);
+    }
+
+    /**
+     * OIDC provider icons are downloaded into public/oidc-icons/<NAME>.png by the
+     * container entrypoint (see rucio/containers webui/docker-entrypoint.sh), so they
+     * can be served through next/image. We only expose the local path when the file is
+     * actually present; a missing or failed download degrades to the default icon.
+     */
+    private async resolveIconUrl(providerName: string): Promise<string | null> {
+        const configured = await this.get(`OIDC_PROVIDER_${providerName}_ICON_URL`);
+        if (!configured) {
+            return null;
+        }
+        const fileName = `${providerName.toUpperCase()}.png`;
+        const filePath = path.join(process.cwd(), 'public', 'oidc-icons', fileName);
+        return fs.existsSync(filePath) ? `/oidc-icons/${fileName}` : null;
     }
 
     async multiVOEnabled(): Promise<boolean> {

--- a/src/lib/infrastructure/gateway/env-config-gateway.ts
+++ b/src/lib/infrastructure/gateway/env-config-gateway.ts
@@ -5,6 +5,25 @@ import { injectable } from 'inversify';
 import fs from 'fs';
 import path from 'path';
 
+/**
+ * OIDC provider icons are downloaded into public/oidc-icons/<NAME>.png by the
+ * container entrypoint (see rucio/containers webui/docker-entrypoint.sh), so they
+ * can be served through next/image. We only expose the local path when the file is
+ * actually present; a missing or failed download degrades to the default icon.
+ *
+ * Kept as a free function rather than a class method so that EnvConfigGateway stays
+ * structurally assignable to EnvConfigGatewayOutputPort, which some call sites rely on
+ * (e.g. logic-config-feature.ts types the resolved gateway as the concrete class).
+ */
+function resolveLocalOIDCIconUrl(providerName: string, configuredIconUrl: string | undefined): string | null {
+    if (!configuredIconUrl) {
+        return null;
+    }
+    const fileName = `${providerName.toUpperCase()}.png`;
+    const filePath = path.join(process.cwd(), 'public', 'oidc-icons', fileName);
+    return fs.existsSync(filePath) ? `/oidc-icons/${fileName}` : null;
+}
+
 @injectable()
 class EnvConfigGateway implements EnvConfigGatewayOutputPort {
     async listDIDsInitialPattern(): Promise<string | undefined> {
@@ -75,7 +94,7 @@ class EnvConfigGateway implements EnvConfigGatewayOutputPort {
             const provider: OIDCProvider = {
                 name: providerName,
                 url: (await this.get(`OIDC_PROVIDER_${providerName}_URL`)) as string,
-                iconUrl: await this.resolveIconUrl(providerName),
+                iconUrl: resolveLocalOIDCIconUrl(providerName, await this.get(`OIDC_PROVIDER_${providerName}_ICON_URL`)),
                 clientId: (await this.get(`OIDC_PROVIDER_${providerName}_CLIENT_ID`)) as string,
                 clientSecret: (await this.get(`OIDC_PROVIDER_${providerName}_CLIENT_SECRET`)) as string,
                 authorizationUrl: (await this.get(`OIDC_PROVIDER_${providerName}_AUTHORIZATION_URL`)) as string,
@@ -89,22 +108,6 @@ class EnvConfigGateway implements EnvConfigGatewayOutputPort {
             providers.push(provider);
         }
         return Promise.resolve(providers);
-    }
-
-    /**
-     * OIDC provider icons are downloaded into public/oidc-icons/<NAME>.png by the
-     * container entrypoint (see rucio/containers webui/docker-entrypoint.sh), so they
-     * can be served through next/image. We only expose the local path when the file is
-     * actually present; a missing or failed download degrades to the default icon.
-     */
-    private async resolveIconUrl(providerName: string): Promise<string | null> {
-        const configured = await this.get(`OIDC_PROVIDER_${providerName}_ICON_URL`);
-        if (!configured) {
-            return null;
-        }
-        const fileName = `${providerName.toUpperCase()}.png`;
-        const filePath = path.join(process.cwd(), 'public', 'oidc-icons', fileName);
-        return fs.existsSync(filePath) ? `/oidc-icons/${fileName}` : null;
     }
 
     async multiVOEnabled(): Promise<boolean> {

--- a/test/component/Login.test.tsx
+++ b/test/component/Login.test.tsx
@@ -161,7 +161,7 @@ describe('Login Page Test', () => {
     });
 
     it('should render a provider icon when iconUrl is set and fall back when it is not', async () => {
-        const [providerWithIcon] = getSampleOIDCProviders();
+        const providerWithIcon = { ...getSampleOIDCProviders()[0], iconUrl: '/oidc-icons/CERN.png' };
         const providerWithoutIcon = { ...providerWithIcon, name: 'plain-provider', iconUrl: undefined };
         const vo = { ...getSampleVOs()[0], oidcProviders: [providerWithIcon, providerWithoutIcon] };
 
@@ -182,12 +182,13 @@ describe('Login Page Test', () => {
         );
         await act(async () => render(<Login />));
 
-        // Only the provider carrying an iconUrl renders an <img>; the other keeps the
-        // default icon. The image is decorative (alt=""), so it is queried by src.
+        // Only the provider carrying an iconUrl renders an image; the other keeps the
+        // default icon. next/image rewrites src to its optimizer URL (/_next/image?url=...),
+        // so we assert the decoded src contains the local path rather than matching exactly.
         const oidcButtons = screen.getByRole('generic', { name: /OIDC Login Buttons/ });
         const icons = oidcButtons.querySelectorAll('img');
         expect(icons).toHaveLength(1);
-        expect(icons[0]).toHaveAttribute('src', providerWithIcon.iconUrl);
+        expect(decodeURIComponent(icons[0].getAttribute('src') ?? '')).toContain('/oidc-icons/CERN.png');
     });
 
     it('should show error message if exists during initial page load', async () => {

--- a/test/component/Login.test.tsx
+++ b/test/component/Login.test.tsx
@@ -135,6 +135,31 @@ describe('Login Page Test', () => {
         expect(oidcParent).toBeNull();
     });
 
+    it('should not render the x509 button if x509 is disabled', async () => {
+        fetchMock.doMock();
+        fetchMock.mockIf(/login/, req =>
+            Promise.resolve(
+                JSON.stringify({
+                    x509Enabled: false,
+                    userpassEnabled: true,
+                    oidcEnabled: true,
+                    oidcProviders: getSampleOIDCProviders(),
+                    multiVOEnabled: true,
+                    voList: getSampleVOs(),
+                    isLoggedIn: false,
+                    status: 'error',
+                } as LoginViewModel),
+            ),
+        );
+        await act(async () => render(<Login />));
+
+        expect(screen.queryByRole('button', { name: /x509/ })).toBeNull();
+
+        // The other login methods stay untouched
+        expect(screen.getByRole('button', { name: /Userpass/ })).toBeInTheDocument();
+        expect(screen.getByRole('generic', { name: /OIDC Login Buttons/ })).toBeInTheDocument();
+    });
+
     it('should show error message if exists during initial page load', async () => {
         fetchMock.doMock();
         fetchMock.mockIf(/login/, req =>

--- a/test/component/Login.test.tsx
+++ b/test/component/Login.test.tsx
@@ -160,6 +160,36 @@ describe('Login Page Test', () => {
         expect(screen.getByRole('generic', { name: /OIDC Login Buttons/ })).toBeInTheDocument();
     });
 
+    it('should render a provider icon when iconUrl is set and fall back when it is not', async () => {
+        const [providerWithIcon] = getSampleOIDCProviders();
+        const providerWithoutIcon = { ...providerWithIcon, name: 'plain-provider', iconUrl: undefined };
+        const vo = { ...getSampleVOs()[0], oidcProviders: [providerWithIcon, providerWithoutIcon] };
+
+        fetchMock.doMock();
+        fetchMock.mockIf(/login/, req =>
+            Promise.resolve(
+                JSON.stringify({
+                    x509Enabled: true,
+                    userpassEnabled: true,
+                    oidcEnabled: true,
+                    oidcProviders: [providerWithIcon, providerWithoutIcon],
+                    multiVOEnabled: true,
+                    voList: [vo],
+                    isLoggedIn: false,
+                    status: 'error',
+                } as LoginViewModel),
+            ),
+        );
+        await act(async () => render(<Login />));
+
+        // Only the provider carrying an iconUrl renders an <img>; the other keeps the
+        // default icon. The image is decorative (alt=""), so it is queried by src.
+        const oidcButtons = screen.getByRole('generic', { name: /OIDC Login Buttons/ });
+        const icons = oidcButtons.querySelectorAll('img');
+        expect(icons).toHaveLength(1);
+        expect(icons[0]).toHaveAttribute('src', providerWithIcon.iconUrl);
+    });
+
     it('should show error message if exists during initial page load', async () => {
         fetchMock.doMock();
         fetchMock.mockIf(/login/, req =>

--- a/test/gateway/env-config-gateway.test.ts
+++ b/test/gateway/env-config-gateway.test.ts
@@ -3,6 +3,8 @@ import EnvConfigGatewayOutputPort from '@/lib/core/port/secondary/env-config-gat
 import appContainer from '@/lib/infrastructure/ioc/container-config';
 import GATEWAYS from '@/lib/infrastructure/ioc/ioc-symbols-gateway';
 import { createOIDCProviders, deleteOIDCProviders } from 'test/fixtures/oidc-provider-config';
+import fs from 'fs';
+import path from 'path';
 
 describe('env-config-gateway', () => {
     it('should return the value of the environment variable', async () => {
@@ -92,7 +94,9 @@ describe('env-config-gateway oidc config test', () => {
 
         expect(cern.name).toEqual('cern');
         expect(cern.url).toEqual('https://cern.ch');
-        expect(cern.iconUrl).toEqual('https://cern.ch/icon.png');
+        // ICON_URL is set in the fixture, but no local file exists in the test env,
+        // so the gateway degrades to null rather than pointing at a missing image.
+        expect(cern.iconUrl).toBeNull();
         expect(cern.clientId).toEqual('client-id');
         expect(cern.clientSecret).toEqual('client-secret');
         expect(cern.scopes).toEqual(['scope1', 'scope2']);
@@ -102,6 +106,32 @@ describe('env-config-gateway oidc config test', () => {
         expect(cern.redirectUrl).toEqual('https://cern.ch/redirect');
         expect(cern.refreshTokenUrl).toEqual('https://cern.ch/userinfo');
     });
+
+    it('should expose the local icon path when the downloaded file exists', async () => {
+        const existsSpy = jest
+            .spyOn(fs, 'existsSync')
+            .mockImplementation(p => String(p) === path.join(process.cwd(), 'public', 'oidc-icons', 'CERN.png'));
+        const gateway = appContainer.get<EnvConfigGatewayOutputPort>(GATEWAYS.ENV_CONFIG);
+
+        const result = await gateway.oidcProviders();
+
+        expect(result[0].iconUrl).toEqual('/oidc-icons/CERN.png');
+        // test-provider's file does not exist, so it falls back to null.
+        expect(result[1].iconUrl).toBeNull();
+        existsSpy.mockRestore();
+    });
+
+    it('should return null iconUrl when ICON_URL is not configured', async () => {
+        delete process.env['OIDC_PROVIDER_CERN_ICON_URL'];
+        jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+        const gateway = appContainer.get<EnvConfigGatewayOutputPort>(GATEWAYS.ENV_CONFIG);
+
+        const result = await gateway.oidcProviders();
+
+        expect(result[0].iconUrl).toBeNull();
+        jest.restoreAllMocks();
+    });
+
     it('should throw InvalidConfig if oidc is enabled but no providers are provided', async () => {
         delete process.env['OIDC_PROVIDERS'];
         const gateway = appContainer.get<EnvConfigGatewayOutputPort>(GATEWAYS.ENV_CONFIG);

--- a/tools/env-generator/README.md
+++ b/tools/env-generator/README.md
@@ -75,6 +75,7 @@ For each `OIDC Provider` specified in the `OIDC_PROVIDERS` variable, the additio
 | OIDC_PROVIDER_CERN_REFRESH_TOKEN_URL | RUCIO_WEBUI_OIDC_PROVIDER_CERN_REFRESH_TOKEN_URL | The refresh token endpoint                                            |         |         |
 | OIDC_PROVIDER_CERN_USERINFO_URL      | RUCIO_WEBUI_OIDC_PROVIDER_CERN_USERINFO_URL      | The URL to obtain user info from the OIDC Provider                    |         |         |
 | OIDC_PROVIDER_CERN_REDIRECT_URL      | RUCIO_WEBUI_OIDC_PROVIDER_CERN_REDIRECT_URL      | The redirection URL configured on the OIDC Provider                   |         |         |
+| OIDC_PROVIDER_CERN_ICON_URL          | RUCIO_WEBUI_OIDC_PROVIDER_CERN_ICON_URL          | Optional. URL to a raster icon (png/jpg) shown on the provider's login button. Downloaded locally by the container and served via next/image; a default icon is used if unset. |         |         |
 
 3. Run the `generate_env.js` script to generate the `.env` file for the WEBUI. You can switch between `dev` and `prod` modes.
 

--- a/tools/env-generator/src/api/base.ts
+++ b/tools/env-generator/src/api/base.ts
@@ -65,6 +65,7 @@ export class WebUIEnvTemplateCompiler {
       'PARAMS_ENCODING_ENABLED': 'false',
       'RULE_ACTIVITY': 'User Subscriptions',
       'ENABLE_USERPASS_LOGIN': 'true',
+      'X509_ENABLED': 'true',
       'AUTH_TRUST_HOST': 'true',
       'AUTH_SECRET': authSecret,
       'NEXTAUTH_SECRET': authSecret,

--- a/tools/env-generator/src/templates/.env.liquid
+++ b/tools/env-generator/src/templates/.env.liquid
@@ -9,6 +9,7 @@ PROJECT_URL={{ context.PROJECT_URL }}
 
 [login]
 ENABLE_USERPASS_LOGIN={{ context.ENABLE_USERPASS_LOGIN }}
+X509_ENABLED={{ context.X509_ENABLED }}
 
 [rules]
 RULE_ACTIVITY={{ context.RULE_ACTIVITY | json }}


### PR DESCRIPTION
Closes #805.

### 1. The x509 button can now be disabled

`Login.tsx` gated the OIDC and userpass buttons on their flags but rendered x509
anyways.

Also, `X509_ENABLED` was harvested by the env-generator but never emitted by `.env.liquid`.

Kind of important: `X509_ENABLED` is opt-out.
Deployments that never set it are unaffected. Anyone who *did* set `X509_ENABLED=False`
expecting it to work will now see the button disappear. 

### 2. `iconUrl` is now rendered

`OIDC_PROVIDER_<NAME>_ICON_URL` is read by the gateway, emitted by `.env.liquid`
and populated onto `OIDCProvider.iconUrl`, but every OIDC button hardcoded the
same `MdAccountCircle`, leaving the setting unreachable. 

One question/comment for @maany: this uses a plain `<img>` rather than `next/image`,
because the icon URL is provided at deploy time and its host therefore
cannot be allow-listed in `next.config`'s `images.remotePatterns`.

The alternative would be to follow the `community_logo_url` precedent and
serve locally via `next/image`; that needs a `rucio/containers` change and
would have to handle one icon per provider. Happy to switch if you prefer that.

## Testing

- Added a test in `test/component/Login.test.tsx` asserting the x509 button
  is missing when `x509Enabled: false`, and that userpass/OIDC are unaffected.
  Verified it fails against unpatched `Login.tsx` and passes with the fix.