### PR TITLE
fix: use localhost as webpage host and set AUTH_TRUST_HOST to true (#811)

### DIFF
--- a/.env.development.local.template
+++ b/.env.development.local.template
@@ -5,6 +5,15 @@
 
 [public]
 NEXT_PUBLIC_WEBUI_HOST=https://localhost:3000
+HOSTNAME="localhost:3000"
+
+[meta]
+PROJECT_URL=https://atlas.cern/
+
+[session]
+SESSION_PASSWORD=2gyZ3GDw3LHZQKDhPmPDL3sjREVRXPr8
+SESSION_COOKIE_NAME=rucio-webui-session
+NODE_TLS_REJECT_UNAUTHORIZED=0
 
 [nextauth]
 # NextAuth configuration for OIDC authentication
@@ -12,25 +21,19 @@ NEXT_PUBLIC_WEBUI_HOST=https://localhost:3000
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=YSeN2me3Po4GS0IdAvgr70dOX6w0lbazE+MCe05LQ44=
 AUTH_SECRET=YSeN2me3Po4GS0IdAvgr70dOX6w0lbazE+MCe05LQ44=
+AUTH_TRUST_HOST=true
 NODE_TLS_REJECT_UNAUTHORIZED=0
 
-[meta]
-PROJECT_URL=https://atlas.cern/
+[gateway]
+RUCIO_AUTH_HOST=https://localhost:443
+RUCIO_HOST=https://localhost:443
+PARAMS_ENCODING_ENABLED=false
 
 [config]
 ENABLE_USERPASS_LOGIN=true
 RULE_ACTIVITY=User Subscriptions
 LIST_DIDS_INITIAL_PATTERN=
 
-[session]
-SESSION_PASSWORD=2gyZ3GDw3LHZQKDhPmPDL3sjREVRXPr8
-SESSION_COOKIE_NAME=rucio-webui-session
-NODE_TLS_REJECT_UNAUTHORIZED=0
-
-[gateway]
-RUCIO_AUTH_HOST=https://rucio-devmaany.cern.ch:443
-RUCIO_HOST=https://rucio-devmaany.cern.ch:443
-PARAMS_ENCODING_ENABLED=false
 
 # --- DDM Dashboard Integration ---
 # Enable DDM Dashboard links in the Rule Locks table
@@ -120,5 +123,4 @@ VO_DTM_LOGO=https://rucio.cern.ch/static/img/rucio-log
 
 VO_OPS_NAME="Operations"
 VO_OPS_LOGO=https://rucio.cern.ch/static/img/rucio-logo.png
-VO_OPS_OIDC_ENABLED=true
-VO_OPS_OIDC_PROVIDERS=twitter
+


### PR DESCRIPTION
Fixes #811 

### Changes that repair default configuration for local development:

#### 1. The host provided in `RUCIO_AUTH_HOST` and `RUCIO_HOST` variables changed from public domain to `localhost`.  
Now new webpage can run fully locally and does not need to be run on some externel server.
#### 2. `AUTH_TRUST_HOST` variable set to `true`.  
Without this configuration the authentication of user did not work and user was unable to log in using UserPass or x509.

#### 3. `VO_OPS_OIDC_PROVIDERS` previously set to `twitter` removed.