### PR TITLE
feat(rse-and-did-tips): add tips dropdowns for RSE queries view and DID list view

### DIFF
--- a/src/app/(rucio)/dids/ListDIDClient.tsx
+++ b/src/app/(rucio)/dids/ListDIDClient.tsx
@@ -4,7 +4,10 @@ import { ListDID } from '@/component-library/pages/DID/list/ListDID';
 import { DIDSearchParams } from '@/component-library/features/search/DIDSearchPanel';
 import { DIDType } from '@/lib/core/entity/rucio';
 import { useRouter, usePathname } from 'next/navigation';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
+import { HiChevronDown, HiInformationCircle } from 'react-icons/hi2';
+import { cn } from '@/component-library/utils';
+import { HiFilter } from 'react-icons/hi';
 
 export interface ListDIDClientProps {
     firstPattern?: string;
@@ -58,7 +61,52 @@ export const ListDIDClient = (props: ListDIDClientProps) => {
         [router, pathname],
     );
 
+    const [isTipsOpen, setIsTipsOpen] = useState(false);
+
     return (
-        <ListDID firstPattern={props.firstPattern} autoSearch={props.autoSearch} initialType={props.initialType} onSearchStart={handleSearchStart} />
+        <div className="flex flex-col space-y-6 w-full">
+            {/* Tips */}
+            <div className="rounded-md bg-base-info-50 dark:bg-base-info-900 text-sm text-base-info-700 dark:text-base-info-200">
+                <button
+                    type="button"
+                    className="flex w-full items-center gap-2 p-3 text-left"
+                    onClick={() => setIsTipsOpen(!isTipsOpen)}
+                >
+                    <HiInformationCircle className="w-5 h-5" />
+                    <span className="font-medium flex flex-1">Tips</span>
+                    <HiChevronDown className={cn('w-4 h-4 transition-transform duration-200', isTipsOpen && 'rotate-180')} />
+                </button>
+                {isTipsOpen &&
+                    <div>
+                        <ul className="list-disc list-inside space-y-1 px-3 pl-10 pb-3">
+                            <li>
+                                <span className="font-medium">Purpose:</span> Filtering DIDs and showing their basic data and metadata.
+                            </li>
+                            <li>
+                                <span className="font-medium">Scope:</span> Must be specified, there is no possibility of finding DID without its properly defined scope.
+                            </li>
+                            <li>
+                                <span className="font-medium">Name:</span> You can use proper name of a DID, or a caption with wildcards <code className="font-mono">*</code> and <code className="font-mono">%</code>, which both stands for any number of signs, even zero:
+                                <ul className="list-decimal list-inside space-y-0.5 px-3 pl-5 py-1">
+                                    <li>
+                                        <code className="font-mono">test*</code> will show all DIDs of specified type and scope, which name starts with <code className="font-mono">test</code>.
+                                    </li>
+                                    <li>
+                                        <code className="font-mono">%-atlas-%-%</code> will show DIDs where all the places occured by <code className="font-mono">%</code> are replaced for proper signs in their real names.
+                                    </li>
+                                    <li>
+                                        One <code className="font-mono">*</code> will return all DIDs within provided scope and type.
+                                    </li>
+                                </ul>
+                            </li>
+                            <li>
+                                <span className="font-medium">Metadata filters:</span> In addition to the required filters, you can specify several metadata parameters in the dropdown menu that opens by clicking on the <HiFilter className="inline-block align-middle w-4 h-4 shrink-0 mx-0.5" /> icon.
+                            </li>
+                        </ul>
+                    </div>
+                }
+            </div>
+            <ListDID firstPattern={props.firstPattern} autoSearch={props.autoSearch} initialType={props.initialType} onSearchStart={handleSearchStart} />
+        </div>
     );
 };

--- a/src/app/(rucio)/dids/page.tsx
+++ b/src/app/(rucio)/dids/page.tsx
@@ -45,7 +45,7 @@ export default async function Page({ searchParams }: { searchParams?: Promise<{ 
     return (
         <main className=" bg-neutral-0 dark:bg-neutral-900 transition-colors duration-200">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 lg:py-10">
-                <header className="mb-8">
+                <header className="mb-6">
                     <h1 className="text-3xl sm:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-2">Data Identifiers</h1>
                     <p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400">
                         Search and browse datasets, containers, and files in Rucio

--- a/src/app/(rucio)/rses/page.tsx
+++ b/src/app/(rucio)/rses/page.tsx
@@ -16,7 +16,7 @@ export default async function Page({ searchParams }: { searchParams?: Promise<{ 
     return (
         <main className="min-h-screen bg-neutral-0 dark:bg-neutral-900 transition-colors duration-200">
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 lg:py-10">
-                <header className="mb-8">
+                <header className="mb-6">
                     <h1 className="text-3xl sm:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-2">Rucio Storage Elements</h1>
                     <p className="text-base sm:text-lg text-neutral-600 dark:text-neutral-400">
                         Search and browse storage elements using RSE expressions

--- a/src/component-library/features/search/RSESearchPanel.tsx
+++ b/src/component-library/features/search/RSESearchPanel.tsx
@@ -43,7 +43,6 @@ export const RSESearchPanel = (props: SearchPanelProps) => {
         <div className="space-y-2">
             <div className="text-neutral-900 dark:text-neutral-100">
                 Expression
-                <HintLink href="https://rucio.github.io/documentation/started/concepts/rse_expressions" className="pl-2" />
             </div>
             <div className="flex flex-col space-y-2 sm:flex-row sm:space-y-0 sm:space-x-2 items-center sm:items-start">
                 <Input

--- a/src/component-library/pages/RSE/list/ListRSE.tsx
+++ b/src/component-library/pages/RSE/list/ListRSE.tsx
@@ -6,6 +6,10 @@ import { ListRSETable } from '@/component-library/pages/RSE/list/ListRSETable';
 import { Heading } from '@/component-library/atoms/misc/Heading';
 import useTableStreaming from '@/lib/infrastructure/hooks/useTableStreaming';
 import { RSESearchPanel } from '@/component-library/features/search/RSESearchPanel';
+import { useState } from 'react';
+import { HiChevronDown, HiInformationCircle } from 'react-icons/hi2';
+import { HiExternalLink } from 'react-icons/hi';
+import { cn } from '@/component-library/utils';
 
 type ListRSEProps = {
     initialExpression?: string;
@@ -20,8 +24,68 @@ export const ListRSE = (props: ListRSEProps) => {
         startStreaming(`/api/feature/list-rses?rseExpression=${expression}`);
     };
 
+    const [isTipsOpen, setIsTipsOpen] = useState(false);
+
     return (
         <div className="flex flex-col space-y-6 w-full">
+            {/* Tips */}
+            <div className="rounded-md bg-base-info-50 dark:bg-base-info-900 text-sm text-base-info-700 dark:text-base-info-200">
+                <button
+                    type="button"
+                    className="flex w-full items-center gap-2 p-3 text-left"
+                    onClick={() => setIsTipsOpen(prev => !prev)}
+                    aria-expanded={isTipsOpen}
+                >
+                    <HiInformationCircle className="h-5 w-5 shrink-0" aria-hidden="true" />
+                    <span className="font-medium flex-1">Tips</span>
+                    <HiChevronDown
+                        className={cn('h-4 w-4 shrink-0 transition-transform duration-200', isTipsOpen && 'rotate-180')}
+                        aria-hidden="true"
+                    />
+                </button>
+                {isTipsOpen &&
+                    <div>
+                        <ul className="list-disc list-inside space-y-1 px-3 pl-10 pb-2">
+                            <li>
+                                <span className="font-medium">Purpose:</span> Allows to select a set of RSEs, by providing one or more terms which can be a single RSE name or a condition over the RSE attributes.
+                            </li>
+                            <li>
+                                <span className="font-medium">Simple expressions:</span>
+                                <ul className="list-decimal list-inside space-y-0.5 px-3 pl-5 py-1">
+                                    <li>
+                                        <code className="font-medium">*</code> lists all available RSEs,
+                                    </li>
+                                    <li>
+                                        <code className="font-medium">type=SCRATCHDISK</code> shows RSEs of specific type,
+                                    </li>
+                                    <li>
+                                        <code className="font-medium">freespace&gt;3000</code> shows RSEs that have more than 3000TB of free space.
+                                    </li>
+                                </ul>
+                            </li>
+                            <li>
+                                <span className="font-medium">Operators:</span> Allows to connect terms via union |, intersection & or complementing \.
+                            </li>
+                        </ul>
+                        <a
+                            href="https://rucio.github.io/documentation/started/concepts/rse_expressions"
+                            target="_blank"
+                            className={cn(
+                                'pl-9 pb-3',
+                                'inline-flex items-center gap-1',
+                                'font-medium underline underline-offset-2',
+                                'hover:opacity-80 transition-opacity',
+                                'focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 rounded',
+                            )}
+                        >
+                            Learn more
+                            <HiExternalLink className="h-3 w-3 mr-1" aria-hidden="true" />
+                        </a>
+                        about RSEs expressions.
+                    </div>
+                }
+            </div>
+
             {/* Search Panel */}
             <div className="rounded-lg bg-neutral-0 dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 shadow-sm p-6">
                 <RSESearchPanel


### PR DESCRIPTION
Closes #447 

## Work done
Tips dropdowns for DID list view and RSE queries view:
* User can now see tips for querying RSE with several examples and can redirect to Rucio documentation for further information.
* DID tips contain information on how to use search component and what patterns of text input are accepted (there are also few examples).